### PR TITLE
Apply electron security patch #611

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/LiskHQ/lisk-hub/badge.svg?branch=development)](https://coveralls.io/github/LiskHQ/lisk-hub?branch=development)
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](http://www.gnu.org/licenses/gpl-3.0)
 [![Join the chat at https://gitter.im/LiskHQ/lisk](https://badges.gitter.im/LiskHQ/lisk.svg)](https://gitter.im/LiskHQ/lisk?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Dependencies Status](https://david-dm.org/liskHQ/lisk-hub/status.svg)](https://david-dm.org/liskHQ/lisk-hub)
 [![devDependencies Status](https://david-dm.org/liskHQ/lisk-hub/dev-status.svg)](https://david-dm.org/liskHQ/lisk-hub?type=dev)
 
 ## Development

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "cucumber": "2.2.0",
     "cucumber-junit": "1.7.0",
     "del-cli": "1.1.0",
-    "electron": "1.8.2",
+    "electron": "1.8.4",
     "electron-builder": "19.32.2",
     "electron-json-storage": "=3.2.0",
     "electron-updater": "2.16.1",


### PR DESCRIPTION
### What was the problem?
electron had a newly discovered vulnerability. https://nodesecurity.io/advisories/574

### How did I fix it?
I upgraded electron.

### How to test it?
Install the new version of electron and check that the app still works.

### Review checklist
- The PR solves #611
