### PR TITLE
Split Login into smaller components - subTask #513

### DIFF
--- a/src/components/login/animations.css
+++ b/src/components/login/animations.css
@@ -1,0 +1,62 @@
+@keyframes delayedFadeIn {
+  0% { opacity: 0; }
+  75% { opacity: 0; }
+  100% { opacity: 1; }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes somersault {
+  0% {
+    transform: translate3d(15%, 0, 0) rotateZ(10deg);
+  }
+
+  100% {
+    transform: translate3d(-15%, 0, 0) rotateZ(-10deg);
+  }
+}
+
+@keyframes tilt {
+  0% {
+    transform: rotateX(-30deg);
+  }
+
+  25% {
+    transform: rotateX(30deg);
+  }
+
+  50% {
+    transform: rotateY(-30deg);
+  }
+
+  75% {
+    transform: rotateY(30deg);
+  }
+
+  100% {
+    transform: rotateZ(20deg);
+  }
+}
+
+@-webkit-keyframes wave {
+  0% {
+    transform: rotateZ(0deg) translate3d(0, 10%, 0) rotateZ(0deg);
+  }
+
+  100% {
+    transform: rotateZ(360deg) translate3d(0, 10%, 0) rotateZ(-360deg);
+  }
+}
+
+@-webkit-keyframes wander {
+  0% {
+    transform: translate3d(0, 0, 0) rotateZ(0deg);
+  }
+
+  100% {
+    transform: translate3d(-15%, 10%, 0) rotateZ(0deg);
+  }
+}

--- a/src/components/login/layout.css
+++ b/src/components/login/layout.css
@@ -1,0 +1,57 @@
+@import './../app/variables.css';
+
+:root {
+  --transition: all ease 300ms;
+}
+
+.wrapper {
+  animation: delayedFadeIn 300ms;
+  overflow: visible !important;
+  display: block !important;
+  clear: both;
+  padding-right: 16px;
+}
+
+@define-mixin login-signup {
+  transition: var(--transition);
+  position: relative;
+  box-sizing: border-box;
+  float: left;
+}
+
+.table {
+  display: table;
+  width: 100%;
+  height: 100%;
+}
+
+.outTaken {
+  position: absolute;
+}
+
+.loading {
+  text-align: center;
+  padding: 20px;
+  color: var(--color-grayscale-medium);
+  padding-top: 200px;
+  clear: both;
+}
+
+.input {
+  padding-bottom: 0px;
+}
+
+@media (--medium-viewport) {
+  .wrapper {
+    height: 100%;
+    padding-right: 0;
+  }
+}
+
+@media (--small-viewport) {
+  .wrapper {
+    padding-left: 0;
+    padding-right: 0;
+    height: 100%;
+  }
+}

--- a/src/components/login/login.css
+++ b/src/components/login/login.css
@@ -1,53 +1,24 @@
 @import './../app/variables.css';
+@import './animations.css';
+@import './layout.css';
 
 :root {
-  --gradient: linear-gradient(45deg, rgba(0, 74, 255, 1) 0%, rgba(147, 244, 254, 1) 100%);
   --transition: all ease 300ms;
   --header-focused-font-size: 32px;
-  --arrow-font-size: 60px;
-  --arrow-focused-font-size: 40px;
-  --rect-width: 200px;
   --login-box-padding-L: var(--box-padding-left-L);
   --login-box-padding-XL: var(--box-padding-left-XL);
-  --signup-box-padding-L: var(--box-padding-left-L);
-  --signup-box-padding-XL: var(--box-padding-left-XL);
-  --focused-signup-box-padding-XL: 31px;
-  --focused-signup-box-padding-L: 24px;
   --back-button-label-font-size-XL: 15px;
   --back-button-label-font-size-L: 12px;
   --back-button-icon-font-size-XL: 24px;
   --back-button-icon-font-size-L: 16px;
 }
 
-@keyframes delayedFadeIn {
-  0% { opacity: 0; }
-  75% { opacity: 0; }
-  100% { opacity: 1; }
-}
-
-.wrapper {
-  animation: delayedFadeIn 300ms;
-  overflow: visible !important;
-  display: block !important;
-  clear: both;
-  padding-right: 16px;
-}
-
 .login {
   height: 100%;
-}
-
-.login,
-.signUp {
-  transition: var(--transition);
-  position: relative;
-  box-sizing: border-box;
-  float: left;
-}
-
-.login {
   width: 42%;
   overflow: auto;
+
+  @mixin login-signup;
 
   & footer {
     padding-top: 7vh; /* stylelint-disable-line */
@@ -118,239 +89,6 @@
   }
 }
 
-.signUp {
-  height: calc(100% + 46px);
-  width: 58%;
-  margin-top: -23px;
-  border-radius: 3px;
-  overflow: hidden;
-
-  & .bg,
-  & .shapes,
-  & .shapes > div {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    left: 0;
-    top: 0;
-  }
-
-  & .bg {
-    z-index: 0;
-    opacity: 0.94;
-    background: var(--gradient);
-    border-radius: 3px;
-  }
-
-  & .shapes {
-    z-index: 1;
-  }
-
-  & .shape {
-    position: absolute !important;
-
-    &.rectA {
-      right: 20% !important;
-      top: 20% !important;
-      left: auto !important;
-      width: var(--rect-width);
-
-      & img {
-        width: 100%;
-        animation: wave 20s 0.1s infinite linear; /* stylelint-disable-line */
-      }
-    }
-
-    &.rectB {
-      left: 10% !important;
-      bottom: 25% !important;
-      top: auto !important;
-      width: var(--rect-width);
-
-      & img {
-        width: 100%;
-        animation: wave 16s 0.1s infinite linear; /* stylelint-disable-line */
-      }
-    }
-
-    &.rectC {
-      right: 20% !important;
-      bottom: 20% !important;
-      top: auto !important;
-      left: auto !important;
-      z-index: 2;
-      width: var(--rect-width);
-
-      & img {
-        width: 100%;
-        animation: wave 12s 0.1s infinite linear; /* stylelint-disable-line */
-      }
-    }
-
-    &.circle {
-      right: 5% !important;
-      bottom: 0% !important;
-      left: auto !important;
-      top: auto !important;
-      width: 150px;
-
-      & img {
-        width: 100%;
-        animation: wander 16s 0.1s infinite alternate cubic-bezier(0.455, 0.03, 0.515, 0.955); /* stylelint-disable-line */
-      }
-    }
-
-    &.triangle {
-      right: 10% !important;
-      left: auto !important;
-      top: 10% !important;
-      width: 250px;
-
-      & img {
-        width: 100%;
-        animation: somersault 20s 0.1s infinite alternate cubic-bezier(0.455, 0.03, 0.515, 0.955); /* stylelint-disable-line */
-      }
-    }
-  }
-
-  & .table {
-    position: relative;
-    z-index: 2;
-  }
-
-  & h2 {
-    color: var(--color-white);
-    margin-top: 32vh; /* stylelint-disable-line */
-    margin-bottom: 24px;
-    white-space: nowrap;
-  }
-
-  & .subTitle,
-  & a,
-  & .singUpArrow {
-    color: var(--color-white);
-    vertical-align: middle;
-    transition: var(--transition);
-  }
-
-  & .singUpArrow {
-    font-size: var(--arrow-font-size);
-  }
-
-  & .subTitle {
-    line-height: 28px;
-  }
-
-  & a {
-    text-decoration: none;
-    font-size: inherit;
-  }
-
-  & .shapes {
-    position: absolute;
-    z-index: 1;
-  }
-
-  &.focused {
-    transform: translateZ(0);
-
-    & h2 {
-      & a {
-        font-size: var(--header-focused-font-size);
-      }
-
-      & .singUpArrow {
-        font-size: var(--arrow-focused-font-size);
-      }
-    }
-
-    & .subTitle {
-      font-size: var(--subtitle-font-size);
-    }
-
-    & .shape {
-      &.triangle {
-        right: -25% !important;
-      }
-    }
-  }
-}
-
-.table {
-  display: table;
-  width: 100%;
-  height: 100%;
-}
-
-.outTaken {
-  position: absolute;
-}
-
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-@keyframes somersault {
-  0% {
-    transform: translate3d(15%, 0, 0) rotateZ(10deg);
-  }
-
-  100% {
-    transform: translate3d(-15%, 0, 0) rotateZ(-10deg);
-  }
-}
-
-@keyframes tilt {
-  0% {
-    transform: rotateX(-30deg);
-  }
-
-  25% {
-    transform: rotateX(30deg);
-  }
-
-  50% {
-    transform: rotateY(-30deg);
-  }
-
-  75% {
-    transform: rotateY(30deg);
-  }
-
-  100% {
-    transform: rotateZ(20deg);
-  }
-}
-
-@-webkit-keyframes wave {
-  0% {
-    transform: rotateZ(0deg) translate3d(0, 10%, 0) rotateZ(0deg);
-  }
-
-  100% {
-    transform: rotateZ(360deg) translate3d(0, 10%, 0) rotateZ(-360deg);
-  }
-}
-
-@-webkit-keyframes wander {
-  0% {
-    transform: translate3d(0, 0, 0) rotateZ(0deg);
-  }
-
-  100% {
-    transform: translate3d(-15%, 10%, 0) rotateZ(0deg);
-  }
-}
-
-.loading {
-  text-align: center;
-  padding: 20px;
-  color: var(--color-grayscale-medium);
-  padding-top: 200px;
-  clear: both;
-}
-
 @media (--xLarge-viewport) {
   .login {
     padding-right: var(--login-box-padding-XL);
@@ -370,25 +108,9 @@
         }
       }
     }
