### PR TITLE
Fix a rendering issue in delegateList-Safari - Closes #472

### DIFF
--- a/src/components/delegateList/delegateList.css
+++ b/src/components/delegateList/delegateList.css
@@ -324,6 +324,7 @@
       color: var(--color-grayscale-dark);
       font-size: 16px;
       font-weight: 400;
+      transform: translateZ(0);
 
       &:last-child {
         font-weight: 300;
@@ -367,7 +368,7 @@
 @media (--xLarge-viewport) {
   .delegatesList {
     & .row {
-      padding: 0px var(--grid-padding-L);
+      padding: 11px var(--grid-padding-L);
     }
   }
 }


### PR DESCRIPTION
### What was the problem?
Safari invalidates the styles (Just like any other browser) based on specific changes in DOM, but doe some reason, it can not recalculate the style of some parts of delegate list. causing a generated seri of DOM nodes without any style rule bound to. so we ended up having practically transparent list of `li` elements.

### How did I fix it?
 - Fixed the issue by adding a 3d translation to the style rule to `li` elements and forces the browser to create a new layer and send rendering to the GPU. 
 - I although increased the height of element, which reduces the number of items visible, and helps rendering smoothly while keeping consistency with the style of transactions list.

### How to test it?
Make sure Safari renders the delegate list correctly.

### Review checklist
- The PR solves #472 
- All new code follows best practices
