### PR TITLE
Update balance in account switcher - Closes #595

### DIFF
--- a/src/components/savedAccounts/savedAccounts.js
+++ b/src/components/savedAccounts/savedAccounts.js
@@ -99,9 +99,9 @@ class SavedAccounts extends React.Component {
         <div className={`${styles.content}`}>
           <ul className={styles.cardsWrapper} >
             <AddAccountCard t={t} />
-            {savedAccounts.map(account => (
+            {savedAccounts.map((account, key) => (
               <AccountCard
-                key={account.publicKey + account.network}
+                key={key}
                 onClick={() => switchAccount(account)}
                 handleRemove={this.handleRemove.bind(this)}
                 isSelectedForRemove={this.isSelectedForRemove.bind(this)}

--- a/src/store/middlewares/savedAccounts.js
+++ b/src/store/middlewares/savedAccounts.js
@@ -62,9 +62,7 @@ const savedAccountsMiddleware = (store) => {
     const { peers, account, savedAccounts } = store.getState();
     switch (action.type) {
       case actionTypes.newBlockCreated:
-        if (action.data.windowIsFocused) {
-          updateSavedAccounts(peers, action.data.block.transactions, savedAccounts);
-        }
+        updateSavedAccounts(peers, action.data.block.transactions, savedAccounts);
         break;
       case actionTypes.accountSwitched:
         store.dispatch(accountLoading());

--- a/src/store/middlewares/savedAccounts.test.js
+++ b/src/store/middlewares/savedAccounts.test.js
@@ -206,4 +206,26 @@ describe('SavedAccounts middleware', () => {
     expect(store.dispatch).to.not.have.been.calledWith();
     getAccountStub.restore();
   });
+
+  it('should make a request for the account information, when account logged in', () => {
+    const getAccountStub = mock(accountApi);
+    getAccountStub.expects('getAccount').withArgs(match.any, '1155682438012955434L').returnsPromise().resolves({ balance: 1 });
+    middleware(store)(next)({
+      type: actionTypes.accountLoggedIn,
+      data: {
+        publicKey,
+        balance,
+        passphrase,
+      },
+    });
+
+    expect(store.dispatch).to.have.been.calledWith({
+      data: {
+        accounts: state.savedAccounts.accounts,
+        lastActive: match.any,
+      },
+      type: actionTypes.accountsRetrieved,
+    });
+    getAccountStub.restore();
+  });
 });

--- a/src/store/middlewares/savedAccounts.test.js
+++ b/src/store/middlewares/savedAccounts.test.js
@@ -158,7 +158,7 @@ describe('SavedAccounts middleware', () => {
     const transactions = { transactions: [{ senderId: '1234L', recipientId: '1155682438012955434L' }] };
     middleware(store)(next)({
       type: actionTypes.newBlockCreated,
-      data: { block: transactions, windowIsFocused: true },
+      data: { block: transactions },
     });
 
     expect(store.dispatch).to.have.been.calledWith({
@@ -177,20 +177,7 @@ describe('SavedAccounts middleware', () => {
     const transactions = { transactions: [{ senderId: '1234L', recipientId: '4321L' }] };
     middleware(store)(next)({
       type: actionTypes.newBlockCreated,
-      data: { block: transactions, windowIsFocused: true },
-    });
-
-    expect(store.dispatch).to.not.have.been.calledWith();
-    getAccountStub.restore();
-  });
-
-  it('should not make a request for the account information, if a relevant transaction was made but window is not focused', () => {
-    const getAccountStub = mock(accountApi);
-    getAccountStub.expects('getAccount').withArgs(match.any, '1155682438012955434L').returnsPromise().resolves({ balance: 1 });
-    const transactions = { transactions: [{ senderId: '1234L', recipientId: '1155682438012955434L' }] };
-    middleware(store)(next)({
-      type: actionTypes.newBlockCreated,
-      data: { block: transactions, windowIsFocused: false },
+      data: { block: transactions },
     });
 
     expect(store.dispatch).to.not.have.been.calledWith();


### PR DESCRIPTION
### What was the problem?
The balances in the account switcher didn't update when changed

### How did I fix it?
Made an api call to get the account information, if the saved accounts are in a new block

### How to test it?
Make a transaction, open the account switcher -> the balance should be updated

### Review checklist
- The PR solves #595
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