-  }
 
-  .signUp,
-  .login {
     & h2 {
       font-size: 65px;
-    }
-  }
-
-  .signUp {
-    padding: 0 var(--signup-box-padding-XL);
-
-    & .subTitle {
-      font-size: 18px;
-    }
-
-    &.focused {
-      width: 25%;
-      padding: 0 var(--focused-signup-box-padding-XL);
     }
   }
 }
@@ -412,62 +134,23 @@
         }
       }
     }
-  }
 
-  .signUp,
-  .login {
     & h2 {
       font-size: 50px;
-    }
-  }
-
-  .signUp {
-    padding: 0 var(--signup-box-padding-L);
-
-    & .subTitle {
-      font-size: 16px;
-    }
-
-    &.focused {
-      width: 32%;
-      padding: 0 var(--focused-signup-box-padding-L);
     }
   }
 }
 
 @media (--medium-viewport) {
-  .wrapper {
-    height: 100%;
-    padding-right: 0;
-  }
-
   .login {
     height: calc(100vh - var(--m-top-bar-height) - var(--m-menu-bar-height)); /* stylelint-disable-line */
     width: 40%;
-  }
 
-  .login,
-  .signUp {
     & h2 {
       font-size: var(--font-size-h2-l);
       margin-top: 28vh; /* stylelint-disable-line */
     }
-  }
 
-  .signUp {
-    margin-top: 0;
-    margin-right: -33px;
-    border-radius: 0px;
-    width: 60%;
-    height: calc(100vh - var(--m-top-bar-height) - var(--m-menu-bar-height)); /* stylelint-disable-line */
-
-    & .singUpArrow {
-      font-size: var(--arrow-focused-font-size);
-    }
-  }
-
-  .login,
-  .signUp {
     & .focused {
       & h2 {
         font-size: var(--font-size-h3-m);
@@ -477,28 +160,15 @@
 }
 
 @media (--small-viewport) {
-  .wrapper {
-    padding-left: 0;
-    padding-right: 0;
-    height: 100%;
-  }
-
-  .login,
-  .signUp {
+  .login {
+    height: calc(50vh - var(--s-top-bar-height)); /* stylelint-disable-line */
+    width: 100%;
     padding: 0 var(--box-padding-left-M);
 
     & h2 {
       font-size: var(--font-size-h2-s);
-    }
-
-    & h2 {
       margin-top: 12vh; /* stylelint-disable-line */
     }
-  }
-
-  .login {
-    height: calc(50vh - var(--s-top-bar-height)); /* stylelint-disable-line */
-    width: 100%;
 
     & header {
       position: relative;
@@ -545,71 +215,12 @@
       }
     }
   }
-
-  .signUp {
-    margin-right: 0;
-    border-radius: 0;
-    width: 100vw; /* stylelint-disable-line */
-    height: calc(50vh - var(--s-menu-bar-height)); /* stylelint-disable-line */
-
-    & .bg {
-      border-radius: 0;
-    }
-
-    &.focused {
-      width: 100vw; /* stylelint-disable-line */
-    }
-
-    & .shape {
-      position: absolute !important;
-
-      &.rectA {
-        right: 0% !important;
-        top: 5% !important;
-        left: auto !important;
-        width: 30%;
-      }
-
-      &.rectB {
-        right: -4% !important;
-        top: 10% !important;
-        left: auto !important;
-        width: 30%;
-      }
-
-      &.rectC {
-        & img {
-          display: none;
-          width: 0;
-        }
-      }
-
-      &.circle {
-        right: auto !important;
-        left: 0% !important;
-        bottom: 7% !important;
-        width: 45%;
-      }
-
-      &.triangle {
-        right: -5px !important;
-        top: 5px !important;
-        width: 40%;
-      }
-    }
-  }
 }
 
 @media (--xSmall-viewport) {
-  .login,
-  .signUp {
+  .login {
     & h2 {
       margin-top: 8vh; /* stylelint-disable-line */
     }
   }
 }
-
-.input {
-  padding-bottom: 0px;
-}
-

--- a/src/components/login/login.js
+++ b/src/components/login/login.js
@@ -1,10 +1,8 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import grid from 'flexboxgrid/dist/flexboxgrid.css';
 import Dropdown from 'react-toolbox/lib/dropdown';
 import i18next from 'i18next';
 import { FontIcon } from '../fontIcon';
-import Parallax from '../parallax';
 import Input from '../toolbox/inputs/input';
 import { PrimaryButton } from '../toolbox/buttons/button';
 import { extractAddress } from '../../utils/api/account';
@@ -17,7 +15,7 @@ import getNetwork from '../../utils/getNetwork';
 import { parseSearchParams } from './../../utils/searchParams';
 import Box from '../box';
 // eslint-disable-next-line import/no-unresolved
-import * as shapes from '../../assets/images/*.svg';
+import SignUp from './signUp';
 import { validateUrl } from '../../utils/login';
 
 /**
@@ -197,42 +195,7 @@ class Login extends React.Component {
             </div>
           </section>
         </section>
-        <section className={`${styles.signUp} ${styles[this.state.passInputState]}`}>
-          <section className={styles.table}>
-            <div className='text-left'>
-              <h2>
-                <Link className='new-account-button' to={routes.register.path}>
-                  {this.props.t('Create Lisk ID')}
-                </Link>
-                <FontIcon className={styles.singUpArrow} value='arrow-right' />
-              </h2>
-
-              <div className={styles.subTitle}>
-                {this.props.t('Create a Lisk ID to gain access to all services.')}
-              </div>
-            </div>
-          </section>
-          <div className={styles.bg}></div>
-          <div className={styles.shapes}>
-            <Parallax bgWidth='200px' bgHeight='10px'>
-              <figure className={`${styles.shape} ${styles.circle}`} data-depth='0.5'>
-                <img src={shapes.circle} alt='circle'/>
-              </figure>
-              <figure className={`${styles.shape} ${styles.triangle}`} data-depth='0.6'>
-                <img src={shapes.triangle} alt='triangle'/>
-              </figure>
-              <figure className={`${styles.shape} ${styles.rectA}`} data-depth='0.2'>
-                <img src={shapes.rect} alt='rect A'/>
-              </figure>
-              <figure className={`${styles.shape} ${styles.rectB}`} data-depth='0.8'>
-                <img src={shapes.rect} alt='rect B'/>
-              </figure>
-              <figure className={`${styles.shape} ${styles.rectC}`} data-depth='1.5'>
-                <img src={shapes.rect} alt='rect C' />
-              </figure>
-            </Parallax>
-          </div>
-        </section>
+        <SignUp t={this.props.t} passInputState={this.state.passInputState} />
       </Box>
     );
   }

--- a/src/components/login/shapes.css
+++ b/src/components/login/shapes.css
@@ -1,0 +1,132 @@
+:root {
+  --rect-width: 200px;
+  --gradient: linear-gradient(45deg, rgba(0, 74, 255, 1) 0%, rgba(147, 244, 254, 1) 100%);
+}
+
+.bg,
+.shapes,
+.shapes > div {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  left: 0;
+  top: 0;
+}
+
+.bg {
+  z-index: 0;
+  opacity: 0.94;
+  background: var(--gradient);
+  border-radius: 3px;
+}
+
+.shapes {
+  z-index: 1;
+}
+
+.shape {
+  position: absolute !important;
+
+  &.rectA {
+    right: 20% !important;
+    top: 20% !important;
+    left: auto !important;
+    width: var(--rect-width);
+
+    & img {
+      width: 100%;
+      animation: wave 20s 0.1s infinite linear; /* stylelint-disable-line */
+    }
+  }
+
+  &.rectB {
+    left: 10% !important;
+    bottom: 25% !important;
+    top: auto !important;
+    width: var(--rect-width);
+
+    & img {
+      width: 100%;
+      animation: wave 16s 0.1s infinite linear; /* stylelint-disable-line */
+    }
+  }
+
+  &.rectC {
+    right: 20% !important;
+    bottom: 20% !important;
+    top: auto !important;
+    left: auto !important;
+    z-index: 2;
+    width: var(--rect-width);
+
+    & img {
+      width: 100%;
+      animation: wave 12s 0.1s infinite linear; /* stylelint-disable-line */
+    }
+  }
+
+  &.circle {
+    right: 5% !important;
+    bottom: 0% !important;
+    left: auto !important;
+    top: auto !important;
+    width: 150px;
+
+    & img {
+      width: 100%;
+      animation: wander 16s 0.1s infinite alternate cubic-bezier(0.455, 0.03, 0.515, 0.955); /* stylelint-disable-line */
+    }
+  }
+
+  &.triangle {
+    right: 10% !important;
+    left: auto !important;
+    top: 10% !important;
+    width: 250px;
+
+    & img {
+      width: 100%;
+      animation: somersault 20s 0.1s infinite alternate cubic-bezier(0.455, 0.03, 0.515, 0.955); /* stylelint-disable-line */
+    }
+  }
+}
+
+@media (--small-viewport) {
+  .shape {
+    position: absolute !important;
+
+    &.rectA {
+      right: 0% !important;
+      top: 5% !important;
+      left: auto !important;
+      width: 30%;
+    }
+
+    &.rectB {
+      right: -4% !important;
+      top: 10% !important;
+      left: auto !important;
+      width: 30%;
+    }
+
+    &.rectC {
+      & img {
+        display: none;
+        width: 0;
+      }
+    }
+
+    &.circle {
+      right: auto !important;
+      left: 0% !important;
+      bottom: 7% !important;
+      width: 45%;
+    }
+
+    &.triangle {
+      right: -5px !important;
+      top: 5px !important;
+      width: 40%;
+    }
+  }
+}

--- a/src/components/login/signUp.css
+++ b/src/components/login/signUp.css
@@ -1,0 +1,181 @@
+@import './../app/variables.css';
+@import './animations.css';
+@import './shapes.css';
+@import './layout.css';
+
+:root {
+  --transition: all ease 300ms;
+  --header-focused-font-size: 32px;
+  --arrow-font-size: 60px;
+  --arrow-focused-font-size: 40px;
+  --signup-box-padding-L: var(--box-padding-left-L);
+  --signup-box-padding-XL: var(--box-padding-left-XL);
+  --focused-signup-box-padding-XL: 31px;
+  --focused-signup-box-padding-L: 24px;
+}
+
+.signUp {
+  height: calc(100% + 46px);
+  width: 58%;
+  margin-top: -23px;
+  border-radius: 3px;
+  overflow: hidden;
+  @mixin login-signup;
+
+  & .table {
+    position: relative;
+    z-index: 2;
+  }
+
+  & h2 {
+    color: var(--color-white);
+    margin-top: 32vh; /* stylelint-disable-line */
+    margin-bottom: 24px;
+    white-space: nowrap;
+  }
+
+  & .subTitle,
+  & a,
+  & .singUpArrow {
+    color: var(--color-white);
+    vertical-align: middle;
+    transition: var(--transition);
+  }
+
+  & .singUpArrow {
+    font-size: var(--arrow-font-size);
+  }
+
+  & .subTitle {
+    line-height: 28px;
+  }
+
+  & a {
+    text-decoration: none;
+    font-size: inherit;
+  }
+
+  /** @todo redundant? **/
+  & .shapes {
+    position: absolute;
+    z-index: 1;
+  }
+
+  &.focused {
+    transform: translateZ(0);
+
+    & h2 {
+      & a {
+        font-size: var(--header-focused-font-size);
+      }
+
+      & .singUpArrow {
+        font-size: var(--arrow-focused-font-size);
+      }
+    }
+
+    & .subTitle {
+      font-size: var(--subtitle-font-size);
+    }
+
+    & .shape {
+      &.triangle {
+        right: -25% !important;
+      }
+    }
+  }
+}
+
+@media (--xLarge-viewport) {
+  .signUp {
+    padding: 0 var(--signup-box-padding-XL);
+
+    & .subTitle {
+      font-size: 18px;
+    }
+
+    &.focused {
+      width: 25%;
+      padding: 0 var(--focused-signup-box-padding-XL);
+    }
+
+    & h2 {
+      font-size: 65px;
+    }
+  }
+}
+
+@media (--large-viewport) {
+  .signUp {
+    padding: 0 var(--signup-box-padding-L);
+
+    & .subTitle {
+      font-size: 16px;
+    }
+
+    &.focused {
+      width: 32%;
+      padding: 0 var(--focused-signup-box-padding-L);
+    }
+
+    & h2 {
+      font-size: 50px;
+    }
+  }
+}
+
+@media (--medium-viewport) {
+  .signUp {
+    margin-top: 0;
+    margin-right: -33px;
+    border-radius: 0px;
+    width: 60%;
+    height: calc(100vh - var(--m-top-bar-height) - var(--m-menu-bar-height)); /* stylelint-disable-line */
+
+    & .singUpArrow {
+      font-size: var(--arrow-focused-font-size);
+    }
+
+    & h2 {
+      font-size: var(--font-size-h2-l);
+      margin-top: 28vh; /* stylelint-disable-line */
+    }
+
+    & .focused {
+      & h2 {
+        font-size: var(--font-size-h3-m);
+      }
+    }
+  }
+}
+
+@media (--small-viewport) {
+  .signUp {
+    margin-right: 0;
+    border-radius: 0;
+    width: 100vw; /* stylelint-disable-line */
+    height: calc(50vh - var(--s-menu-bar-height)); /* stylelint-disable-line */
+    padding: 0 var(--box-padding-left-M);
+
+    & h2 {
+      font-size: var(--font-size-h2-s);
+      margin-top: 12vh; /* stylelint-disable-line */
+    }
+
+    & .bg {
+      border-radius: 0;
+    }
+
+    &.focused {
+      width: 100vw; /* stylelint-disable-line */
+    }
+  }
+}
+
+@media (--xSmall-viewport) {
+  .signUp {
+    & h2 {
+      margin-top: 8vh; /* stylelint-disable-line */
+    }
+  }
+}

--- a/src/components/login/signUp.css
+++ b/src/components/login/signUp.css
@@ -20,6 +20,7 @@
   margin-top: -23px;
   border-radius: 3px;
   overflow: hidden;
+
   @mixin login-signup;
 
   & .table {

--- a/src/components/login/signUp.js
+++ b/src/components/login/signUp.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import Parallax from '../parallax';
+import { FontIcon } from '../fontIcon';
+// eslint-disable-next-line import/no-unresolved
+import * as shapes from '../../assets/images/*.svg';
+import styles from './signUp.css';
+import routes from '../../constants/routes';
+
+const SignUp = ({ t, passInputState }) =>
+  (<section className={`${styles.signUp} ${styles[passInputState]}`}>
+    <section className={styles.table}>
+      <div className='text-left'>
+        <h2>
+          <Link className='new-account-button' to={routes.register.path}>
+            {t('Create Lisk ID')}
+          </Link>
+          <FontIcon className={styles.singUpArrow} value='arrow-right' />
+        </h2>
+
+        <div className={styles.subTitle}>
+          {t('Create a Lisk ID to gain access to all services.')}
+        </div>
+      </div>
+    </section>
+    <div className={styles.bg}></div>
+    <div className={styles.shapes}>
+      <Parallax bgWidth='200px' bgHeight='10px'>
+        <figure className={`${styles.shape} ${styles.circle}`} data-depth='0.5'>
+          <img src={shapes.circle} alt='circle'/>
+        </figure>
+        <figure className={`${styles.shape} ${styles.triangle}`} data-depth='0.6'>
+          <img src={shapes.triangle} alt='triangle'/>
+        </figure>
+        <figure className={`${styles.shape} ${styles.rectA}`} data-depth='0.2'>
+          <img src={shapes.rect} alt='rect A'/>
+        </figure>
+        <figure className={`${styles.shape} ${styles.rectB}`} data-depth='0.8'>
+          <img src={shapes.rect} alt='rect B'/>
+        </figure>
+        <figure className={`${styles.shape} ${styles.rectC}`} data-depth='1.5'>
+          <img src={shapes.rect} alt='rect C' />
+        </figure>
+      </Parallax>
+    </div>
+  </section>);
+
+export default SignUp;


### PR DESCRIPTION
### What was the problem?
The component and hence the css rules in Login were large and hard to maintain. this ticket aims to split them into smaller/single purpose files.

### How did I fix it?
I divided the Login component into Login and SignUp, then used multiple css files, each targeting a specific set of rules and imported them in my component specific css files.

### Review checklist
- The PR is a subset of changes required for #513 
- All new code follows best practices