### PR TITLE
Add delegate name to account page - Closes #600

### DIFF
--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -54,6 +54,7 @@
   "Cut": "Cut",
   "Dashboard": "Dashboard",
   "Date": "Date",
+  "Delegate": "Delegate",
   "Delegate Registration": "Delegate Registration",
   "Delegate features": "Delegate features",
   "Delegate name": "Delegate name",

--- a/src/components/accountTransactions/index.js
+++ b/src/components/accountTransactions/index.js
@@ -37,7 +37,7 @@ class accountTransactions extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  delegateUsername: state.account.targetDelegate ? state.account.targetDelegate.username : null,
+  delegateUsername: state.account.delegate ? state.account.delegate.username : null,
   balance: state.transactions.account ? state.transactions.account.balance : null,
   notLoading: state.loading.length === 0,
 });

--- a/src/components/accountTransactions/index.js
+++ b/src/components/accountTransactions/index.js
@@ -37,7 +37,7 @@ class accountTransactions extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  delegateUsername: state.account.delegate ? state.account.delegate.username : null,
+  delegateUsername: state.account.targetDelegate ? state.account.targetDelegate.username : null,
   balance: state.transactions.account ? state.transactions.account.balance : null,
   notLoading: state.loading.length === 0,
 });

--- a/src/components/accountTransactions/index.js
+++ b/src/components/accountTransactions/index.js
@@ -21,6 +21,7 @@ class accountTransactions extends React.Component {
         <SendTo
           balance={this.props.balance}
           address={this.props.match.params.address}
+          delegateUsername={this.props.delegateUsername}
           t={this.props.t}
           notLoading={this.props.notLoading}
         />
@@ -36,6 +37,7 @@ class accountTransactions extends React.Component {
 }
 
 const mapStateToProps = state => ({
+  delegateUsername: state.account.delegate ? state.account.delegate.username : null,
   balance: state.transactions.account ? state.transactions.account.balance : null,
   notLoading: state.loading.length === 0,
 });

--- a/src/components/sendTo/index.js
+++ b/src/components/sendTo/index.js
@@ -48,6 +48,10 @@ class SendTo extends React.Component {
               </span>
             </h2>
             <CopyToClipboard value={this.props.address} className={`${styles.address}`} copyClassName={styles.copy} />
+            <div>
+              {this.props.t('Delegate')}
+              <span className={styles.delegateUsername}>{this.props.delegateUsername}</span>
+            </div>
           </div>
         </div>
         <div className={`

--- a/src/components/sendTo/index.js
+++ b/src/components/sendTo/index.js
@@ -48,10 +48,14 @@ class SendTo extends React.Component {
               </span>
             </h2>
             <CopyToClipboard value={this.props.address} className={`${styles.address}`} copyClassName={styles.copy} />
-            <div>
-              {this.props.t('Delegate')}
-              <span className={styles.delegateUsername}>{this.props.delegateUsername}</span>
-            </div>
+            {
+              this.props.delegateUsername ?
+                <div className={styles.delegateRow}>
+                  {this.props.t('Delegate')}
+                  <span className={`${styles.delegateUsername} delegate-name`}>{this.props.delegateUsername}</span>
+                </div>
+                : null
+            }
           </div>
         </div>
         <div className={`

--- a/src/components/sendTo/sendTo.css
+++ b/src/components/sendTo/sendTo.css
@@ -54,6 +54,11 @@
   }
 }
 
+.delegateUsername {
+  font-weight: bold;
+  margin-left: 10px;
+}
+
 @media (--xLarge-viewport) {
   .wrapper {
     & h2 {

--- a/src/components/sendTo/sendTo.css
+++ b/src/components/sendTo/sendTo.css
@@ -54,9 +54,14 @@
   }
 }
 
+.delegateRow {
+  line-height: 26px;
+  color: var(--color-grayscale-dark);
+}
+
 .delegateUsername {
-  font-weight: bold;
-  margin-left: 10px;
+  font-weight: 600;
+  margin-left: 8px;
 }
 
 @media (--xLarge-viewport) {

--- a/src/components/sendTo/sendTo.test.js
+++ b/src/components/sendTo/sendTo.test.js
@@ -25,4 +25,9 @@ describe('SendTo Component', () => {
     wrapper.setProps({ address: '9876L' });
     expect(wrapper.find('Link').prop('to')).to.equal(`${routes.wallet.path}?recipient=9876L`);
   });
+
+  it('renders delegate username', () => {
+    wrapper.setProps({ delegateUsername: 'peter' });
+    expect(wrapper.find('.delegate-name').first()).to.have.text('peter');
+  });
 });

--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -39,7 +39,17 @@ const updateAccountData = (store, action) => {
         updateTransactions(store, peers, account);
       }
     }
