### PR TITLE
Split SavedAccount into smaller components - subTask #513

### DIFF
--- a/src/components/savedAccounts/accountCard.js
+++ b/src/components/savedAccounts/accountCard.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { extractAddress } from '../../utils/api/account';
+import { PrimaryButton } from '../toolbox/buttons/button';
+import AccountVisual from '../accountVisual';
+import LiskAmount from '../liskAmount';
+import networks from '../../constants/networks';
+import getNetwork from '../../utils/getNetwork';
+import CopyToClipboard from '../copyToClipboard';
+import { FontIcon } from '../fontIcon';
+import styles from './card.css';
+
+const AccountCard = ({ account, t, isEditing, handleRemove, isSecureAppears,
+  isSelectedForRemove, selectForRemove, onClick, handleRemovePassphrase }) =>
+  (<li onClick={onClick} className={`saved-account-card ${styles.card}
+    ${isEditing ? null : styles.clickable}
+    ${isSelectedForRemove(account) ? styles.darkBackground : null}`}>
+    {(account.passphrase ?
+      <strong
+        className={`unlocked ${styles.unlocked}`}
+        onClick={e => handleRemovePassphrase(account, e)}>
+        <FontIcon value='unlocked' />
+        {t('Lock ID')}
+      </strong> :
+      null)}
+    {(isSecureAppears[`${account.network}${account.publicKey}`] ?
+      <strong className={`unlockedSecured ${styles.unlockedSecured}`}>
+        {t('Your ID is now secured!')}
+      </strong> :
+      null)}
+    {(account.network !== networks.mainnet.code ?
+      <strong className={styles.network}>
+        {account.address ? account.address : t(getNetwork(account.network).name)}
+      </strong> :
+      null)}
+    <div className={styles.cardIcon}>
+      <AccountVisual address={extractAddress(account.publicKey)} size={155} sizeS={100}
+        className={styles.accountVisual} />
+    </div>
+    <h2>
+      <LiskAmount val={account.balance} /> <small>LSK</small>
+    </h2>
+    <div className={`${styles.address} address`} onClick={ e => e.stopPropagation()}>
+      <CopyToClipboard value={extractAddress(account.publicKey)}/></div>
+    { isSelectedForRemove(account) ?
+      <div className={styles.removeConfirm}>
+        <h2>{t('You can always get it back.')}</h2>
+        <a onClick={selectForRemove}>{t('Keep it')}</a>
+      </div> :
+      null
+    }
+    { isEditing ?
+      <PrimaryButton className='remove-button'
+        theme={ isSelectedForRemove(account) ?
+          {} :
+          { button: styles.removeButton }
+        }
+        onClick={e => handleRemove(account, e)}
+        label={isSelectedForRemove(account) ? t('Confirm') : t('Remove')}/> :
+      null
+    }
+  </li>);
+
+export default AccountCard;

--- a/src/components/savedAccounts/accountCard.test.js
+++ b/src/components/savedAccounts/accountCard.test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import { spy } from 'sinon';
+import PropTypes from 'prop-types';
+import i18n from '../../i18n';
+import AccountCard from './accountCard';
+
+
+describe('SavedAccounts', () => {
+  const account = {
+    passsphrase: 'dolphin inhale planet talk insect release maze engine guilt loan attend lawn',
+    publicKey: 'ecf6a5cc0b7168c7948ccfaa652cce8a41256bdac1be62eb52f68cde2fb69f2d',
+    balance: 0,
+    network: 1,
+  };
+
+  const props = {
+    account,
+    t: str => str,
+    isEditing: false,
+    handleRemove: spy(),
+    isSecureAppears: false,
+    isSelectedForRemove: spy(),
+    selectForRemove: spy(),
+    onClick: spy(),
+    handleRemovePassphrase: spy(),
+  };
+
+  it('should prevent event propagation if clicked on address', () => {
+    const wrapper = mount(<AccountCard {...props} />, {
+      context: { i18n },
+      childContextTypes: {
+        i18n: PropTypes.object.isRequired,
+      },
+    });
+    // Address won't propagate
+    wrapper.find('.address').simulate('click');
+    expect(props.onClick).to.not.have.been.calledWith();
+    // but any other element with do
+    wrapper.find('h2').simulate('click');
+    expect(props.onClick).to.have.been.calledWith();
+  });
+});

