### PR TITLE
Add recipient to send launch protocol - Closes #668

### DIFF
--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -164,9 +164,7 @@
   "Redo": "Redo",
   "Register": "Register",
   "Register 2nd passphrase": "Register 2nd passphrase",
-  "Register Second Passphrase": "Register Second Passphrase",
   "Register and oversee your decentralized application here. Available soon.": "Register and oversee your decentralized application here. Available soon.",
-  "Register as delegate": "Register as delegate",
   "Reload": "Reload",
   "Remove": "Remove",
   "Report Issue...": "Report Issue...",
@@ -256,10 +254,6 @@
   "You are looking into a saved account. In order to {{nextAction}} you need to enter your passphrase.": "You are looking into a saved account. In order to {{nextAction}} you need to enter your passphrase.",
   "You can also press ↲ enter to search": "You can also press ↲ enter to search",
   "You can always get it back.": "You can always get it back.",
-  "You can select up to {{count}} delegates in one voting turn.": "You can select up to {{count}} delegates in one voting turn.",
-  "You can select up to {{count}} delegates in one voting turn._plural": "",
-  "You can vote for up to {{count}} delegates in total.": "You can vote for up to {{count}} delegates in total.",
-  "You can vote for up to {{count}} delegates in total._plural": "",
   "You can now use Lisk Hub.<br": {
     " If you want to repeat the onboarding, navigate to \"More\" on the sidebar.": "You can now use Lisk Hub.<br> If you want to repeat the onboarding, navigate to \"More\" on the sidebar."
   },

--- a/src/components/send/index.js
+++ b/src/components/send/index.js
@@ -20,9 +20,9 @@ class Send extends React.Component {
       && props.account.balance > 0
       && props.pendingTransactions.length === 0;
 
-    const { amount, address, recipient } = this.getSearchParams();
+    const { amount, recipient } = this.getSearchParams();
     this.state = {
-      sendIsActive: !!address || !!recipient || !!amount || needsAccountInit,
+      sendIsActive: !!recipient || !!amount || needsAccountInit,
     };
   }
 
@@ -36,7 +36,7 @@ class Send extends React.Component {
 
   render() {
     const { t } = this.props;
-    const { amount, address, recipient } = this.getSearchParams();
+    const { amount, recipient } = this.getSearchParams();
 
     return (
       <Fragment>
@@ -56,7 +56,7 @@ class Send extends React.Component {
             <AccountInitialization />
             <SendWritable
               autoFocus={this.state.sendIsActive || window.innerWidth > breakpoints.m}
-              address={address || recipient}
+              address={recipient}
               amount={amount}
             />
             <PassphraseSteps />

--- a/src/components/send/index.js
+++ b/src/components/send/index.js
@@ -20,10 +20,9 @@ class Send extends React.Component {
       && props.account.balance > 0
       && props.pendingTransactions.length === 0;
 
+    const { amount, address, recipient } = this.getSearchParams();
     this.state = {
-      sendIsActive: !!this.getSearchParams().address
-      || !!this.getSearchParams().amount
-      || needsAccountInit,
+      sendIsActive: !!address || !!recipient || !!amount || needsAccountInit,
     };
   }
 
@@ -37,6 +36,8 @@ class Send extends React.Component {
 
   render() {
     const { t } = this.props;
+    const { amount, address, recipient } = this.getSearchParams();
+
     return (
       <Fragment>
         <span className={styles.mobileMenu}>
@@ -55,8 +56,8 @@ class Send extends React.Component {
             <AccountInitialization />
             <SendWritable
               autoFocus={this.state.sendIsActive || window.innerWidth > breakpoints.m}
-              address={this.getSearchParams().address}
-              amount={this.getSearchParams().amount}
+              address={address || recipient}
+              amount={amount}
             />
             <PassphraseSteps />
             <SendReadable />

--- a/src/components/sendTo/index.js
+++ b/src/components/sendTo/index.js
@@ -58,7 +58,7 @@ class SendTo extends React.Component {
       ${grid['middle-sm']}
       ${styles.sendButton}
       `}>
-          <Link to={`${routes.main.path}${routes.wallet.path}?address=${this.props.address}`}>
+          <Link to={`${routes.main.path}${routes.wallet.path}?recipient=${this.props.address}`}>
             <TertiaryButton className={`${styles.button} send-to-address`} >
               <FontIcon value={'send-token'}/> {this.props.t('Send to this address')}
             </TertiaryButton>

--- a/src/components/sendTo/sendTo.test.js
+++ b/src/components/sendTo/sendTo.test.js
@@ -18,11 +18,11 @@ describe('SendTo Component', () => {
   });
 
   it('renders correct link', () => {
-    expect(wrapper.find('Link').prop('to')).to.equal(`${routes.main.path}${routes.wallet.path}?address=${props.address}`);
+    expect(wrapper.find('Link').prop('to')).to.equal(`${routes.main.path}${routes.wallet.path}?recipient=${props.address}`);
   });
 
   it('updates when address changes', () => {
     wrapper.setProps({ address: '9876L' });
-    expect(wrapper.find('Link').prop('to')).to.equal(`${routes.main.path}${routes.wallet.path}?address=9876L`);
+    expect(wrapper.find('Link').prop('to')).to.equal(`${routes.main.path}${routes.wallet.path}?recipient=9876L`);
   });
 });

--- a/test/e2e/explorer.feature
+++ b/test/e2e/explorer.feature
@@ -14,7 +14,7 @@ Feature: Explorer page
     Then I should see 25 rows
     When I click "send to address"
     And I wait 1 seconds
-    Then I should be on url "/?referrer=/main/transactions%3Faddress%3D15610359283786884938L"
+    Then I should be on url "/?referrer=/main/transactions%3Frecipient%3D15610359283786884938L"
     When I click "explorer" menu
     When I fill in "1465651642158264047" to "search input" field
     And I click "input search button"


### PR DESCRIPTION
### What was the problem?
This launch protocol did not work:
lisk://main/transactions/send?recipient=12530546017554603584L&amount=10

### How did I fix it?
By adding `recipient` & removing `address`

### How to test it?
try the link/params as mentioned above and in #668 (and shouldn't work with address anymore)

### Review checklist
- The PR solves #668
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
