### PR TITLE
Split transactions.css into smaller files - subTask #513

### DIFF
--- a/src/components/transactions/states.css
+++ b/src/components/transactions/states.css
@@ -1,0 +1,17 @@
+.leftText {
+  text-align: left;
+  padding-left: 0px;
+}
+
+.rightText {
+  text-align: right;
+}
+
+.ordinaryText {
+  text-decoration: none;
+  color: inherit;
+}
+
+.clickable {
+  cursor: pointer;
+}

--- a/src/components/transactions/transactionDetailView.css
+++ b/src/components/transactions/transactionDetailView.css
@@ -1,0 +1,218 @@
+@import '../app/variables.css';
+
+:root {
+  --grid-header-color: var(--color-black);
+  --amount-positive-color: var(--color-success-dark);
+  --amount-negative-color: var(--color-grayscale-dark);
+  --blue: var(--color-primary-medium);
+  --link-color: var(--color-primary-very-light);
+  --row-background-color: var(--color-white);
+  --filter-list-color: var(--color-grayscale-medium);
+  --result-address-font-weight: var(--font-weight-semi-bold);
+  --detail-label-font-weight: var(--font-weight-very-bold);
+  --header-address-font-weight: var(--font-weight-semi-bold);
+  --header-balance-unit-font-size-XL: 20px;
+  --header-balance-unit-font-size-L: 18px;
+  --header-subtitle-font-size-XL: 18px;
+  --header-subtitle-font-size-L: 16px;
+  --list-line-height: 25px;
+  --grid-header-line-height: 60px;
+  --main-row-line-height: 70px;
+  --sub-row-height: 50px;
+  --header-line-height: 36px;
+  --main-header-unit-font-size: 20px;
+  --grid-header-font-size: 15px;
+  --details-font-color: var(--color-grayscale-dark);
+  --details-label-font-size-XL: 15px;
+  --details-label-font-size-L: 12px;
+  --details-label-font-size-XS: 12px;
+  --back-button-font-size-XL: 15px;
+  --back-button-font-size-L: 12px;
+  --back-button-font-size-XS: 12px;
+  --back-button-arrow-font-size-XL: 16px;
+  --back-button-arrow-font-size-L: 16px;
+  --back-button-arrow-font-size-XS: 16px;
+}
+
+.accountVisual {
+  position: absolute;
+  left: 0px;
+  top: 3px;
+  margin: 0;
+}
+
+.addressLink {
+  color: var(--color-link);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.details {
+  line-height: var(--list-line-height);
+  color: var(--details-font-color);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  & footer {
+    padding-bottom: 92px;
+  }
+
+  & .copy {
+    color: var(--color-primary-standard) !important;
+  }
+
+  & .row {
+    padding-bottom: 48px;
+
+    &:last-child {
+      padding-bottom: 0px;
+    }
+  }
+
+  & .column {
+    position: relative;
+    padding-left: 50px;
+  }
+
+  & .label {
+    font-weight: var(--font-weight-very-bold);
+  }
+
+  & .sender {
+    font-weight: var(--font-weight-semi-bold);
+  }
+
+  & header {
+    padding-left: 0px;
+
+    & h3 {
+      font-family: var(--content-font);
+
+      & small {
+        font-weight: var(--detail-label-font-weight);
+        margin-left: -6px;
+        cursor: pointer;
+      }
+
+      & .backButton {
+        & .arrow {
+          vertical-align: middle;
+        }
+
+        & .text {
+          vertical-align: middle;
+        }
+      }
+    }
+  }
+}
+
+@media (--xLarge-viewport) {
+  .details {
+    & .label {
+      font-size: var(--details-label-font-size-L);
+    }
+
+    & .value {
+      & a,
+      & span {
+        font-size: 15px;
+        font-weight: 500;
+
+        & span {
+          color: inherit;
+        }
+      }
+
+      & span {
+        color: var(--details-font-color);
+      }
+
+      & .copy {
+        font-size: 24px;
+        vertical-align: top;
+      }
+
+      &.sender a {
+        font-weight: 600;
+      }
+    }
+
+    & header {
+      & small {
+        font-size: var(--back-button-font-size-XL);
+      }
+
+      & .backButton {
+        & .arrow {
+          font-size: var(--back-button-arrow-font-size-XL);
+        }
+      }
+    }
+  }
+}
+
+@media (--large-viewport) {
+  .details {
+    & .label {
+      font-size: var(--details-label-font-size-L);
+    }
+
+    & header {
+      & small {
+        font-size: var(--back-button-font-size-L);
+      }
+
+      & .backButton {
+        & .arrow {
+          font-size: var(--back-button-arrow-font-size-L);
+        }
+      }
+    }
+  }
+}
+
+@media (--small-viewport) {
+  .details {
+    & .row {
+      margin-right: 0;
+      margin-left: 0;
+      padding-bottom: 0;
+    }
+
+    & .column {
+      padding-bottom: 30px;
+    }
+  }
+}
+
+@media (--xSmall-viewport) {
+  .details {
+    & .row {
+      padding-bottom: 0px;
+    }
+
+    & .column {
+      padding-bottom: 20px;
+    }
+
+    & .label {
+      font-size: var(--details-label-font-size-XS);
+    }
+
+    & header {
+      margin-bottom: 20px;
+
+      & small {
+        font-size: var(--back-button-font-size-XS);
+      }
+
+      & .backButton {
+        & .arrow {
+          font-size: var(--back-button-arrow-font-size-XS);
+        }
+      }
+    }
+  }
+}

--- a/src/components/transactions/transactionDetailView.css
+++ b/src/components/transactions/transactionDetailView.css
@@ -1,27 +1,8 @@
 @import '../app/variables.css';
 
 :root {
-  --grid-header-color: var(--color-black);
-  --amount-positive-color: var(--color-success-dark);
-  --amount-negative-color: var(--color-grayscale-dark);
-  --blue: var(--color-primary-medium);
-  --link-color: var(--color-primary-very-light);
-  --row-background-color: var(--color-white);
-  --filter-list-color: var(--color-grayscale-medium);
-  --result-address-font-weight: var(--font-weight-semi-bold);
   --detail-label-font-weight: var(--font-weight-very-bold);
-  --header-address-font-weight: var(--font-weight-semi-bold);
-  --header-balance-unit-font-size-XL: 20px;
-  --header-balance-unit-font-size-L: 18px;
-  --header-subtitle-font-size-XL: 18px;
-  --header-subtitle-font-size-L: 16px;
   --list-line-height: 25px;
-  --grid-header-line-height: 60px;
-  --main-row-line-height: 70px;
-  --sub-row-height: 50px;
-  --header-line-height: 36px;
-  --main-header-unit-font-size: 20px;
-  --grid-header-font-size: 15px;
   --details-font-color: var(--color-grayscale-dark);
   --details-label-font-size-XL: 15px;
   --details-label-font-size-L: 12px;

--- a/src/components/transactions/transactionDetailView.js
+++ b/src/components/transactions/transactionDetailView.js
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import { TimeFromTimestamp, DateFromTimestamp } from './../timestamp/index';
 import CopyToClipboard from '../copyToClipboard';
 import AccountVisual from '../accountVisual';
-import styles from './transactions.css';
+import styles from './transactionDetailView.css';
 import { FontIcon } from '../fontIcon';
 import TransactionType from './transactionType';
 import LiskAmount from '../liskAmount';

--- a/src/components/transactions/transactionList.css
+++ b/src/components/transactions/transactionList.css
@@ -1,39 +1,5 @@
 @import '../app/variables.css';
 
-:root {
-  --grid-header-color: var(--color-black);
-  --amount-positive-color: var(--color-success-dark);
-  --amount-negative-color: var(--color-grayscale-dark);
-  --blue: var(--color-primary-medium);
-  --link-color: var(--color-primary-very-light);
-  --row-background-color: var(--color-white);
-  --filter-list-color: var(--color-grayscale-medium);
-  --result-address-font-weight: var(--font-weight-semi-bold);
-  --detail-label-font-weight: var(--font-weight-very-bold);
-  --header-address-font-weight: var(--font-weight-semi-bold);
-  --header-balance-unit-font-size-XL: 20px;
-  --header-balance-unit-font-size-L: 18px;
-  --header-subtitle-font-size-XL: 18px;
-  --header-subtitle-font-size-L: 16px;
-  --list-line-height: 25px;
-  --grid-header-line-height: 60px;
-  --main-row-line-height: 70px;
-  --sub-row-height: 50px;
-  --header-line-height: 36px;
-  --main-header-unit-font-size: 20px;
-  --grid-header-font-size: 15px;
-  --details-font-color: var(--color-grayscale-dark);
-  --details-label-font-size-XL: 15px;
-  --details-label-font-size-L: 12px;
-  --details-label-font-size-XS: 12px;
-  --back-button-font-size-XL: 15px;
-  --back-button-font-size-L: 12px;
-  --back-button-font-size-XS: 12px;
-  --back-button-arrow-font-size-XL: 16px;
-  --back-button-arrow-font-size-L: 16px;
-  --back-button-arrow-font-size-XS: 16px;
-}
-
 .empty {
   text-align: center;
   font-weight: var(--font-weight-semi-bold);

--- a/src/components/transactions/transactionList.css
+++ b/src/components/transactions/transactionList.css
@@ -1,0 +1,72 @@
+@import '../app/variables.css';
+
+:root {
+  --grid-header-color: var(--color-black);
+  --amount-positive-color: var(--color-success-dark);
+  --amount-negative-color: var(--color-grayscale-dark);
+  --blue: var(--color-primary-medium);
+  --link-color: var(--color-primary-very-light);
+  --row-background-color: var(--color-white);
+  --filter-list-color: var(--color-grayscale-medium);
+  --result-address-font-weight: var(--font-weight-semi-bold);
+  --detail-label-font-weight: var(--font-weight-very-bold);
+  --header-address-font-weight: var(--font-weight-semi-bold);
+  --header-balance-unit-font-size-XL: 20px;
+  --header-balance-unit-font-size-L: 18px;
+  --header-subtitle-font-size-XL: 18px;
+  --header-subtitle-font-size-L: 16px;
+  --list-line-height: 25px;
+  --grid-header-line-height: 60px;
+  --main-row-line-height: 70px;
+  --sub-row-height: 50px;
+  --header-line-height: 36px;
+  --main-header-unit-font-size: 20px;
+  --grid-header-font-size: 15px;
+  --details-font-color: var(--color-grayscale-dark);
+  --details-label-font-size-XL: 15px;
+  --details-label-font-size-L: 12px;
+  --details-label-font-size-XS: 12px;
+  --back-button-font-size-XL: 15px;
+  --back-button-font-size-L: 12px;
+  --back-button-font-size-XS: 12px;
+  --back-button-arrow-font-size-XL: 16px;
+  --back-button-arrow-font-size-L: 16px;
+  --back-button-arrow-font-size-XS: 16px;
+}
+
+.empty {
+  text-align: center;
+  font-weight: var(--font-weight-semi-bold);
+  padding-top: 25px;
+  color: var(--color-grayscale-dark);
+}
+
+.results {
+  overflow-y: initial;
+
+  & .turnArrow {
+    transform: rotate(180deg);
+  }
+}
+
+@media (--xLarge-viewport) {
+  .results {
+    overflow-y: auto;
+    margin: 0px calc(0 - var(--box-padding-left-XL));
+  }
+}
+
+@media (--large-viewport) {
+  .results {
+    overflow-y: auto;
+    margin: 0px calc(0 - var(--box-padding-left-L));
+  }
+}
+
+@media (--medium-viewport) {
+  .results {
+    overflow-y: initial;
+    padding-bottom: 100px;
+    margin: 0px calc(0 - var(--box-padding-left-M));
+  }
+}

--- a/src/components/transactions/transactionList.js
+++ b/src/components/transactions/transactionList.js
@@ -7,7 +7,7 @@ import TransactionsHeader from './transactionsHeader';
 import { transactionsRequestInit } from '../../actions/transactions';
 import txFilters from './../../constants/transactionFilters';
 import txTypes from './../../constants/transactionTypes';
-import styles from './transactions.css';
+import styles from './transactionList.css';
 import { parseSearchParams } from './../../utils/searchParams';
 
 class TransactionsList extends React.Component {

--- a/src/components/transactions/transactionRow.css
+++ b/src/components/transactions/transactionRow.css
@@ -1,0 +1,121 @@
+@import '../app/variables.css';
+@import './states.css';
+
+:root {
+  --grid-header-color: var(--color-black);
+  --amount-positive-color: var(--color-success-dark);
+  --amount-negative-color: var(--color-grayscale-dark);
+  --blue: var(--color-primary-medium);
+  --link-color: var(--color-primary-very-light);
+  --row-background-color: var(--color-white);
+  --filter-list-color: var(--color-grayscale-medium);
+  --result-address-font-weight: var(--font-weight-semi-bold);
+  --detail-label-font-weight: var(--font-weight-very-bold);
+  --header-address-font-weight: var(--font-weight-semi-bold);
+  --header-balance-unit-font-size-XL: 20px;
+  --header-balance-unit-font-size-L: 18px;
+  --header-subtitle-font-size-XL: 18px;
+  --header-subtitle-font-size-L: 16px;
+  --list-line-height: 25px;
+  --grid-header-line-height: 60px;
+  --main-row-line-height: 70px;
+  --sub-row-height: 50px;
+  --header-line-height: 36px;
+  --main-header-unit-font-size: 20px;
+  --grid-header-font-size: 15px;
+  --details-font-color: var(--color-grayscale-dark);
+  --details-label-font-size-XL: 15px;
+  --details-label-font-size-L: 12px;
+  --details-label-font-size-XS: 12px;
+  --back-button-font-size-XL: 15px;
+  --back-button-font-size-L: 12px;
+  --back-button-font-size-XS: 12px;
+  --back-button-arrow-font-size-XL: 16px;
+  --back-button-arrow-font-size-L: 16px;
+  --back-button-arrow-font-size-XS: 16px;
+}
+
+.header {
+  color: var(--grid-header-color);
+  line-height: var(--grid-header-line-height);
+  font-weight: var(--font-weight-very-bold);
+}
+
+.rows {
+  color: var(--amount-negative-color);
+  border-bottom: 0;
+  border-top: 0;
+  margin-right: 0;
+  margin-left: 0;
+  line-height: var(--main-row-line-height);
+  white-space: nowrap;
+
+  &:nth-of-type(even) {
+    background: var(--gradient-greyscale);
+  }
+
+  &:nth-of-type(odd) {
+    background: var(--row-background-color);
+  }
+
+  &:hover:not(:first-child) {
+    background: var(--link-color);
+  }
+
+  & .copyIcon {
+    vertical-align: bottom;
+    padding-left: 5px;
+    cursor: pointer;
+  }
+
+  & .address {
+    font-weight: var(--result-address-font-weight);
+    text-overflow: ellipsis;
+    overflow: hidden;
+    width: 135%;
+  }
+}
+
+@media (--xLarge-viewport) {
+  .header {
+    font-size: 15px;
+  }
+
+  .rows {
+    padding: 0px var(--box-padding-left-XL);
+  }
+}
+
+@media (--large-viewport) {
+  .header {
+    font-size: 12px;
+  }
+
+  .rows {
+    padding: 0px var(--box-padding-left-L);
+  }
+}
+
+@media (--medium-viewport) {
+  .header {
+    font-size: 12px;
+  }
+
+  .rows {
+    padding: 0px var(--box-padding-left-M);
+
+    &:nth-of-type(even) {
+      background: var(--gradient-greyscale-mobile);
+    }
+
+    &:nth-of-type(odd) {
+      background: var(--color-grayscale-mobile-background);
+    }
+  }
+}
+
+@media (--small-viewport) {
+  .hiddenXs {
+    display: none;
+  }
+}

--- a/src/components/transactions/transactionRow.css
+++ b/src/components/transactions/transactionRow.css
@@ -3,36 +3,12 @@
 
 :root {
   --grid-header-color: var(--color-black);
-  --amount-positive-color: var(--color-success-dark);
   --amount-negative-color: var(--color-grayscale-dark);
-  --blue: var(--color-primary-medium);
   --link-color: var(--color-primary-very-light);
   --row-background-color: var(--color-white);
-  --filter-list-color: var(--color-grayscale-medium);
   --result-address-font-weight: var(--font-weight-semi-bold);
-  --detail-label-font-weight: var(--font-weight-very-bold);
-  --header-address-font-weight: var(--font-weight-semi-bold);
-  --header-balance-unit-font-size-XL: 20px;
-  --header-balance-unit-font-size-L: 18px;
-  --header-subtitle-font-size-XL: 18px;
-  --header-subtitle-font-size-L: 16px;
-  --list-line-height: 25px;
   --grid-header-line-height: 60px;
   --main-row-line-height: 70px;
-  --sub-row-height: 50px;
-  --header-line-height: 36px;
-  --main-header-unit-font-size: 20px;
-  --grid-header-font-size: 15px;
-  --details-font-color: var(--color-grayscale-dark);
-  --details-label-font-size-XL: 15px;
-  --details-label-font-size-L: 12px;
-  --details-label-font-size-XS: 12px;
-  --back-button-font-size-XL: 15px;
-  --back-button-font-size-L: 12px;
-  --back-button-font-size-XS: 12px;
-  --back-button-arrow-font-size-XL: 16px;
-  --back-button-arrow-font-size-L: 16px;
-  --back-button-arrow-font-size-XS: 16px;
 }
 
 .header {

--- a/src/components/transactions/transactionRow.js
+++ b/src/components/transactions/transactionRow.js
@@ -2,7 +2,7 @@ import React from 'react';
 import grid from 'flexboxgrid/dist/flexboxgrid.css';
 import { translate } from 'react-i18next';
 import TransactionType from './transactionType';
-import styles from './transactions.css';
+import styles from './transactionRow.css';
 import Amount from './amount';
 import Spinner from '../spinner';
 import { DateFromTimestamp } from './../timestamp/index';

--- a/src/components/transactions/transactions.css
+++ b/src/components/transactions/transactions.css
@@ -1,4 +1,5 @@
 @import '../app/variables.css';
+@import './states.css';
 
 :root {
   --grid-header-color: var(--color-black);
@@ -36,44 +37,6 @@
 
 .smallButton {
   display: inline-block;
-}
-
-.empty {
-  text-align: center;
-  font-weight: var(--font-weight-semi-bold);
-  padding-top: 25px;
-  color: var(--color-grayscale-dark);
-}
-
-.leftText {
-  text-align: left;
-  padding-left: 0px;
-}
-
-.rightText {
-  text-align: right;
-}
-
-.ordinaryText {
-  text-decoration: none;
-  color: inherit;
-}
-
-@media (--small-viewport) {
-  .hiddenXs {
-    display: none;
-  }
-}
-
-.clickable {
-  cursor: pointer;
-}
-
-.accountVisual {
-  position: absolute;
-  left: 0px;
-  top: 3px;
-  margin: 0;
 }
 
 .transactions {
@@ -156,122 +119,6 @@
   }
 }
 
-.details {
-  line-height: var(--list-line-height);
-  color: var(--details-font-color);
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-
-  & footer {
-    padding-bottom: 92px;
-  }
-
-  & .copy {
-    color: var(--color-primary-standard) !important;
-  }
-
-  & .row {
-    padding-bottom: 48px;
-
-    &:last-child {
-      padding-bottom: 0px;
-    }
-  }
-
-  & .column {
-    position: relative;
-    padding-left: 50px;
-  }
-
-  & .label {
-    font-weight: var(--font-weight-very-bold);
-  }
-
-  & .sender {
-    font-weight: var(--font-weight-semi-bold);
-  }
-
-  & header {
-    padding-left: 0px;
-
-    & h3 {
-      font-family: var(--content-font);
-
-      & small {
-        font-weight: var(--detail-label-font-weight);
-        margin-left: -6px;
-        cursor: pointer;
-      }
-
-      & .backButton {
-        & .arrow {
-          vertical-align: middle;
-        }
-
-        & .text {
-          vertical-align: middle;
-        }
-      }
-    }
-  }
-}
-
-.results {
-  overflow-y: initial;
-
-  & .header {
-    color: var(--grid-header-color);
-    line-height: var(--grid-header-line-height);
-    font-weight: var(--font-weight-very-bold);
-  }
-
-  & .rows:nth-of-type(even) {
-    background: var(--gradient-greyscale);
-  }
-
-  & .rows:nth-of-type(odd) {
-    background: var(--row-background-color);
-  }
-
-  & .rows {
-    color: var(--amount-negative-color);
-    border-bottom: 0;
-    border-top: 0;
-    margin-right: 0;
-    margin-left: 0;
-    line-height: var(--main-row-line-height);
-    white-space: nowrap;
-
-    &:hover:not(:first-child) {
-      background: var(--link-color);
-    }
-
-    & .copyIcon {
-      vertical-align: bottom;
-      padding-left: 5px;
-      cursor: pointer;
-    }
-  }
-
-  & .turnArrow {
-    transform: rotate(180deg);
-  }
-
-  & .address {
-    font-weight: var(--result-address-font-weight);
-    text-overflow: ellipsis;
-    overflow: hidden;
-    width: 135%;
-  }
-}
-
-.addressLink {
-  color: var(--color-link);
-  font-weight: 600;
-  text-decoration: none;
-}
-
 @media (--xLarge-viewport) {
   .transactions {
     & .activity {
@@ -286,62 +133,6 @@
           font-size: var(--header-subtitle-font-size-XL);
         }
       }
-    }
-  }
-
-  .details {
-    & .label {
-      font-size: var(--details-label-font-size-L);
-    }
-
-    & .value {
-      & a,
-      & span {
-        font-size: 15px;
-        font-weight: 500;
-
-        & span {
-          color: inherit;
-        }
-      }
-
-      & span {
-        color: var(--details-font-color);
-      }
-
-      & .copy {
-        font-size: 24px;
-        vertical-align: top;
-      }
-
-      &.sender a {
-        font-weight: 600;
-      }
-    }
-
-    & header {
-      & small {
-        font-size: var(--back-button-font-size-XL);
-      }
-
-      & .backButton {
-        & .arrow {
-          font-size: var(--back-button-arrow-font-size-XL);
-        }
-      }
-    }
-  }
-
-  .results {
-    overflow-y: auto;
-    margin: 0px calc(0 - var(--box-padding-left-XL));
-
-    & .header {
-      font-size: 15px;
-    }
-
-    & .rows {
-      padding: 0px var(--box-padding-left-XL);
     }
   }
 }
@@ -362,74 +153,11 @@
       }
     }
   }
