### PR TITLE
Fix stuck on loading screen on transaction details - Closes #565

### DIFF
--- a/src/components/transactions/transactionDetailView.js
+++ b/src/components/transactions/transactionDetailView.js
@@ -25,7 +25,7 @@ const TransactionsDetailView = props => (
         </header> : null
     }
     <div>
-      <div className={`${grid.row} ${grid['between-md']} ${grid['between-sm']} ${styles.row}`}>
+      <div className={`transactions-detail-view ${grid.row} ${grid['between-md']} ${grid['between-sm']} ${styles.row}`}>
         <div className={`${grid['col-xs-12']} ${grid['col-sm-4']} ${grid['col-md-4']} ${styles.column}`}>
           <div className={styles.label}>{props.t('Sender')}</div>
           {

--- a/src/components/transactions/transactionRow.js
+++ b/src/components/transactions/transactionRow.js
@@ -16,9 +16,10 @@ class TransactionRow extends React.Component {
 
   render() {
     const { props } = this;
-    const nextStep = props.nextStep || (() => {});
+    const nextStep = () => (props.nextStep({ value: props.value })) || (() => {});
+
     return (
-      <div className={`${grid.row} ${styles.rows} ${styles.clickable} transactionsRow`} onClick={nextStep.call({ ...props })}>
+      <div className={`${grid.row} ${styles.rows} ${styles.clickable} transactionsRow`} onClick={nextStep}>
         <div className={`${styles.leftText} ${grid['col-xs-6']} ${grid['col-sm-6']} transactions-cell`}>
           <div className={`${styles.mainRow} ${styles.address}`}>
             <TransactionType {...props.value} address={props.address}></TransactionType>

--- a/src/components/transactions/transactionRow.js
+++ b/src/components/transactions/transactionRow.js
@@ -18,7 +18,7 @@ class TransactionRow extends React.Component {
     const { props } = this;
     const nextStep = props.nextStep || (() => {});
     return (
-      <div className={`${grid.row} ${styles.rows} ${styles.clickable} transactionsRow`} onClick={nextStep.bind(this, { ...props })}>
+      <div className={`${grid.row} ${styles.rows} ${styles.clickable} transactionsRow`} onClick={nextStep.call({ ...props })}>
         <div className={`${styles.leftText} ${grid['col-xs-6']} ${grid['col-sm-6']} transactions-cell`}>
           <div className={`${styles.mainRow} ${styles.address}`}>
             <TransactionType {...props.value} address={props.address}></TransactionType>

--- a/src/components/transactions/transactionRow.js
+++ b/src/components/transactions/transactionRow.js
@@ -16,7 +16,7 @@ class TransactionRow extends React.Component {
 
   render() {
     const { props } = this;
-    const nextStep = () => (props.nextStep({ value: props.value })) || (() => {});
+    const nextStep = !props.nextStep ? (() => {}) : () => (props.nextStep({ value: props.value }));
 
     return (
       <div className={`${grid.row} ${styles.rows} ${styles.clickable} transactionsRow`} onClick={nextStep}>

--- a/src/components/transactions/transactions.js
+++ b/src/components/transactions/transactions.js
@@ -11,7 +11,7 @@ class Transactions extends React.Component {
       <Box>
         <MultiStep className={styles.transactions}>
           <TransactionOverview {...this.props} />
-          <TransactionDetailView />
+          <TransactionDetailView {...this.props} />
         </MultiStep>
       </Box>
     );

--- a/test/integration/accountTransactions.test.js
+++ b/test/integration/accountTransactions.test.js
@@ -109,6 +109,8 @@ describe('@integration: Account Transactions', () => {
   describe('Scenario: should allow to view transactions of any account', () => {
     step('Given I\'m on "accounts/123L" as "genesis" account', () => setupStep({ accountType: 'genesis', address: '123L' }));
     step('Then I should see 20 transaction rows as result of the address 123L', () => helper.shouldSeeCountInstancesOf(20, 'TransactionRow'));
+    step('When I click on a transaction row', () => helper.clickOnElement('.transactionsRow'));
+    step('Then I should be able to see the details of that transaction', () => helper.shouldSeeCountInstancesOf(1, '.transactions-detail-view'));
   });
 
   describe('Scenario: should allow to filter transactions', () => {


### PR DESCRIPTION
### What was the problem?
clicking on a transactionRow of an account doesn't display it's details.

### How did I fix it?
- Avoid usage of this.props on presentational components.
- nextStep should pass value from props. 
- add integration tests

### How to test it?
go to /explorer/accounts/5932438298200837883L, and click on a transaction row:
- detailView of that transaction must be displayed. 

### Review checklist
- The PR solves #565
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
