### PR TITLE
Fix see all transactions - Closes #571

### DIFF
--- a/src/components/dashboard/index.js
+++ b/src/components/dashboard/index.js
@@ -23,7 +23,7 @@ class Dashboard extends React.Component {
           <header>
             <h2 className={styles.title}>
               {t('Latest activity')}
-              <Link to={`${routes.main.path}${routes.transaction.path}`} className={styles.seeAllLink}>
+              <Link to={`${routes.main.path}${routes.transaction.path}`} className={`${styles.seeAllLink} seeAllLink`}>
                 {t('See all transactions')}
                 <FontIcon value='arrow-right'/>
               </Link>

--- a/src/components/dashboard/index.js
+++ b/src/components/dashboard/index.js
@@ -23,7 +23,7 @@ class Dashboard extends React.Component {
           <header>
             <h2 className={styles.title}>
               {t('Latest activity')}
-              <Link to={`${routes.main.path}${routes.dashboard.path}`} className={styles.seeAllLink}>
+              <Link to={`${routes.main.path}${routes.transaction.path}`} className={styles.seeAllLink}>
                 {t('See all transactions')}
                 <FontIcon value='arrow-right'/>
               </Link>

--- a/test/e2e/transactions.feature
+++ b/test/e2e/transactions.feature
@@ -5,6 +5,14 @@ Feature: Transactions page
     Then I should see 25 rows
     When I scroll to the bottom of "transaction results"
     Then I should see 50 rows
+  
+  Scenario: should open all transactions
+    Given I'm logged in as "genesis"
+    When I click "dashboard" menu
+    And I should see 3 rows
+    When I click "seeAllLink"
+    Then I should be on url "/main/transactions"
+    And I should see 25 rows
 
   @integration
   Scenario: should provide a message if there are "No transactions" 


### PR DESCRIPTION
### What was the problem?
See all transactions didn't redirect to/transactions
### How did I fix it?
Changed route on See all transactions
### How to test it?
Go to dashboard and click See all transactions it should redirect you to /transactions
### Review checklist
- The PR solves #571
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