--- a/src/components/savedAccounts/accountCard.test.js
+++ b/src/components/savedAccounts/accountCard.test.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import i18n from '../../i18n';
 import AccountCard from './accountCard';
 
-
 describe('SavedAccounts', () => {
   const account = {
     passsphrase: 'dolphin inhale planet talk insect release maze engine guilt loan attend lawn',

--- a/src/components/savedAccounts/addAccountCard.js
+++ b/src/components/savedAccounts/addAccountCard.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import routes from '../../constants/routes';
+import plusShapeIcon from '../../assets/images/plus-shape.svg';
+import circleImage from '../../assets/images/add-id-oval.svg';
+import rectangleOnTheRight from '../../assets/images/add-id-rectangle-1.svg';
+import rectangleImage2 from '../../assets/images/add-id-rectangle-2.svg';
+import rectangleImage3 from '../../assets/images/add-id-rectangle-3.svg';
+import triangleImage from '../../assets/images/add-id-triangle.svg';
+import styles from './card.css';
+
+const AddAccountCard = ({ t }) =>
+  (<li>
+    <Link to={`${routes.addAccount.path}?referrer=${routes.main.path}${routes.dashboard.path}/`} >
+      <div className={`add-lisk-id-card ${styles.card} ${styles.addNew}`} >
+        <div className={styles.cardIcon}>
+          <img src={plusShapeIcon} className={styles.plusShapeIcon} />
+        </div>
+        <img src={rectangleOnTheRight} className={styles.rectangleOnTheRight} />
+        <img src={rectangleImage2} className={styles.rectangleImage2} />
+        <img src={rectangleImage3} className={styles.rectangleImage3} />
+        <img src={triangleImage} className={styles.triangleImage} />
+        <img src={circleImage} className={styles.circleImage} />
+        <h2 className={styles.addTittle} >{t('Add a Lisk ID')}</h2>
+      </div>
+    </Link>
+  </li>);
+
+export default AddAccountCard;

--- a/src/components/savedAccounts/card.css
+++ b/src/components/savedAccounts/card.css
@@ -1,0 +1,228 @@
+@import '../app/variables.css';
+
+:root {
+  --font-size-card-h2: 30px;
+  --font-size-card-h2-s: 24px;
+  --address-font-size: 17px;
+  --small-font-size: 20px;
+  --card-width: 347px;
+  --card-height: 436px;
+  --card-width-m: 267px;
+  --card-height-m: 336px;
+}
+
+.card {
+  position: relative;
+  display: inline-block;
+  width: var(--card-width);
+  height: var(--card-height);
+  border-radius: var(--border-radius-normal);
+  background-color: var(--color-white);
+  box-shadow: var(--normal-shadow);
+  margin: 24px;
+  text-align: center;
+  vertical-align: top;
+
+  & h2 {
+    position: relative;
+    font-size: var(--font-size-card-h2);
+    color: var(--color-black);
+
+    & > small {
+      font-size: var(--small-font-size);
+    }
+  }
+
+  &:hover {
+    & .accountVisual {
+      transform: scale(1.1);
+      transform-origin: 50%;
+    }
+  }
+
+  & .removeButton {
+    background: var(--color-white) !important;
+    color: var(--color-grayscale-dark) !important;
+    border: none;
+    box-shadow: var(--normal-shadow);
+    text-transform: none;
+
+    &:hover {
+      background: var(--color-white) !important;
+      color: var(--color-primary-medium) !important;
+    }
+  }
+}
+
+.clickable {
+  cursor: pointer;
+}
+
+.addNew {
+  background-image: linear-gradient(-134deg, #93f4fe 1%, #004aff 98%);
+
+  & > h2 {
+    color: var(--color-white);
+    text-align: center;
+  }
+}
+
+.address {
+  margin-bottom: 40px;
+  color: var(--color-grayscale-dark);
+  font-size: var(--address-font-size);
+  font-weight: var(--font-weight-normal);
+}
+
+.cardIcon {
+  width: 175px;
+  height: 175px;
+  margin: 78px 78px 32px;
+  position: relative;
+}
+
+.plusShapeIcon {
+  width: 134px;
+  height: 134px;
+  margin: 24px;
+}
+
+/** shapes  **/
+.rectangleOnTheRight,
+.rectangleImage2,
+.rectangleImage3,
+.triangleImage,
+.circleImage {
+  position: absolute;
+  opacity: 0.8;
+}
+
+.circleImage {
+  right: 0px;
+  bottom: 64px;
+}
+
+.rectangleOnTheRight {
+  right: 0px;
+  bottom: 60px;
+}
+
+.rectangleImage2 {
+  left: 50px;
+  bottom: 0px;
+}
+
+.rectangleImage3 {
+  left: 0px;
+  bottom: 0px;
+}
+
+.triangleImage {
+  left: 54px;
+  bottom: 92px;
+}
+
+.network,
+.unlocked,
+.unlockedSecured {
+  font-size: var(--font-size-h6);
+  position: absolute;
+  top: 0;
+  padding: 24px;
+  color: var(--color-grayscale-dark);
+  font-weight: bold;
+
+  & > * {
+    vertical-align: bottom;
+  }
+}
+
+.unlocked {
+  left: 0;
+  padding-top: 25px;
+
+  & span {
+    margin-bottom: 3px;
+    transition: transform ease-in-out 500ms;
+  }
+
+  &:hover {
+    & span {
+      transform: scale(1.1);
+      transform-origin: 100%;
+    }
+  }
+}
+
+.unlockedSecured {
+  left: 0;
+  padding-top: 30px;
+}
+
+.network {
+  padding-top: 30px;
+  right: 0;
+}
+
+.darkBackground {
+  background-color: var(--color-primary-dark);
+}
+
+.removeConfirm {
+  position: absolute;
+  top: 0px;
+  background-color: var(--color-primary-dark);
+  color: var(--color-white);
+  border-radius: var(--border-radius-normal);
+  height: var(--card-height);
+
+  & h2 {
+    white-space: normal;
+    color: var(--color-white);
+    margin: 155px 45px 24px;
+  }
+
+  & a {
+    color: var(--color-white);
+    text-decoration: underline;
+    margin: 20px 40px 200px;
+    cursor: pointer;
+  }
+}
+
+@media (--medium-viewport) {
+  .card {
+    width: var(--card-width-m);
+    height: var(--card-height-m);
+
+    & h2 {
+      font-size: var(--font-size-card-h2);
+    }
+  }
+
+  .removeConfirm {
+    height: var(--card-height-m);
+  }
+
+  .cardIcon {
+    width: 175px;
+    height: 175px;
+    margin: 38px 48px 32px;
+  }
+
+  .address {
+    margin-bottom: 20px;
+  }
+}
+
+@media (--small-viewport) {
+  .card {
+    width: var(--card-width-m);
+    height: 320px;
+    margin: 0px 24px;
+  }
+
+  .cardIcon {
+    height: 130px;
+  }
+}

--- a/src/components/savedAccounts/savedAccounts.css
+++ b/src/components/savedAccounts/savedAccounts.css
@@ -4,21 +4,10 @@
   --font-size-ids-h1-xl: 64px;
   --font-size-ids-h1-l: 48px;
   --font-size-ids-h1-s: 30px;
-  --font-size-card-h2: 30px;
-  --font-size-card-h2-s: 24px;
-  --address-font-size: 17px;
-  --small-font-size: 20px;
   --close-button-shadow: 0 20px 20px 0 rgba(0, 32, 68, 0.25);
   --h1-padding-xl: 85px;
   --h1-padding-l: 40px;
   --h1-padding-m: 25px;
-  --add-button-margin: 200px;
-  --card-width: 347px;
-  --card-height: 436px;
-  --card-width-m: 267px;
-  --card-height-m: 336px;
-  --add-button-margin: 240px;
-  --wrapper-margin: -24px;
 }
 
 .content {
@@ -71,116 +60,7 @@
   }
 }
 
-.card {
-  position: relative;
-  display: inline-block;
-  width: var(--card-width);
-  height: var(--card-height);
-  border-radius: var(--border-radius-normal);
-  background-color: var(--color-white);
-  box-shadow: var(--normal-shadow);
-  margin: 24px;
-  text-align: center;
-  vertical-align: top;
-
-  & h2 {
-    position: relative;
-    font-size: var(--font-size-card-h2);
-    color: var(--color-black);
-
-    & > small {
-      font-size: var(--small-font-size);
-    }
-  }
-
-  &:hover {
-    & .accountVisual {
-      transform: scale(1.1);
-      transform-origin: 50%;
-    }
-  }
-
-  & .removeButton {
-    background: var(--color-white) !important;
-    color: var(--color-grayscale-dark) !important;
-    border: none;
-    box-shadow: var(--normal-shadow);
-    text-transform: none;
-
-    &:hover {
-      background: var(--color-white) !important;
-      color: var(--color-primary-medium) !important;
-    }
-  }
-}
-
-.clickable {
-  cursor: pointer;
-}
-
-.addNew {
-  background-image: linear-gradient(-134deg, #93f4fe 1%, #004aff 98%);
-
-  & > h2 {
-    color: var(--color-white);
-    text-align: center;
-  }
-}
-
-.address {
-  margin-bottom: 40px;
-  color: var(--color-grayscale-dark);
-  font-size: var(--address-font-size);
-  font-weight: var(--font-weight-normal);
-}
-
-.cardIcon {
-  width: 175px;
-  height: 175px;
-  margin: 78px 78px 32px;
-  position: relative;
-}
-
-.plusShapeIcon {
-  width: 134px;
-  height: 134px;
-  margin: 24px;
-}
-
-.rectangleOnTheRight,
-.rectangleImage2,
-.rectangleImage3,
-.triangleImage,
-.circleImage {
-  position: absolute;
-  opacity: 0.8;
-}
-
-.circleImage {
-  right: 0px;
-  bottom: 64px;
-}
-
-.rectangleOnTheRight {
-  right: 0px;
-  bottom: 60px;
-}
-
-.rectangleImage2 {
-  left: 50px;
-  bottom: 0px;
-}
-
-.rectangleImage3 {
-  left: 0px;
-  bottom: 0px;
-}
-
-.triangleImage {
-  left: 54px;
-  bottom: 92px;
-}
-
+/** Obsolete
 .accountVisualPlaceholder,
 .accountVisualPlaceholder2 {
   position: absolute;
@@ -196,48 +76,7 @@
   top: 70px;
   left: 44px;
 }
-
-.network,
-.unlocked,
-.unlockedSecured {
-  font-size: var(--font-size-h6);
-  position: absolute;
-  top: 0;
-  padding: 24px;
-  color: var(--color-grayscale-dark);
-  font-weight: bold;
-
-  & > * {
-    vertical-align: bottom;
-  }
-}
-
-.unlocked {
-  left: 0;
-  padding-top: 25px;
-
-  & span {
-    margin-bottom: 3px;
-    transition: transform ease-in-out 500ms;
-  }
-
-  &:hover {
-    & span {
-      transform: scale(1.1);
-      transform-origin: 100%;
-    }
-  }
-}
-
-.unlockedSecured {
-  left: 0;
-  padding-top: 30px;
-}
-
-.network {
-  padding-top: 30px;
-  right: 0;
-}
+**/
 
 .addAcctiveAccountButton {
   position: absolute !important;
@@ -251,32 +90,6 @@
   position: absolute !important;
   top: var(--h1-padding-l);
   right: 85px;
-}
-
-.darkBackground {
-  background-color: var(--color-primary-dark);
-}
-
-.removeConfirm {
-  position: absolute;
-  top: 0px;
-  background-color: var(--color-primary-dark);
-  color: var(--color-white);
-  border-radius: var(--border-radius-normal);
-  height: var(--card-height);
-
-  & h2 {
-    white-space: normal;
-    color: var(--color-white);
-    margin: 155px 45px 24px;
-  }
-
-  & a {
-    color: var(--color-white);
-    text-decoration: underline;
-    margin: 20px 40px 200px;
-    cursor: pointer;
-  }
 }
 
 .editIcon {
@@ -297,6 +110,13 @@
   }
 }
 
+.background {
+  display: block !important;
+  position: fixed !important;
+  left: 0;
+  top: 0;
+}
+
 @media (--medium-viewport) {
   .wrapper {
     top: -100px;
@@ -311,25 +131,6 @@
     padding: 0 40px;
   }
 
-  .card {
-    width: var(--card-width-m);
-    height: var(--card-height-m);
-
-    & h2 {
-      font-size: var(--font-size-card-h2);
-    }
-  }
-
-  .removeConfirm {
-    height: var(--card-height-m);
-  }
-
-  .cardIcon {
-    width: 175px;
-    height: 175px;
-    margin: 38px 48px 32px;
-  }
-
   .closeButton {
     top: var(--h1-padding-m);
     right: 35px;
@@ -338,17 +139,6 @@
   .addAcctiveAccountButton {
     bottom: 16vh; /* stylelint-disable-line */
   }
-
-  .address {
-    margin-bottom: 20px;
-  }
-}
-
-.background {
-  display: block !important;
-  position: fixed !important;
-  left: 0;
-  top: 0;
 }
 
 @media (--small-viewport) {
@@ -367,16 +157,6 @@
 
   .cardsWrapper {
     padding: 0;
-  }
-
-  .card {
-    width: var(--card-width-m);
-    height: 320px;
-    margin: 0px 24px;
-  }
-
-  .cardIcon {
-    height: 130px;
   }
 
   .addAcctiveAccountButton {

--- a/src/components/savedAccounts/savedAccounts.js
+++ b/src/components/savedAccounts/savedAccounts.js
@@ -1,25 +1,11 @@
 import { Button as ToolBoxButton } from 'react-toolbox/lib/button';
-import { Link } from 'react-router-dom';
-// import FontIcon from 'react-toolbox/lib/font_icon';
 import React from 'react';
-import { extractAddress } from '../../utils/api/account';
-import { PrimaryButton, SecondaryLightButton } from '../toolbox/buttons/button';
-import AccountVisual from '../accountVisual';
-import LiskAmount from '../liskAmount';
+import { SecondaryLightButton } from '../toolbox/buttons/button';
 import BackgroundMaker from '../backgroundMaker';
-import networks from '../../constants/networks';
-import getNetwork from '../../utils/getNetwork';
 import routes from '../../constants/routes';
-
-import plusShapeIcon from '../../assets/images/plus-shape.svg';
-import circleImage from '../../assets/images/add-id-oval.svg';
-import rectangleOnTheRight from '../../assets/images/add-id-rectangle-1.svg';
-import rectangleImage2 from '../../assets/images/add-id-rectangle-2.svg';
-import rectangleImage3 from '../../assets/images/add-id-rectangle-3.svg';
-import triangleImage from '../../assets/images/add-id-triangle.svg';
 import { FontIcon } from '../fontIcon';
-import CopyToClipboard from '../copyToClipboard';
-
+import AddAccountCard from './addAccountCard';
+import AccountCard from './accountCard';
 import styles from './savedAccounts.css';
 
 
@@ -112,72 +98,19 @@ class SavedAccounts extends React.Component {
         </h1>
         <div className={`${styles.content}`}>
           <ul className={styles.cardsWrapper} >
-            <li>
-              <Link to={`${routes.addAccount.path}?referrer=${routes.main.path}${routes.dashboard.path}/`} >
-                <div className={`add-lisk-id-card ${styles.card} ${styles.addNew}`} >
-                  <div className={styles.cardIcon}>
-                    <img src={plusShapeIcon} className={styles.plusShapeIcon} />
-                  </div>
-                  <img src={rectangleOnTheRight} className={styles.rectangleOnTheRight} />
-                  <img src={rectangleImage2} className={styles.rectangleImage2} />
-                  <img src={rectangleImage3} className={styles.rectangleImage3} />
-                  <img src={triangleImage} className={styles.triangleImage} />
-                  <img src={circleImage} className={styles.circleImage} />
-                  <h2 className={styles.addTittle} >{t('Add a Lisk ID')}</h2>
-                </div>
-              </Link>
-            </li>
+            <AddAccountCard t={t} />
             {savedAccounts.map(account => (
-              <li className={`saved-account-card ${styles.card}
-                ${this.state.editing ? null : styles.clickable}
-                ${this.isSelectedForRemove(account) ? styles.darkBackground : null}`}
-              key={account.publicKey + account.network}
-              onClick={ switchAccount.bind(null, account)} >
-                {(account.passphrase ?
-                  <strong
-                    className={`unlocked ${styles.unlocked}`}
-                    onClick={this.handleRemovePassphrase.bind(this, account)}>
-                    <FontIcon value='unlocked' />
-                    {t('Lock ID')}
-                  </strong> :
-                  null)}
-                {(this.state.isSecureAppears[`${account.network}${account.publicKey}`] ?
-                  <strong className={`unlockedSecured ${styles.unlockedSecured}`}>
-                    {t('Your ID is now secured!')}
-                  </strong> :
-                  null)}
-                {(account.network !== networks.mainnet.code ?
-                  <strong className={styles.network}>
-                    {account.address ? account.address : t(getNetwork(account.network).name)}
-                  </strong> :
-                  null)}
-                <div className={styles.cardIcon}>
-                  <AccountVisual address={extractAddress(account.publicKey)} size={155} sizeS={100}
-                    className={styles.accountVisual} />
-                </div>
-                <h2>
-                  <LiskAmount val={account.balance} /> <small>LSK</small>
-                </h2>
-                <div className={styles.address} onClick={ e => e.stopPropagation()}>
-                  <CopyToClipboard value={extractAddress(account.publicKey)}/></div>
-                { this.isSelectedForRemove(account) ?
-                  <div className={styles.removeConfirm}>
-                    <h2>{t('You can always get it back.')}</h2>
-                    <a onClick={this.selectForRemove.bind(this)}>{t('Keep it')}</a>
-                  </div> :
-                  null
-                }
-                { this.state.editing ?
-                  <PrimaryButton className='remove-button'
-                    theme={ this.isSelectedForRemove(account) ?
-                      {} :
-                      { button: styles.removeButton }
-                    }
-                    onClick={this.handleRemove.bind(this, account)}
-                    label={this.isSelectedForRemove(account) ? t('Confirm') : t('Remove')}/> :
-                  null
-                }
-              </li>
+              <AccountCard
+                key={account.publicKey + account.network}
+                onClick={() => switchAccount(account)}
+                handleRemove={this.handleRemove.bind(this)}
+                isSelectedForRemove={this.isSelectedForRemove.bind(this)}
+                selectForRemove={this.selectForRemove.bind(this)}
+                handleRemovePassphrase={this.handleRemovePassphrase.bind(this)}
+                account={account}
+                isSecureAppears={this.state.isSecureAppears}
+                t={t}
+                isEditing={this.state.editing} />
             ))}
           </ul>
         </div>


### PR DESCRIPTION
### What was the problem?
The component and hence the css rules in savedAccount were large and hard to maintain. this ticket aims to split them into smaller/single purpose files.

### How did I fix it?
I created accountCard and addAccountCard components, moved their specific css rules into card.css file and converted the missing lines of accountCard component with unit test.

### Review checklist
- The PR is a subset of changes required for #513 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices