### PR TITLE
Prevent account visual from turning black in Safari - Closes #338

### DIFF
--- a/src/components/accountVisual/accountVisual.css
+++ b/src/components/accountVisual/accountVisual.css
@@ -14,14 +14,15 @@
   animation-iteration-count: infinite;
   animation-timing-function: ease-in-out;
   animation-direction: alternate;
+  transform: translateZ(0);
 }
 
 @keyframes float {
   from {
-    transform: rotate(0deg);
+    transform: translateZ(0) rotate(0deg);
   }
 
   to {
-    transform: rotate(10deg);
+    transform: translateZ(0) rotate(10deg);
   }
 }


### PR DESCRIPTION
### What was the problem?
Some issue with safari rendering I don't really understand.

### How did I fix it?
Applied `transform: translateZ(0);` to account visual.

### How to test it?
Open the app in Safari and wait :-)

### Review checklist
- The PR solves #338
