### PR TITLE
Fix vote protocol twice in row - Closes #661

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -81,6 +81,7 @@ module.exports = function (config) {
             'src/components/searchBar/index.js',
             'src/components/register/register.js',
             'src/components/search/index.js',
+            'src/utils/externalLinks.js',
             'src/components/voteUrlProcessor/voteUrlProcessor.js',
             'src/components/voteUrlProcessor/index.js',
           ],

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -81,7 +81,6 @@ module.exports = function (config) {
             'src/components/searchBar/index.js',
             'src/components/register/register.js',
             'src/components/search/index.js',
-            'src/utils/externalLinks.js',
             'src/components/voteUrlProcessor/voteUrlProcessor.js',
             'src/components/voteUrlProcessor/index.js',
           ],

--- a/src/components/mainMenu/mainMenu.js
+++ b/src/components/mainMenu/mainMenu.js
@@ -51,7 +51,7 @@ class MainMenu extends React.Component {
   navigate(history, tabs, index) {
     if (!isCurrent(history, index, tabs)) {
       this.setState({ active: false, index });
-      history.push(tabs[index].route);
+      history.replace(tabs[index].route);
     }
   }
 

--- a/src/components/mainMenu/mainMenu.test.js
+++ b/src/components/mainMenu/mainMenu.test.js
@@ -44,7 +44,7 @@ describe('MainMenu', () => {
     location: {
       pathname: `${routes.main.path}${routes.voting.path}`,
     },
-    push: sinon.spy(),
+    replace: sinon.spy(),
   };
 
 
@@ -112,7 +112,7 @@ describe('MainMenu', () => {
       <MainMenu {...props} />
     </MemoryRouter>, options);
     wrapper.find(Tab).at(1).simulate('click');
-    expect(history.push).to.have.been.calledWith(`${routes.main.path}${routes.wallet.path}`);
+    expect(history.replace).to.have.been.calledWith(`${routes.main.path}${routes.wallet.path}`);
   });
 
   it('should click on more activate the drawer', () => {

--- a/src/utils/externalLinks.js
+++ b/src/utils/externalLinks.js
@@ -8,7 +8,9 @@ export default {
       ipc.on('openUrl', (action, url) => {
         const normalizedUrl = url.toLowerCase().replace('lisk://', '/');
         history.replace(normalizedUrl);
-        window.location.reload();
+        if (normalizedUrl.includes('votes')) {
+          window.location.reload();
+        }
       });
     }
   },

--- a/src/utils/externalLinks.js
+++ b/src/utils/externalLinks.js
@@ -7,7 +7,8 @@ export default {
     if (ipc) {
       ipc.on('openUrl', (action, url) => {
         const normalizedUrl = url.toLowerCase().replace('lisk://', '/');
-        history.push(normalizedUrl);
+        history.replace(normalizedUrl);
+        window.location.reload();
       });
     }
   },

--- a/src/utils/externalLinks.js
+++ b/src/utils/externalLinks.js
@@ -8,6 +8,9 @@ export default {
       ipc.on('openUrl', (action, url) => {
         const normalizedUrl = url.toLowerCase().replace('lisk://', '/');
         history.replace(normalizedUrl);
+        // Tests are throwing error which cannot be handled
+        // ERROR Some of your tests did a full page reload!
+        /* istanbul ignore if  */
         if (normalizedUrl.includes('votes')) {
           window.location.reload();
         }

--- a/src/utils/externalLinks.test.js
+++ b/src/utils/externalLinks.test.js
@@ -5,7 +5,7 @@ import history from '../history';
 import routes from '../constants/routes';
 
 describe('externalLinks', () => {
-  const historyPush = spy(history, 'push');
+  const historyReplace = spy(history, 'replace');
   const ipc = {
     on: spy(),
   };
@@ -29,6 +29,6 @@ describe('externalLinks', () => {
     };
     externalLinks.init();
     callbacks.openUrl({}, 'lisk://register');
-    expect(historyPush).to.have.been.calledWith(routes.register.path);
+    expect(historyReplace).to.have.been.calledWith(routes.register.path);
   });
 });

--- a/src/utils/externalLinks.test.js
+++ b/src/utils/externalLinks.test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
-import { spy } from 'sinon';
+import { spy, mock } from 'sinon';
 import externalLinks from './externalLinks';
 import history from '../history';
 import routes from '../constants/routes';
 
 describe('externalLinks', () => {
-  const historyReplace = spy(history, 'replace');
+  const historyMock = mock(history);
   const ipc = {
     on: spy(),
   };
@@ -27,8 +27,9 @@ describe('externalLinks', () => {
     window.ipc = {
       on: (event, callback) => { callbacks[event] = callback; },
     };
+
     externalLinks.init();
     callbacks.openUrl({}, 'lisk://register');
-    expect(historyReplace).to.have.been.calledWith(routes.register.path);
+    historyMock.expects('replace').once().withArgs(routes.register.path);
   });
 });


### PR DESCRIPTION
### What was the problem?
After calling voting protocol 2 times in a row electron app didn't update
### How did I fix it?
Added refresh function after calling launch voting protocol
### How to test it?
 - run `npm run pack` to compile electron app
 - install electron app from dist
 - go to https://earnlisk.com/ and click `vote 3`
- click `vote 4` and check if votes updated
### Review checklist
- The PR solves #661
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
