### PR TITLE
Prevent autoupdater error when there's tag without published release - Closes #647

### DIFF
--- a/app/src/modules/autoUpdater.js
+++ b/app/src/modules/autoUpdater.js
@@ -20,7 +20,10 @@ export default ({ autoUpdater, dialog, win, process }) => {
     console.error(error);
     if (updater.error !== error) {
       updater.error = error;
-      dialog.showErrorBox('Error: ', error == null ? 'unknown' : error.toString());
+      if (error && error.toString().indexOf('404 Not Found') === -1) {
+        // this condition is because of https://github.com/LiskHQ/lisk-hub/issues/647
+        dialog.showErrorBox('Error: ', error == null ? 'unknown' : error.toString());
+      }
     }
   });
 

--- a/app/src/modules/autoUpdater.test.js
+++ b/app/src/modules/autoUpdater.test.js
@@ -68,8 +68,11 @@ describe('autoUpdater', () => {
     callbacks.error(undefined);
     expect(params.dialog.showErrorBox).to.not.have.been.calledWith();
 
+    callbacks.error('404 Not Found');
+    expect(params.dialog.showErrorBox).to.not.have.been.calledWith();
+
     callbacks.error(null);
-    expect(params.dialog.showErrorBox).to.have.been.calledWith('Error: ', 'unknown');
+    expect(params.dialog.showErrorBox).to.not.have.been.calledWith();
 
     callbacks.error('error');
     expect(params.dialog.showErrorBox).to.have.been.calledWith('Error: ', 'error');


### PR DESCRIPTION
### What was the problem?
See #647

### How did I fix it?
I don't show the error alert in that situation

### How to test it?
- clone Lisk Hub on GitHub
- push `v0.4.0` tag to your GitHub clone of Lisk Hub
- change repository in package.json to your GitHub clone of Lisk Hub
- build Hub with `npm run pack`
- launch the app

### Review checklist
- The PR solves #647
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
