### PR TITLE
Send to address button doesnt show send form - Closes #670

### DIFF
--- a/src/components/accountInitialization/index.js
+++ b/src/components/accountInitialization/index.js
@@ -14,11 +14,11 @@ class AccountInitialization extends React.Component {
   }
 
   componentDidMount() {
-    const { account, transactions } = this.props;
+    const { account, transactions, address } = this.props;
     const needsNoAccountInit = account.serverPublicKey
       || account.balance === 0
       || transactions.pending.length > 0;
-    if (needsNoAccountInit) {
+    if (needsNoAccountInit || address) {
       this.props.nextStep();
     }
   }

--- a/src/components/send/index.js
+++ b/src/components/send/index.js
@@ -53,7 +53,7 @@ class Send extends React.Component {
           </span>
           <MultiStep finalCallback={this.setSendIsActive.bind(this, false)}
             className={styles.wrapper}>
-            <AccountInitialization />
+            <AccountInitialization address={recipient} />
             <SendWritable
               autoFocus={this.state.sendIsActive || window.innerWidth > breakpoints.m}
               address={recipient}


### PR DESCRIPTION
### What was the problem?
If you clicked on "Send to this address" button, it didn't show the Transform form with the address profiled when account isn't initialized 
### How to test it?

1. login with an account witch isn't initialized
2. go to explorer page and search for a lisk address
3. in account page click on sendTo button
4. then you must redirect to wallet page and account initialization shouldn't be shown 

### Review checklist
- The PR solves #670
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
