### PR TITLE
Remove "back to lisk.io" from login page

### DIFF
--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -18,7 +18,6 @@
   "Are you sure to confirm this selection?": "Are you sure to confirm this selection?",
   "Auto-Lock": "Auto-Lock",
   "Back": "Back",
-  "Back to lisk.io": "Back to lisk.io",
   "Back to overview": "Back to overview",
   "Becoming a delegate requires registration. You may choose your own delegate name, which can be used to promote your delegate. Only the top 101 delegates are eligible to forge. All fees are shared equally between the top 101 delegates.": "Becoming a delegate requires registration. You may choose your own delegate name, which can be used to promote your delegate. Only the top 101 delegates are eligible to forge. All fees are shared equally between the top 101 delegates.",
   "Blockchain Application Registration": "Blockchain Application Registration",

--- a/src/components/login/login.js
+++ b/src/components/login/login.js
@@ -144,12 +144,6 @@ class Login extends React.Component {
       <Box className={styles.wrapper}>
         <section className={`${styles.login} ${styles[this.state.passInputState]}`}>
           <section className={styles.table}>
-            <header>
-              <a className={styles.backButton} href='https://lisk.io' target='_blank' rel='noopener noreferrer'>
-                <FontIcon className={styles.icon}>arrow-left</FontIcon>
-                <span className={styles.label}>{this.props.t('Back to lisk.io')}</span>
-              </a>
-            </header>
             <div className={`${styles.tableCell} text-left`}>
               <h2>{this.props.t('Sign in')}</h2>
               <form onSubmit={this.onFormSubmit.bind(this)}>


### PR DESCRIPTION
### What was the problem?
Removing the "back to lisk.io" from login page

### How did I fix it?
Removed the HTML code which is used to display the content

### How to test it?
Visit the login page and ensure there's no 'back to list.io' link

### Review checklist
- The PR solves #599 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices

Screenshot 

<img width="1089" alt="screen shot 2018-03-26 at 1 55 55 pm" src="https://user-images.githubusercontent.com/15159118/37923586-7a2c433a-30fd-11e8-8f1f-753df683736e.png">

