### PR TITLE
Fix 'npm run build-prod' on Windows - Closes #478

### DIFF
--- a/config/webpack.config.react.js
+++ b/config/webpack.config.react.js
@@ -11,7 +11,7 @@ const path = require('path');
 const getLocales = (url) => {
   const file = fs.readFileSync(path.join(__dirname, url));
   const str = [];
-  const langs = file.toString().match(/.*:\s{\n/g);
+  const langs = file.toString().match(/.*:\s{\r?\n/g);
   langs.forEach((item) => {
     str.push(item.match(/[a-z]{2}/g)[0]);
   });


### PR DESCRIPTION
### What was the problem?
The problem was the Windows new line char sequence `\r\n` in webpack conf (run on nodejs).

### How did I fix it?
I updated the regexp to allow both `\r\n` and `\n` new line options.

### How to test it?
Run `npm run build-prod` on Windows and Mac.

### Review checklist
- The PR solves #478 
- All new code follows best practices
