### PR TITLE
Misplaced delegate filters in s breakpoint - Closes #368

### DIFF
--- a/src/components/delegateList/delegateList.css
+++ b/src/components/delegateList/delegateList.css
@@ -168,6 +168,9 @@
   line-height: var(--list-line-height);
   list-style: none;
   padding: 0;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
 
   & .filter {
     display: inline-block;
@@ -427,15 +430,9 @@
   }
 
   .filters {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-
     & .filter {
-      margin-right: 0;
-
       &:not(:last-of-type) {
-        margin-right: 0;
+        margin-right: 24px;
       }
 
       & input {
@@ -513,11 +510,7 @@
   }
 
   .filters {
-    justify-content: flex-start;
-
     & .filter {
-      margin-right: 10px;
-
       &:not(:last-of-type) {
         margin-right: 20px;
       }

--- a/src/components/delegateList/delegateList.css
+++ b/src/components/delegateList/delegateList.css
@@ -519,7 +519,7 @@
       margin-right: 10px;
 
       &:not(:last-of-type) {
-        margin-right: 24px;
+        margin-right: 20px;
       }
     }
   }

--- a/src/components/delegateList/delegateList.css
+++ b/src/components/delegateList/delegateList.css
@@ -168,6 +168,7 @@
   line-height: var(--list-line-height);
   list-style: none;
   padding: 0;
+  justify-content: flex-start;
 
   & .filter {
     display: inline-block;
@@ -205,7 +206,7 @@
     font-weight: 400;
     padding-left: 30px;
     padding-right: 20px;
-    vertical-align: middle;
+    vertical-align: top;
     background-color: transparent;
     border-bottom: solid 1px transparent;
     transition: all ease 250ms;

--- a/src/components/delegateList/delegateList.css
+++ b/src/components/delegateList/delegateList.css
@@ -168,7 +168,6 @@
   line-height: var(--list-line-height);
   list-style: none;
   padding: 0;
-  justify-content: flex-start;
 
   & .filter {
     display: inline-block;
@@ -433,7 +432,11 @@
     justify-content: space-between;
 
     & .filter {
-      margin-right: 0 !important;
+      margin-right: 0;
+
+      &:not(:last-of-type) {
+        margin-right: 0;
+      }
 
       & input {
         width: 70px;
@@ -506,6 +509,18 @@
 
     & .account {
       display: none;
+    }
+  }
+
+  .filters {
+    justify-content: flex-start;
+
+    & .filter {
+      margin-right: 10px;
+
+      &:not(:last-of-type) {
+        margin-right: 24px;
+      }
     }
   }
 }


### PR DESCRIPTION
### What was the problem?
Displayed filters for `/main/voting` are equally spaced in xs breakpoint, and should be left aligned. 

### How did I fix it?
Added flex-start direction with margins, and reseted margins in greater Bpoints 

### How to test it?
Open dev tools and set a (max-width < 414px), verify filter items are no longer spaced equally but left aligned, verify rest of Bpoints behave as expected. 

### Review checklist
- The PR solves #368 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