-    store.dispatch(accountUpdated(result));
+    let accountUpdatedWithDelegate = { ...result };
+
+    if ((action.data.isDelegate && !result.delegate) ||
+        (result.delegate.username !== action.data.delegate.username)) {
+      accountUpdatedWithDelegate = {
+        ...accountUpdatedWithDelegate,
+        delegate: { ...action.data.delegate },
+      };
+    }
+
+    store.dispatch(accountUpdated(accountUpdatedWithDelegate));
     store.dispatch(activePeerUpdate({ online: true }));
   }).catch((res) => {
     store.dispatch(activePeerUpdate({ online: false, code: res.error.code }));

--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -39,17 +39,7 @@ const updateAccountData = (store, action) => {
         updateTransactions(store, peers, account);
       }
     }
-    let accountUpdatedWithDelegate = { ...result };
-
-    if ((action.data.isDelegate && !result.delegate) ||
-        (result.delegate.username !== action.data.delegate.username)) {
-      accountUpdatedWithDelegate = {
-        ...accountUpdatedWithDelegate,
-        delegate: { ...action.data.delegate },
-      };
-    }
-
-    store.dispatch(accountUpdated(accountUpdatedWithDelegate));
+    store.dispatch(accountUpdated(result));
     store.dispatch(activePeerUpdate({ online: true }));
   }).catch((res) => {
     store.dispatch(activePeerUpdate({ online: false, code: res.error.code }));

--- a/src/store/middlewares/transactions.js
+++ b/src/store/middlewares/transactions.js
@@ -44,10 +44,11 @@ const getAccountSuccess = (store, accountData) => {
 };
 
 const initTransactions = (store, action) => {
-  const activePeer = store.getState().peers.data;
-  const address = action.data.address;
-  const lastActiveAddress = store.getState().savedAccounts.lastActive ?
-    extractAddress(store.getState().savedAccounts.lastActive.publicKey) :
+  const state = store.getState();
+  const activePeer = state.peers.data;
+  const { address } = action.data;
+  const lastActiveAddress = state.account ?
+    extractAddress(state.account.publicKey) :
     null;
   const isSameAccount = lastActiveAddress === address;
   loadingStarted('transactions-init');

--- a/src/store/middlewares/transactions.js
+++ b/src/store/middlewares/transactions.js
@@ -69,7 +69,7 @@ const initTransactions = (store, action) => {
               .then((delegateData) => {
                 accountDataResult = {
                   ...accountDataResult,
-                  targetDelegate: { ...delegateData.delegate },
+                  delegate: { ...delegateData.delegate },
                 };
                 getAccountSuccess(store, accountDataResult);
               }).catch(() => {
@@ -79,7 +79,7 @@ const initTransactions = (store, action) => {
           } else if (isSameAccount && accountData.isDelegate) {
             accountDataResult = {
               ...accountDataResult,
-              targetDelegate: { ...accountData.delegate },
+              delegate: { ...accountData.delegate },
             };
           }
           getAccountSuccess(store, accountDataResult);

--- a/src/store/middlewares/transactions.js
+++ b/src/store/middlewares/transactions.js
@@ -38,14 +38,15 @@ const filterTransactions = (store, action) => {
     });
 };
 
+const getAccountSuccess = (store, accountData) => {
+  store.dispatch(transactionsInit(accountData));
+  loadingFinished('transactions-init');
+};
+
 const initTransactions = (store, action) => {
   const activePeer = store.getState().peers.data;
   const address = action.data.address;
   loadingStarted('transactions-init');
-  const getAccountSuccess = (accountData) => {
-    store.dispatch(transactionsInit(accountData));
-    loadingFinished('transactions-init');
-  };
 
   getTransactions({ activePeer, address, limit: 25 })
     .then((txResponse) => {
@@ -65,12 +66,12 @@ const initTransactions = (store, action) => {
                   ...accountDataResult,
                   delegate: { ...delegateData.delegate },
                 };
-                getAccountSuccess(accountDataResult);
+                getAccountSuccess(store, accountDataResult);
               }).catch(() => {
-                getAccountSuccess(accountDataResult);
+                getAccountSuccess(store, accountDataResult);
               });
           } else {
-            getAccountSuccess(accountDataResult);
+            getAccountSuccess(store, accountDataResult);
           }
         });
     });

