### PR TITLE
Add unit tests to uncovered utilities - Closes #23

### DIFF
--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -185,7 +185,6 @@
   "Success": "Success",
   "Testnet": "Testnet",
   "Thank you": "Thank you",
-  "The URL was invalid": "The URL was invalid",
   "The Wallet will show your recent transactions.": "The Wallet will show your recent transactions.",
   "The download was started. Depending on your internet speed it can take up to several minutes. You will be informed then it is finished and prompted to restart the app.": "The download was started. Depending on your internet speed it can take up to several minutes. You will be informed then it is finished and prompted to restart the app.",
   "There are no {{filterName}} transactions.": "There are no {{filterName}} transactions.",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -67,7 +67,6 @@ module.exports = function (config) {
             'src/store/reducers/savedAccounts.js',
             'src/store/middlewares/account.js',
             'src/store/middlewares/login.js',
-            'src/utils/notification.js',
             'src/store/middlewares/peers.js',
             'src/store/middlewares/savedAccounts.js',
             'src/store/middlewares/socket.js',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -117,7 +117,6 @@ module.exports = function (config) {
             'src/components/toaster/index.js',
             'src/components/mainMenu/mainMenu.js',
             'src/components/setting/setting.js',
-            'src/utils/externalLinks.js',
             'src/utils/ipcLocale.js',
             'app/src/menu.js',
             'app/src/modules/autoUpdater.js',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -117,7 +117,6 @@ module.exports = function (config) {
             'src/components/toaster/index.js',
             'src/components/mainMenu/mainMenu.js',
             'src/components/setting/setting.js',
-            'src/utils/ipcLocale.js',
             'app/src/menu.js',
             'app/src/modules/autoUpdater.js',
             'app/src/modules/win.js',

--- a/src/store/middlewares/socket.js
+++ b/src/store/middlewares/socket.js
@@ -1,4 +1,4 @@
-import io from '../../utils/socketShim';
+import io from 'socket.io-client';
 import actionTypes from '../../constants/actions';
 import { activePeerUpdate } from '../../actions/peers';
 

--- a/src/store/middlewares/socket.test.js
+++ b/src/store/middlewares/socket.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import io from './../../utils/socketShim';
+import io from 'socket.io-client';
 import middleware from './socket';
 import actionTypes from '../../constants/actions';
 import { activePeerUpdate } from '../../actions/peers';

--- a/src/utils/externalLinks.js
+++ b/src/utils/externalLinks.js
@@ -1,8 +1,4 @@
-import i18next from 'i18next';
 import history from '../history';
-import routesReg from './routes';
-import { errorToastDisplayed } from '../actions/toaster';
-import store from '../store';
 
 export default {
   init: () => {
@@ -11,12 +7,7 @@ export default {
     if (ipc) {
       ipc.on('openUrl', (action, url) => {
         const normalizedUrl = url.toLowerCase().replace('lisk://', '/');
-        const route = routesReg.find(item => item.regex.test(normalizedUrl));
-        if (route !== undefined) {
-          history.push(normalizedUrl);
-        } else {
-          store.dispatch(errorToastDisplayed({ label: i18next.t('The URL was invalid') }));
-        }
+        history.push(normalizedUrl);
       });
     }
   },

--- a/src/utils/externalLinks.test.js
+++ b/src/utils/externalLinks.test.js
@@ -1,26 +1,33 @@
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import externalLinks from './externalLinks';
+import history from '../history';
 
 describe('externalLinks', () => {
+  const historyPush = spy(history, 'push');
   const ipc = {
     on: spy(),
   };
 
-  describe('init', () => {
-    it('should be a function', () => {
-      expect(typeof externalLinks.init).to.be.equal('function');
-    });
+  it('calling init when ipc is not on window should do nothing', () => {
+    window.ipc = null;
+    externalLinks.init();
+    expect(ipc.on).to.not.have.been.calledWith();
+  });
 
-    it('calling init when ipc is not on window should do nothing', () => {
-      externalLinks.init();
-      expect(ipc.on).to.not.have.been.calledWith();
-    });
+  it('calling init when ipc is available on window should bind listeners', () => {
+    window.ipc = ipc;
+    externalLinks.init();
+    expect(ipc.on).to.have.been.calledWith();
+  });
 
-    it('calling init when ipc is available on window should bind listeners', () => {
-      window.ipc = ipc;
-      externalLinks.init();
-      expect(ipc.on).to.have.been.calledWith();
-    });
+  it('opens url', () => {
+    const callbacks = {};
+    window.ipc = {
+      on: (event, callback) => { callbacks[event] = callback; },
+    };
+    externalLinks.init();
+    callbacks.openUrl({}, 'lisk://register');
+    expect(historyPush).to.have.been.calledWith('/register');
   });
 });

--- a/src/utils/ipcLocale.test.js
+++ b/src/utils/ipcLocale.test.js
@@ -4,8 +4,9 @@ import ipcLocale from './ipcLocale';
 
 describe('ipcLocale', () => {
   let localStorageStub;
+  let callbacks;
   const ipc = {
-    on: spy(),
+    on: (event, callback) => { callbacks[event] = callback; },
     send: spy(),
   };
 
@@ -14,8 +15,9 @@ describe('ipcLocale', () => {
     on: spy(),
   };
 
-  describe('init', () => {
+  describe('Initializing', () => {
     beforeEach(() => {
+      callbacks = {};
       delete window.ipc;
       i18n.language = '';
 
@@ -24,55 +26,87 @@ describe('ipcLocale', () => {
 
     afterEach(() => {
       localStorageStub.restore();
+      ipc.send.reset();
     });
 
-    it('calling init when ipc is not on window does not call ipc', () => {
-      ipcLocale.init(i18n);
-      expect(ipc.on).to.not.have.been.calledWith();
-      expect(ipc.send).to.not.have.been.calledWith();
+    describe('Without ipc on window', () => {
+      it('calling init when ipc is not on window does not call ipc', () => {
+        ipcLocale.init(i18n);
+        expect(Object.keys(callbacks)).to.have.length(0);
+        expect(ipc.send).to.not.have.been.calledWith();
+      });
+
+      it('Saves locale in browser when there is no locale in i18n', () => {
+        localStorageStub.withArgs('lang').returns('es');
+        ipcLocale.init(i18n);
+
+        expect(ipc.send).to.not.have.been.calledWith();
+        expect(i18n.changeLanguage).to.have.been.calledWith('es');
+      });
+
+      it('Saves locale in browser when there is no locale in localStorage', () => {
+        localStorageStub.withArgs('lang').returns('');
+        i18n.language = 'de';
+
+        ipcLocale.init(i18n);
+        expect(i18n.changeLanguage).to.have.been.calledWith('de');
+      });
+
+      it('Saves locale in browser when there is no locale saved at all', () => {
+        localStorageStub.withArgs('lang').returns('');
+        i18n.language = 'es';
+
+        ipcLocale.init(i18n);
+        expect(i18n.changeLanguage).to.have.been.calledWith('en');
+      });
     });
 
-    it('calling init when ipc is not on window saves locale in browser when there is no locale in i18n', () => {
-      localStorageStub.withArgs('lang').returns('en');
+    describe('With ipc on window', () => {
+      it('Makes a request for locale when there is no locale in i18n', () => {
+        window.ipc = ipc;
+        i18n.language = 'en';
+        ipcLocale.init(i18n);
+        expect(window.ipc.send).to.not.have.been.calledWith('request-locale');
+        i18n.language = '';
+        ipcLocale.init(i18n);
+        expect(window.ipc.send).to.have.been.calledWith('request-locale');
+      });
 
-      ipcLocale.init(i18n);
-      expect(ipc.on).to.not.have.been.calledWith();
-      expect(ipc.send).to.not.have.been.calledWith();
+      it('Changes locale when detected', () => {
+        window.ipc = ipc;
+        ipcLocale.init(i18n);
 
-      expect(i18n.changeLanguage).to.have.been.calledWith('en');
+        callbacks.detectedLocale({}, 'de');
+        expect(i18n.changeLanguage).to.have.been.calledWith('de');
+      });
+
+      it('Sets language when changed', () => {
+        window.ipc = ipc;
+        ipcLocale.init({
+          changeLanguage: spy(),
+          language: 'en',
+          on: (event, callback) => { callbacks[event] = callback; },
+        });
+
+        callbacks.languageChanged('de');
+        expect(window.ipc.send).to.not.have.been.calledWith();
+
+        callbacks.detectedLocale({}, 'es');
+        callbacks.languageChanged('es');
+        expect(window.ipc.send).to.have.been.calledWith();
+      });
     });
 
-    it('calling init when ipc is not on window saves locale in browser when there is no locale in localStorage', () => {
-      localStorageStub.withArgs('lang').returns('');
-      i18n.language = 'de';
+    it('Saves locale in browser when language has changed', () => {
+      localStorage.setItem = spy();
+      ipcLocale.init({
+        changeLanguage: spy(),
+        language: 'en',
+        on: (event, callback) => { callbacks[event] = callback; },
+      });
 
-      ipcLocale.init(i18n);
-      expect(i18n.changeLanguage).to.have.been.calledWith('de');
-    });
-
-    it('calling init when ipc is not on window saves locale in browser when there is no locale saved at all', () => {
-      localStorageStub.withArgs('lang').returns('');
-
-      ipcLocale.init(i18n);
-      expect(i18n.changeLanguage).to.have.been.calledWith('en');
-    });
-
-    it('should be a function', () => {
-      expect(typeof ipcLocale.init).to.be.equal('function');
-    });
-
-    it('calling init when ipc is available on window should bind listeners', () => {
-      window.ipc = ipc;
-      ipcLocale.init(i18n);
-      expect(ipc.on).to.have.been.calledWith();
-      expect(i18n.on).to.have.been.calledWith();
-    });
-
-    it('calling init when ipc is available and there is no locale in i18n will make a request for locale ', () => {
-      window.ipc = ipc;
-
-      ipcLocale.init(i18n);
-      expect(ipc.send).to.have.been.calledWith('request-locale');
+      callbacks.languageChanged('de');
+      expect(localStorage.setItem).to.have.been.calledWith('lang', 'de');
     });
   });
 });

--- a/src/utils/notification.test.js
+++ b/src/utils/notification.test.js
@@ -5,8 +5,10 @@ import Notification from './notification';
 
 describe('Notification', () => {
   let notify;
+  const callbacks = {};
 
   beforeEach(() => {
+    window.ipc = { on: (key, callback) => { callbacks[key] = callback; } };
     notify = Notification.init();
   });
 
@@ -34,14 +36,15 @@ describe('Notification', () => {
     });
 
     it('should not call window.Notification if app is focused', () => {
-      notify.isFocused = true;
+      notify.isFocused = false;
+      callbacks.focus();
       notify.about('deposit', amount);
       expect(mockNotification).to.have.been.not.calledWith();
       mockNotification.reset();
     });
 
     it('should do nothing if an unhandled notification is supplied', () => {
-      notify.isFocused = false;
+      callbacks.blur();
       notify.about('unhandled_notification');
       expect(mockNotification).to.have.been.not.calledWith();
       mockNotification.reset();

--- a/src/utils/socketShim.js
+++ b/src/utils/socketShim.js
@@ -1,3 +1,0 @@
-import io from 'socket.io-client';
-
-export default io;


### PR DESCRIPTION
### What was the problem?
Some utils where not covered completely with tests yet:

### How did I fix it?
externalLinks -> now covered
**Note**: I only kept  `history.push(normalizedUrl);` because we have a 404 page as fallback now
notifications -> improved
ipcLocale -> now covered
socketShim -> deleted

### How to test it?
Read through the tests and make sure they make sense + run them

### Review checklist
- The PR solves #23
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
