### PR TITLE
Hide ID after creation - Closes #474

### DIFF
--- a/src/components/passphrase/create/index.js
+++ b/src/components/passphrase/create/index.js
@@ -173,6 +173,11 @@ class Create extends React.Component {
     const { shapes } = this.state;
     const percentage = this.state.data ? this.state.data.percentage : 0;
     const hintTitle = this.isTouchDevice ? 'by tilting your device.' : 'by moving your mouse.';
+    const modifyID = (id) => {
+      const substring = id.slice(3, id.length - 1);
+      const replacement = substring.replace(/.{1}/g, '*');
+      return id.replace(substring, replacement);
+    };
 
     return (
       <section className={`${grid.row} ${grid['center-xs']} ${styles.wrapper} ${styles.generation}`} id="generatorContainer" >
@@ -258,7 +263,8 @@ class Create extends React.Component {
             <aside className={`${styles.description} ${this.state.step === 'info' && this.state.showHint ? styles.fadeIn : ''}`}>
               <p>The <b>Avatar</b> represents the ID making it easy to recognize.
                 Every Lisk ID has one unique avatar.</p>
-              <p>The <b>ID</b> is unique and can’t be changed. It’s yours.</p>
+              <p>The <b>ID</b> is unique and can’t be changed. It’s yours.
+                You will get the full <b>ID</b> at the end.</p>
               <Button
                 label={t('Got it')}
                 onClick={this.showHint.bind(this)}
@@ -270,7 +276,7 @@ class Create extends React.Component {
               <figure>
                 <AccountVisual address={this.state.address} size={200} />
               </figure>
-              <h4 className={styles.address}>{this.state.address}</h4>
+              <h4 className={styles.address}>{modifyID(this.state.address)}</h4>
               <PrimaryButton
                 theme={styles}
                 label='Get passphrase'


### PR DESCRIPTION
### What was the problem?
see #474

### How did I fix it?
By replacing some of the numbers with `*`

### How to test it?
Create an ID, should look like this:

<img width="1179" alt="screen shot 2018-03-21 at 17 28 16" src="https://user-images.githubusercontent.com/9592216/37722935-6f0bedc6-2d2d-11e8-97ab-b1b38e1ac0de.png">


### Review checklist
- The PR solves #474
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
