### PR TITLE
Fix "Account not found" error in Delegates - Closes #552

### DIFF
--- a/src/components/delegateList/delegateList.js
+++ b/src/components/delegateList/delegateList.js
@@ -23,7 +23,10 @@ class DelegateList extends React.Component {
   }
 
   componentDidMount() {
-    this.loadVotedDelegates(true);
+    if (this.props.serverPublicKey) {
+      this.loadVotedDelegates(true);
+    }
+
     if (navigator.userAgent) {
       const agent = navigator.userAgent;
       if (agent.indexOf('Safari') > 0 && agent.indexOf('Chrome') === -1) {

--- a/src/components/delegateList/delegateList.test.js
+++ b/src/components/delegateList/delegateList.test.js
@@ -31,6 +31,7 @@ describe('DelegateList', () => {
     delegates,
     totalDelegates: 10,
     votes,
+    serverPublicKey: null,
     activePeer: {},
     address: '16313739661670634666L',
     setActiveDialog: sinon.spy(),

--- a/src/components/delegateList/index.js
+++ b/src/components/delegateList/index.js
@@ -5,6 +5,7 @@ import DelegateList from './delegateList';
 
 const mapStateToProps = state => ({
   address: state.account.address,
+  serverPublicKey: state.account.serverPublicKey,
   activePeer: state.peers.data,
   votes: state.voting.votes,
   delegates: state.voting.delegates,

--- a/src/components/voting/voting.test.js
+++ b/src/components/voting/voting.test.js
@@ -16,12 +16,14 @@ describe('Voting', () => {
       address: 'address 1',
       username: 'username1',
       publicKey: 'sample_key',
+      serverPublicKey: 'sample_key',
       rank: 12,
     },
     {
       address: 'address 2',
       username: 'username2',
       publicKey: 'sample_key',
+      serverPublicKey: 'sample_key',
       rank: 23,
     },
   ];

--- a/test/constants/accounts.js
+++ b/test/constants/accounts.js
@@ -2,12 +2,14 @@ const accounts = {
   genesis: {
     passphrase: 'wagon stock borrow episode laundry kitten salute link globe zero feed marble',
     publicKey: 'c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f',
+    serverPublicKey: 'c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f',
     address: '16313739661670634666L',
     balance: '9967542080836600',
   },
   delegate: {
     passphrase: 'recipe bomb asset salon coil symbol tiger engine assist pact pumpkin visit',
     publicKey: '86499879448d1b0215d59cbf078836e3d7d9d2782d56a2274a568761bff36f19',
+    serverPublicKey: '86499879448d1b0215d59cbf078836e3d7d9d2782d56a2274a568761bff36f19',
     address: '537318935439898807L',
     username: 'genesis_17',
     balance: 1000e8,
@@ -15,28 +17,33 @@ const accounts = {
   'empty account': {
     passphrase: 'stay undo beyond powder sand laptop grow gloom apology hamster primary arrive',
     publicKey: '197cf311f678406bc72a8edfdc3dffe6f59f49c4550a860e4b68fb20382211d0',
+    serverPublicKey: '197cf311f678406bc72a8edfdc3dffe6f59f49c4550a860e4b68fb20382211d0',
     address: '5932438298200837883L',
     balance: 0,
   },
   'delegate candidate': {
     passphrase: 'right cat soul renew under climb middle maid powder churn cram coconut',
     publicKey: '35c6b25520fc868b56c83fed6e1c89bb350fb7994a5da0bcea7a4f621f948c7f',
+    serverPublicKey: '35c6b25520fc868b56c83fed6e1c89bb350fb7994a5da0bcea7a4f621f948c7f',
     address: '544792633152563672L',
     username: 'test',
   },
   'second passphrase candidate': {
     passphrase: 'dolphin inhale planet talk insect release maze engine guilt loan attend lawn',
     publicKey: 'ecf6a5cc0b7168c7948ccfaa652cce8a41256bdac1be62eb52f68cde2fb69f2d',
+    serverPublicKey: 'ecf6a5cc0b7168c7948ccfaa652cce8a41256bdac1be62eb52f68cde2fb69f2d',
     address: '4264113712245538326L',
   },
   'send all account': {
     passphrase: 'oyster flush inquiry bright leopard gas replace ball hold pudding teach swear',
     publicKey: 'c5e64031407c3ca8d526bf7404f7c78ab60ea0792e90393a73b3b06a8c8841d4',
+    serverPublicKey: 'c5e64031407c3ca8d526bf7404f7c78ab60ea0792e90393a73b3b06a8c8841d4',
     address: '16422276087748907680L',
   },
   'second passphrase account': {
     passphrase: 'awkward service glimpse punch genre calm grow life bullet boil match like',
     publicKey: 'fab9d261ea050b9e326d7e11587eccc343a20e64e29d8781b50fd06683cacc88',
+    serverPublicKey: 'fab9d261ea050b9e326d7e11587eccc343a20e64e29d8781b50fd06683cacc88',
     secondPassphrase: 'forest around decrease farm vanish permit hotel clay senior matter endorse domain',
     address: '1155682438012955434L',
     balance: 1000e8,

--- a/test/integration/wallet.test.js
+++ b/test/integration/wallet.test.js
@@ -113,12 +113,15 @@ describe('@integration: Wallet', () => {
       passphrase,
     };
 
+    if (!options.withPublicKey) {
+      delete account.serverPublicKey;
+    }
+
     accountAPIStub.withArgs(match.any).returnsPromise().resolves({ ...account });
     store.dispatch(activePeerSet({ network: getNetwork(networks.mainnet.code) }));
     accountAPIStub.withArgs(match.any).returnsPromise()
       .resolves({
         ...account,
-        serverPublicKey: options.withPublicKey ? account.publicKey : undefined,
       });
     store.dispatch(accountLoggedIn(account));
     wrapper = mount(renderWithRouter(Wallet, store, { history: { location: { search: '' } } }));


### PR DESCRIPTION
### What was the problem?
```
Uncaught (in promise) {success: false, error: "Account not found"}
error: "Account not found"success: false
```
in delegates when an account is not initialized.
### How did I fix it?
I prevented from making function call when the account is not initialized 
### How to test it?
1. Create new account
2. Go to delegates and check if there is an error in a console.
### Review checklist
- The PR solves #552
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
