### PR TITLE
Remove extra margin in account detail page - Closes #687

### DIFF
--- a/src/components/accountTransactions/accountTransactions.css
+++ b/src/components/accountTransactions/accountTransactions.css
@@ -13,35 +13,15 @@
   }
 }
 
-@media (--xLarge-viewport) {
-  .gridPadding {
-    padding-right: 37px;
-  }
-}
-
-@media (--large-viewport) {
-  .gridPadding {
-    padding-right: 24px;
-  }
-}
-
 @media (--medium-viewport) {
   .wrapper {
     padding-top: var(--title-bar-extra-padding-M);
-
-    & .gridPadding {
-      padding-right: 0;
-    }
   }
 }
 
 @media (--small-viewport) {
   .wrapper {
     padding-top: var(--title-bar-extra-padding-S);
-
-    & .gridPadding {
-      padding-right: 0;
-    }
   }
 }
 

--- a/src/components/accountTransactions/index.js
+++ b/src/components/accountTransactions/index.js
@@ -17,7 +17,7 @@ class accountTransactions extends React.Component {
   // eslint-disable-next-line class-methods-use-this
   render() {
     return <div className={`${grid.row} ${styles.wrapper}`}>
-      <div className={`${grid['col-md-4']} ${styles.gridPadding} ${styles.sendTo}`}>
+      <div className={`${grid['col-md-4']} ${styles.sendTo}`}>
         <SendTo
           balance={this.props.balance}
           address={this.props.match.params.address}


### PR DESCRIPTION
### What was the problem?
There was an extra margin between sidebar and main box in account detail page that needs to be removed.

### Review checklist
- The PR solves #687
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