-
-  .details {
-    & .label {
-      font-size: var(--details-label-font-size-L);
-    }
-
-    & header {
-      & small {
-        font-size: var(--back-button-font-size-L);
-      }
-
-      & .backButton {
-        & .arrow {
-          font-size: var(--back-button-arrow-font-size-L);
-        }
-      }
-    }
-  }
-
-  .results {
-    overflow-y: auto;
-    margin: 0px calc(0 - var(--box-padding-left-L));
-
-    & .header {
-      font-size: 12px;
-    }
-
-    & .rows {
-      padding: 0px var(--box-padding-left-L);
-    }
-  }
-}
-
-@media (--medium-viewport) {
-  .results {
-    overflow-y: initial;
-    padding-bottom: 100px;
-    margin: 0px calc(0 - var(--box-padding-left-M));
-
-    & .header {
-      font-size: 12px;
-    }
-
-    & .rows {
-      padding: 0px var(--box-padding-left-M);
-    }
-
-    & .rows:nth-of-type(even) {
-      background: var(--gradient-greyscale-mobile);
-    }
-
-    & .rows:nth-of-type(odd) {
-      background: var(--color-grayscale-mobile-background);
-    }
-  }
 }
 
 @media (--small-viewport) {
-  .details {
-    & .row {
-      margin-right: 0;
-      margin-left: 0;
-      padding-bottom: 0;
-    }
-
-    & .column {
-      padding-bottom: 30px;
-    }
+  .hiddenXs {
+    display: none;
   }
 }
 
@@ -448,34 +176,6 @@
     & .item {
       &:not(:last-of-type) {
         margin-right: 24px;
-      }
-    }
-  }
-
-  .details {
-    & .row {
-      padding-bottom: 0px;
-    }
-
-    & .column {
-      padding-bottom: 20px;
-    }
-
-    & .label {
-      font-size: var(--details-label-font-size-XS);
-    }
-
-    & header {
-      margin-bottom: 20px;
-
-      & small {
-        font-size: var(--back-button-font-size-XS);
-      }
-
-      & .backButton {
-        & .arrow {
-          font-size: var(--back-button-arrow-font-size-XS);
-        }
       }
     }
   }

