### PR TITLE
Fix Account visual location in xSmall

### DIFF
--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -318,3 +318,9 @@
     }
   }
 }
+
+@media (--xSmall-viewport) {
+  .logo {
+    padding: 10px 0 7px;
+  }
+}


### PR DESCRIPTION
### What was the problem?
As depicted in screenshots in #624 , account visual breaks down due to small width of screen.

### How did I fix it?
Removed extra paddings from logo to open up some space for account visual.

### How to test it?
Make sure it's not broken to second line in xSmall screen width.

### Review checklist
- The PR solves #624 
- All new code follows best practices