### PR TITLE
Fix filters persist - Closes #531

### DIFF
--- a/src/components/delegateList/delegateList.js
+++ b/src/components/delegateList/delegateList.js
@@ -40,6 +40,7 @@ class DelegateList extends React.Component {
 
     if (this.props.showChangeSummery !== nextProps.showChangeSummery) {
       this.setState({
+        activeFilter: voteFilters.all,
         showChangeSummery: nextProps.showChangeSummery,
       });
     }

--- a/src/components/delegateList/delegateList.js
+++ b/src/components/delegateList/delegateList.js
@@ -152,7 +152,6 @@ class DelegateList extends React.Component {
           setActiveFilter={this.setActiveFilter.bind(this)}
           showChangeSummery={this.state.showChangeSummery}
           voteToggled={this.props.voteToggled}
-          addTransaction={this.props.addTransaction}
           search={ value => this.search(value) }
         />
         <section className={`${styles.delegatesList} delegate-list`}>

--- a/src/components/delegateList/votingRow.js
+++ b/src/components/delegateList/votingRow.js
@@ -11,7 +11,7 @@ const setRowClass = (voteStatus) => {
   if (pending) {
     return styles.pendingRow;
   } else if (confirmed !== unconfirmed) {
-    return confirmed ? `${styles.downVoteRow} votedRow` : `${styles.upVoteRow} votedRow`;
+    return confirmed ? `${styles.downVoteRow} selected-row` : `${styles.upVoteRow} selected-row`;
   }
   return confirmed ? styles.votedRow : '';
 };

--- a/src/components/delegateList/votingRow.js
+++ b/src/components/delegateList/votingRow.js
@@ -11,7 +11,7 @@ const setRowClass = (voteStatus) => {
   if (pending) {
     return styles.pendingRow;
   } else if (confirmed !== unconfirmed) {
-    return confirmed ? styles.downVoteRow : styles.upVoteRow;
+    return confirmed ? `${styles.downVoteRow} votedRow` : `${styles.upVoteRow} votedRow`;
   }
   return confirmed ? styles.votedRow : '';
 };

--- a/test/integration/voting.test.js
+++ b/test/integration/voting.test.js
@@ -204,7 +204,7 @@ describe('@integration test of Voting', () => {
     step('And I click checkbox on list item no. 0', () => helper.voteToDelegates(0, true));
     step('Then next button should be enabled', () => helper.checkDisableInput('button.next', 'not'));
     step('When I go to confirmation step', () => helper.goToConfirmation());
-    step('Then I should see all votes on confirmation step', () => helper.haveLengthOf('ul.votedRow', 2));
+    step('Then I should see all votes on confirmation step', () => helper.haveLengthOf('ul.selected-row', 2));
     step('Then I restore Api mocks', restoreApiMocks);
   });
 });

--- a/test/integration/voting.test.js
+++ b/test/integration/voting.test.js
@@ -194,4 +194,17 @@ describe('@integration test of Voting', () => {
     step('Then I should see result box', () => helper.haveTextOf('h2.result-box-header', 'Votes submitted'));
     step('Then I restore Api mocks', restoreApiMocks);
   });
+
+  describe('Scenario: should allow to see all selected delegates in confirm step', () => {
+    step('I\'m logged in as "genesis"', () => loginProcess([delegates[0]]));
+    step('And next button should be disabled', () => helper.checkDisableInput('button.next'));
+    step('And I click filter-voted', () => helper.clickOnElement('li.filter-voted'));
+    step('And I click checkbox on list item no. 0', () => helper.voteToDelegates(0, false));
+    step('And I click filter-not-voted', () => helper.clickOnElement('li.filter-not-voted'));
+    step('And I click checkbox on list item no. 0', () => helper.voteToDelegates(0, true));
+    step('Then next button should be enabled', () => helper.checkDisableInput('button.next', 'not'));
+    step('When I go to confirmation step', () => helper.goToConfirmation());
+    step('Then I should see all votes on confirmation step', () => helper.haveLengthOf('ul.votedRow', 2));
+    step('Then I restore Api mocks', restoreApiMocks);
+  });
 });


### PR DESCRIPTION
### What was the problem?
Delegates vote confirm page didn't display all changed delegates.
### How did I fix it?
Added show all filters when you are on confirm page.
### How to test it ?
- Go to delegates page
- Click on "Not voted" and select some delegates
- Click on "Voted" and select some delegates
- Click on "Next"
- Check if all changed delegates are displayed.

### Review checklist
- The PR solves #531
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