--- a/src/store/middlewares/transactions.test.js
+++ b/src/store/middlewares/transactions.test.js
@@ -31,11 +31,6 @@ describe('transaction middleware', () => {
       transactions: {
         pending: [],
       },
-      savedAccounts: {
-        lastActive: {
-          address: '8096217735672704724L',
-        },
-      },
     };
     store.getState = () => (state);
     store.dispatch = spy();

--- a/src/store/middlewares/transactions.test.js
+++ b/src/store/middlewares/transactions.test.js
@@ -131,7 +131,9 @@ describe('transaction middleware', () => {
 
     store.getState = () => ({
       ...state,
-      account: { address: delegateCandidateData.address },
+      account: {
+        publicKey: delegateCandidateData.publicKey,
+      },
     });
 
     const givenAction = {

--- a/src/store/middlewares/transactions.test.js
+++ b/src/store/middlewares/transactions.test.js
@@ -109,7 +109,7 @@ describe('transaction middleware', () => {
       count: 1,
       balance: genesisAccountData.balance,
       address: delegateCandidateData.address,
-      targetDelegate: {
+      delegate: {
         ...delegateCandidateData,
       },
     };
@@ -149,7 +149,7 @@ describe('transaction middleware', () => {
       count: 1,
       balance: delegateCandidateData.balance,
       address: delegateCandidateData.address,
-      targetDelegate: {
+      delegate: {
         ...delegateCandidateData,
       },
     };

--- a/src/store/reducers/account.js
+++ b/src/store/reducers/account.js
@@ -58,7 +58,7 @@ const account = (state = {}, action) => {
     case actionTypes.accountUpdated:
       return merge(state, action.data);
     case actionTypes.transactionsInit:
-      return { ...state, targetDelegate: action.data.targetDelegate };
+      return { ...state, delegate: action.data.delegate };
     case actionTypes.accountLoggedIn:
       return action.data;
     case actionTypes.accountLoggedOut:

--- a/src/store/reducers/account.js
+++ b/src/store/reducers/account.js
@@ -57,6 +57,8 @@ const account = (state = {}, action) => {
       return Object.assign({}, state, { passphrase: null, expireTime: 0 });
     case actionTypes.accountUpdated:
       return merge(state, action.data);
+    case actionTypes.transactionsInit:
+      return merge(state, action.data);
     case actionTypes.accountLoggedIn:
       return action.data;
     case actionTypes.accountLoggedOut:

--- a/src/store/reducers/account.js
+++ b/src/store/reducers/account.js
@@ -58,7 +58,7 @@ const account = (state = {}, action) => {
     case actionTypes.accountUpdated:
       return merge(state, action.data);
     case actionTypes.transactionsInit:
-      return merge(state, action.data);
+      return { ...state, targetDelegate: action.data.targetDelegate };
     case actionTypes.accountLoggedIn:
       return action.data;
     case actionTypes.accountLoggedOut:

--- a/src/store/reducers/transactions.js
+++ b/src/store/reducers/transactions.js
@@ -55,7 +55,11 @@ const transactions = (state = { pending: [], confirmed: [], count: null }, actio
       return Object.assign({}, state, {
         confirmed: action.data.confirmed,
         count: action.data.count,
-        account: { address: action.data.address, balance: action.data.balance },
+        account: {
+          address: action.data.address,
+          balance: action.data.balance,
+          delegate: action.data.delegate,
+        },
         filter: txFilter.all,
       });
     case (actionTypes.accountSwitched):

--- a/src/store/reducers/transactions.js
+++ b/src/store/reducers/transactions.js
@@ -58,7 +58,7 @@ const transactions = (state = { pending: [], confirmed: [], count: null }, actio
         account: {
           address: action.data.address,
           balance: action.data.balance,
-          delegate: action.data.delegate,
+          targetDelegate: action.data.targetDelegate,
         },
         filter: txFilter.all,
       });

--- a/src/store/reducers/transactions.js
+++ b/src/store/reducers/transactions.js
@@ -58,7 +58,7 @@ const transactions = (state = { pending: [], confirmed: [], count: null }, actio
         account: {
           address: action.data.address,
           balance: action.data.balance,
-          targetDelegate: action.data.targetDelegate,
+          delegate: action.data.delegate,
         },
         filter: txFilter.all,
       });

--- a/test/integration/accountTransactions.test.js
+++ b/test/integration/accountTransactions.test.js
@@ -12,11 +12,9 @@ import accountReducer from '../../src/store/reducers/account';
 import transactionReducer from '../../src/store/reducers/transactions';
 import peersReducer from '../../src/store/reducers/peers';
 import loadingReducer from '../../src/store/reducers/loading';
-import savedAccountsReducer from '../../src/store/reducers/savedAccounts';
 import loginMiddleware from '../../src/store/middlewares/login';
 import accountMiddleware from '../../src/store/middlewares/account';
 import transactionsMiddleware from '../../src/store/middlewares/transactions';
-import savedAccountsMiddleware from '../../src/store/middlewares/savedAccounts';
 import { activePeerSet } from '../../src/actions/peers';
 import networks from './../../src/constants/networks';
 import txTypes from './../../src/constants/transactionTypes';
@@ -90,13 +88,11 @@ describe('@integration: Account Transactions', () => {
       transactions: transactionReducer,
       peers: peersReducer,
       loading: loadingReducer,
-      savedAccounts: savedAccountsReducer,
     }, [
       thunk,
       accountMiddleware,
       loginMiddleware,
       transactionsMiddleware,
-      savedAccountsMiddleware,
     ]);
 
     const account = {

--- a/test/integration/accountTransactions.test.js
+++ b/test/integration/accountTransactions.test.js
@@ -12,9 +12,11 @@ import accountReducer from '../../src/store/reducers/account';
 import transactionReducer from '../../src/store/reducers/transactions';
 import peersReducer from '../../src/store/reducers/peers';
 import loadingReducer from '../../src/store/reducers/loading';
+import savedAccountsReducer from '../../src/store/reducers/savedAccounts';
 import loginMiddleware from '../../src/store/middlewares/login';
 import accountMiddleware from '../../src/store/middlewares/account';
 import transactionsMiddleware from '../../src/store/middlewares/transactions';
+import savedAccountsMiddleware from '../../src/store/middlewares/savedAccounts';
 import { activePeerSet } from '../../src/actions/peers';
 import networks from './../../src/constants/networks';
 import txTypes from './../../src/constants/transactionTypes';
@@ -88,11 +90,13 @@ describe('@integration: Account Transactions', () => {
       transactions: transactionReducer,
       peers: peersReducer,
       loading: loadingReducer,
+      savedAccounts: savedAccountsReducer,
     }, [
       thunk,
       accountMiddleware,
       loginMiddleware,
       transactionsMiddleware,
+      savedAccountsMiddleware,
     ]);
 
     const account = {

--- a/test/integration/accountTransactions.test.js
+++ b/test/integration/accountTransactions.test.js
@@ -6,6 +6,7 @@ import { stub, match } from 'sinon';
 
 import * as peers from '../../src/utils/api/peers';
 import * as accountAPI from '../../src/utils/api/account';
+import * as delegateAPI from '../../src/utils/api/delegate';
 import { prepareStore, renderWithRouter } from '../utils/applicationInit';
 import accountReducer from '../../src/store/reducers/account';
 import transactionReducer from '../../src/store/reducers/transactions';
@@ -42,12 +43,17 @@ describe('@integration: Account Transactions', () => {
   let wrapper;
   let requestToActivePeerStub;
   let accountAPIStub;
+  let delegateAPIStub;
 
   beforeEach(() => {
     requestToActivePeerStub = stub(peers, 'requestToActivePeer');
     accountAPIStub = stub(accountAPI, 'getAccount');
+    delegateAPIStub = stub(delegateAPI, 'getDelegate');
 
     const transactionExample = { senderId: '456L', receiverId: '456L', type: txTypes.send };
+
+    delegateAPIStub.withArgs(match.any).returnsPromise()
+      .resolves({ delegate: { ...accounts['delegate candidate'] } });
 
     // specific address
     let transactions = new Array(20);
@@ -72,6 +78,7 @@ describe('@integration: Account Transactions', () => {
   afterEach(() => {
     requestToActivePeerStub.restore();
     accountAPIStub.restore();
+    delegateAPIStub.restore();
     wrapper.update();
   });
 

--- a/test/integration/wallet.test.js
+++ b/test/integration/wallet.test.js
@@ -6,6 +6,7 @@ import { stub, match } from 'sinon';
 
 import * as peers from '../../src/utils/api/peers';
 import * as accountAPI from '../../src/utils/api/account';
+import * as delegateAPI from '../../src/utils/api/delegate';
 import { prepareStore, renderWithRouter } from '../utils/applicationInit';
 import accountReducer from '../../src/store/reducers/account';
 import transactionReducer from '../../src/store/reducers/transactions';
@@ -42,6 +43,7 @@ describe('@integration: Wallet', () => {
   let wrapper;
   let requestToActivePeerStub;
   let accountAPIStub;
+  let delegateAPIStub;
   let localStorageStub;
   let helper;
 
@@ -58,6 +60,7 @@ describe('@integration: Wallet', () => {
   beforeEach(() => {
     requestToActivePeerStub = stub(peers, 'requestToActivePeer');
     accountAPIStub = stub(accountAPI, 'getAccount');
+    delegateAPIStub = stub(delegateAPI, 'getDelegate');
 
     localStorageStub = stub(localStorage, 'getItem');
     localStorageStub.withArgs('accounts').returns(JSON.stringify([{}, {}]));
@@ -86,6 +89,7 @@ describe('@integration: Wallet', () => {
   afterEach(() => {
     requestToActivePeerStub.restore();
     accountAPIStub.restore();
+    delegateAPIStub.restore();
     localStorageStub.restore();
   });
 
@@ -124,6 +128,8 @@ describe('@integration: Wallet', () => {
         ...account,
       });
     store.dispatch(accountLoggedIn(account));
+    delegateAPIStub.withArgs(match.any).returnsPromise()
+      .resolves({ delegate: { ...accounts['delegate candidate'] } });
     wrapper = mount(renderWithRouter(Wallet, store, { history: { location: { search: '' } } }));
     helper = new Helper(wrapper, store);
   };

--- a/test/integration/wallet.test.js
+++ b/test/integration/wallet.test.js
@@ -12,12 +12,10 @@ import accountReducer from '../../src/store/reducers/account';
 import transactionReducer from '../../src/store/reducers/transactions';
 import peersReducer from '../../src/store/reducers/peers';
 import loadingReducer from '../../src/store/reducers/loading';
-import savedAccountsReducer from '../../src/store/reducers/savedAccounts';
 import loginMiddleware from '../../src/store/middlewares/login';
 import accountMiddleware from '../../src/store/middlewares/account';
 import peerMiddleware from '../../src/store/middlewares/peers';
 import transactionsMiddleware from '../../src/store/middlewares/transactions';
-import savedAccountsMiddleware from '../../src/store/middlewares/savedAccounts';
 import { accountLoggedIn } from '../../src/actions/account';
 import { accountsRetrieved } from '../../src/actions/savedAccounts';
 import { activePeerSet } from '../../src/actions/peers';
@@ -101,14 +99,12 @@ describe('@integration: Wallet', () => {
       transactions: transactionReducer,
       peers: peersReducer,
       loading: loadingReducer,
-      savedAccounts: savedAccountsReducer,
     }, [
       thunk,
       accountMiddleware,
       loginMiddleware,
       transactionsMiddleware,
       peerMiddleware,
-      savedAccountsMiddleware,
     ]);
 
     const passphrase = options.isLocked ? undefined : accounts[accountType].passphrase;


### PR DESCRIPTION
### What was the problem?
- Delegate name not displayed in account explorer
### How did I fix it?
- change transactionInit middleware, and request the delegate of the account as long as the account has a public key. 
- new state.account.delegate object contains the delegate info of the delegate account
### How to test it?
* `/#/explorer/accounts/544792633152563672L` should display name *test* on testnet
* `/#/explorer/accounts/16313739661670634666L` should not display any delegate name on testnet

### Review checklist
- The PR solves #600
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
