### PR TITLE
Fix mixed transactions in explorer - Closes #508

### DIFF
--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -14,7 +14,10 @@ const { lockDuration } = accountConfig;
 const updateTransactions = (store, peers) => {
   const state = store.getState();
   const { filter } = state.transactions;
-  const address = state.transactions.address ? state.transactions.address : state.account.address;
+  const address = state.transactions.account
+    ? state.transactions.account.address
+    : state.account.address;
+
   getTransactions({
     activePeer: peers.data, address, limit: 25, filter,
   }).then(response => store.dispatch(transactionsUpdated({

--- a/src/store/middlewares/account.test.js
+++ b/src/store/middlewares/account.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { spy, stub, useFakeTimers } from 'sinon';
+import { spy, stub, useFakeTimers, match } from 'sinon';
 import { accountUpdated } from '../../actions/account';
 import accountConfig from '../../constants/account';
 import { activePeerUpdate } from '../../actions/peers';
@@ -68,6 +68,7 @@ describe('Account middleware', () => {
           id: 12498250891724098,
         }],
         confirmed: [],
+        account: { address: 'test_address' },
       },
     };
     store.getState = () => (state);
@@ -143,7 +144,7 @@ describe('Account middleware', () => {
     middleware(store)(next)(newBlockCreated);
 
     expect(stubGetAccount).to.have.been.calledWith();
-    expect(stubTransactions).to.have.been.calledWith();
+    expect(stubTransactions).to.have.been.calledWith(match({ address: 'test_address' }));
   });
 
   it(`should fetch delegate info on ${actionTypes.newBlockCreated} action if account.balance changes and account.isDelegate`, () => {


### PR DESCRIPTION
### What was the problem?
The single account transactions results were mixed with the transactions of the logged in account (when confirmations < 1000)

### How did I fix it?
The problem was that the state structure was changed, but this was not updated in `updateTransactions` in the account middleware

### How to test it?
reproduce the steps from #508, but with an account that has a recent transaction

### Review checklist
- The PR solves #508
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
