### PR TITLE
Open all external links in default browser - Closes #532

### DIFF
--- a/app/src/modules/win.js
+++ b/app/src/modules/win.js
@@ -65,6 +65,15 @@ const win = {
       menuPopup({ props, selectionMenu, inputMenu }); // eslint-disable-line no-use-before-define
     });
 
+    const handleRedirect = (e, url) => {
+      if (url !== win.browser.webContents.getURL()) {
+        e.preventDefault();
+        electron.shell.openExternal(url);
+      }
+    };
+    win.browser.webContents.on('will-navigate', handleRedirect);
+    win.browser.webContents.on('new-window', handleRedirect);
+
     // Resolve all events from stack when dom is ready
     win.browser.webContents.on('did-finish-load', () => {
       win.isUILoaded = true;


### PR DESCRIPTION
### What was the problem?
Links in electron app needed to open in browser
### How did I fix it?
Links in electron app opened in another electron window
### How to test it?

1. run 'npm build'
2. run 'npm start'
3. go to sidechain page
4. click on 'Learn more about Lisk sidechains'

### Review checklist
- The PR solves #532 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
