### PR TITLE
Automate Linux desktop build in Jenkins - Closes #609

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,7 +110,7 @@ node('lisk-hub') {
         '''
         archiveArtifacts artifacts: 'app/build/'
         archiveArtifacts artifacts: 'app/build-testnet/'
-        archiveArtifacts artifacts: 'dist/lisk-hub*'
+        archiveArtifacts allowEmptyArchive: true, artifacts: 'dist/lisk-hub*'
         githubNotify context: 'Jenkins test deployment', description: 'Commit was deployed to test', status: 'SUCCESS', targetUrl: "${HUDSON_URL}test/" + "${JOB_NAME}".tokenize('/')[0] + "/${BRANCH_NAME}"
       } catch (err) {
         echo "Error: ${err}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,9 +102,15 @@ node('lisk-hub') {
         npm run --silent build:testnet
         rsync -axl --delete --rsync-path="mkdir -p /var/www/test/${JOB_NAME%/*}/$BRANCH_NAME/ && rsync" $WORKSPACE/app/build/ jenkins@master-01:/var/www/test/${JOB_NAME%/*}/$BRANCH_NAME/
         npm run --silent bundlesize
+        if [ -z $CHANGE_BRANCH ]; then
+          USE_SYSTEM_XORRISO=true npm run dist
+        else
+          echo "Skipping desktop build for Linux because we're not on 'development' branch"
+        fi
         '''
         archiveArtifacts artifacts: 'app/build/'
         archiveArtifacts artifacts: 'app/build-testnet/'
+        archiveArtifacts artifacts: 'dist/lisk-hub*'
         githubNotify context: 'Jenkins test deployment', description: 'Commit was deployed to test', status: 'SUCCESS', targetUrl: "${HUDSON_URL}test/" + "${JOB_NAME}".tokenize('/')[0] + "/${BRANCH_NAME}"
       } catch (err) {
         echo "Error: ${err}"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "analyze-bundles": "webpack  --config ./config/webpack.config.analyze",
     "test-live": "npm test -- --auto-watch --no-single-run",
     "start": "electron ./app/",
-    "dist": "build --ia32 --x64 --armv7l --publish onTag",
+    "dist": "build --ia32 --x64 --publish onTag",
     "dist:win": "build --win --ia32 --x64 --publish onTag",
     "dist:mac": "build --mac",
     "dist:linux": "build --linux --ia32 --x64 --armv7l",
@@ -196,10 +196,7 @@
     ],
     "linux": {
       "target": [
-        "AppImage",
-        "deb",
-        "rpm",
-        "tar.gz"
+        "AppImage"
       ],
       "desktop": {
         "MimeType": "application/lisk;x-scheme-handler/lisk"


### PR DESCRIPTION
### What was the problem?
Linux build had to be built manually. (It's actually also the case for Win and Mac, but those will be handled some other time because they need to be signed which is more complicated)
### How did I fix it?
Added `npm run dist` to Jenkins build on branches. I also removed build targets that we don't use to speed the build up.
### How to test it?

See the result of the branch build
https://jenkins.lisk.io/job/lisk-hub/job/609-linux-build-in-jenkins/

### Review checklist
- The PR solves #609