--- a/src/components/transactions/transactions.css
+++ b/src/components/transactions/transactions.css
@@ -2,37 +2,15 @@
 @import './states.css';
 
 :root {
-  --grid-header-color: var(--color-black);
   --amount-positive-color: var(--color-success-dark);
   --amount-negative-color: var(--color-grayscale-dark);
-  --blue: var(--color-primary-medium);
-  --link-color: var(--color-primary-very-light);
-  --row-background-color: var(--color-white);
   --filter-list-color: var(--color-grayscale-medium);
-  --result-address-font-weight: var(--font-weight-semi-bold);
-  --detail-label-font-weight: var(--font-weight-very-bold);
-  --header-address-font-weight: var(--font-weight-semi-bold);
   --header-balance-unit-font-size-XL: 20px;
   --header-balance-unit-font-size-L: 18px;
   --header-subtitle-font-size-XL: 18px;
   --header-subtitle-font-size-L: 16px;
   --list-line-height: 25px;
-  --grid-header-line-height: 60px;
-  --main-row-line-height: 70px;
-  --sub-row-height: 50px;
   --header-line-height: 36px;
-  --main-header-unit-font-size: 20px;
-  --grid-header-font-size: 15px;
-  --details-font-color: var(--color-grayscale-dark);
-  --details-label-font-size-XL: 15px;
-  --details-label-font-size-L: 12px;
-  --details-label-font-size-XS: 12px;
-  --back-button-font-size-XL: 15px;
-  --back-button-font-size-L: 12px;
-  --back-button-font-size-XS: 12px;
-  --back-button-arrow-font-size-XL: 16px;
-  --back-button-arrow-font-size-L: 16px;
-  --back-button-arrow-font-size-XS: 16px;
 }
 
 .smallButton {

--- a/src/components/transactions/transactionsHeader.js
+++ b/src/components/transactions/transactionsHeader.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import grid from 'flexboxgrid/dist/flexboxgrid.css';
 import { translate } from 'react-i18next';
-import styles from './transactions.css';
+import styles from './transactionRow.css';
 
 const TransactionsHeader = ({ t }) => (
   <div className={`${grid.row}  ${styles.rows} ${styles.paddingLeft}`} id="transactionsHeader">


### PR DESCRIPTION
### What was the problem?
The component and hence the css rules in transactions were large and hard to maintain. this ticket aims to split them into smaller/single purpose files.

### How did I fix it?
I've created dedicated css files for each component and moved css styles into them.

**Note:**  There's a regression in styles of delegateList which will be fixed by #635

### Review checklist
- The PR is a subset of changes required for #513 
- All new code follows best practices