### PR TITLE
Fix random index calculation in resetForm() - Closes #651

### DIFF
--- a/src/components/passphrase/confirm/index.js
+++ b/src/components/passphrase/confirm/index.js
@@ -90,7 +90,6 @@ class Confirm extends React.Component {
 
   resetForm() {
     const words = this.props.passphrase.match(/\w+/g);
-    const indexByRand = num => Math.floor(num * (words.length - 1));
 
     /**
      * Returns a random index which doesn't exist in list
@@ -101,7 +100,7 @@ class Confirm extends React.Component {
     const randomIndex = (list) => {
       let index;
       do {
-        index = indexByRand(Math.random());
+        index = Math.floor(Math.random() * words.length);
       }
       while (list.includes(index));
       return index;


### PR DESCRIPTION
### What was the problem?

random index did not return random index. See #651.

### How did I fix it?

Apply correct formula, see #651

### How to test it?

Hmm, I din't know how to build this project. But I guess account creation should now include the last word in the password confirmation step.

### Review checklist
- The PR solves #651
- All new code is covered with unit tests?
- All new features are covered with e2e tests?
- All new code follows best practices?
