### PR TITLE
Delegates features menu breaks layout in tablet portrait - Closes #689

### DIFF
--- a/src/components/setting/setting.css
+++ b/src/components/setting/setting.css
@@ -145,6 +145,7 @@
     display: flex;
     left: -100%;
     transition: all linear 300ms;
+    margin: 0;
 
     &.active {
       left: 0;


### PR DESCRIPTION
### What was the problem?
- There are negative margins set in delegateList footer which affect some others elements
### How did I fix it?
- Reset margin on affected e footer element
### How to test it?
- open settings menu and check delegate features footer
### Review checklist
- The PR solves #689
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
