### PR TITLE
Remove noop in seed initialization - Subtask #663

### DIFF
--- a/src/utils/passphrase.js
+++ b/src/utils/passphrase.js
@@ -33,7 +33,6 @@ const leftPadd = (str, pad, length) => {
  */
 const init = (rand = Math.random()) => {
   let step = (160 + Math.floor(rand * 160)) / 100;
-  step = step >= 0.01 ? step : 0.1 + (step * 5);
   return {
     step,
     percentage: 0,

--- a/src/utils/passphrase.js
+++ b/src/utils/passphrase.js
@@ -32,7 +32,7 @@ const leftPadd = (str, pad, length) => {
  * Resets previous settings and creates a step with a random length between 1.6% to 3.2%
  */
 const init = (rand = Math.random()) => {
-  let step = (160 + Math.floor(rand * 160)) / 100;
+  const step = (160 + Math.floor(rand * 160)) / 100;
   return {
     step,
     percentage: 0,


### PR DESCRIPTION
### What was the problem?

There is a line that does nothing. As the comment above states, seed is between 1.6 and 3.2 (excluded). Thus `seed >= 0.1` is always true and seed is assigned to seed.

### How did I fix it?

Remove the line that does nothing

### How to test it?

Review or check the resulting step value.

### Review checklist
- ~The PR solves #663 
- All new code is covered with unit tests?
- All new features are covered with e2e tests?
- All new code follows best practices?
