### PR TITLE
Make address in account switcher copyable - Closes #594

### DIFF
--- a/src/components/savedAccounts/savedAccounts.css
+++ b/src/components/savedAccounts/savedAccounts.css
@@ -131,6 +131,7 @@
   margin-bottom: 40px;
   color: var(--color-grayscale-dark);
   font-size: var(--address-font-size);
+  font-weight: var(--font-weight-normal);
 }
 
 .cardIcon {

--- a/src/components/savedAccounts/savedAccounts.js
+++ b/src/components/savedAccounts/savedAccounts.js
@@ -18,6 +18,7 @@ import rectangleImage2 from '../../assets/images/add-id-rectangle-2.svg';
 import rectangleImage3 from '../../assets/images/add-id-rectangle-3.svg';
 import triangleImage from '../../assets/images/add-id-triangle.svg';
 import { FontIcon } from '../fontIcon';
+import CopyToClipboard from '../copyToClipboard';
 
 import styles from './savedAccounts.css';
 
@@ -157,7 +158,8 @@ class SavedAccounts extends React.Component {
                 <h2>
                   <LiskAmount val={account.balance} /> <small>LSK</small>
                 </h2>
-                <div className={styles.address} >{extractAddress(account.publicKey)}</div>
+                <div className={styles.address} onClick={ e => e.stopPropagation()}>
+                  <CopyToClipboard value={extractAddress(account.publicKey)}/></div>
                 { this.isSelectedForRemove(account) ?
                   <div className={styles.removeConfirm}>
                     <h2>{t('You can always get it back.')}</h2>


### PR DESCRIPTION
### What was the problem?
Address in account switcher was not copyable

### How did I fix it?
Wrapped `copyToClipboard` around the address

### How to test it?
Try to copy the address

### Review checklist
- The PR solves #594
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
