### PR TITLE
Fix second passphrase back button - Closes #695

### DIFF
--- a/src/components/secondPassphrase/secondPassphrase.js
+++ b/src/components/secondPassphrase/secondPassphrase.js
@@ -21,6 +21,11 @@ class SecondPassphrase extends React.Component {
         .push(`${routes.main.path}${routes.dashboard.path}`);
     }
   }
+
+  backToPreviousPage() {
+    this.props.history.goBack();
+  }
+
   render() {
     const { account, peers, registerSecondPassphrase, t } = this.props;
     const header = t('Secure the use of your Lisk ID with a second passphrase.');
@@ -38,7 +43,9 @@ class SecondPassphrase extends React.Component {
         <MultiStep
           showNav={true}
           finalCallback={onPassphraseRegister}
-          backButtonLabel={t('Back')}>
+          backButtonLabel={t('Back')}
+          prevPage={this.backToPreviousPage.bind(this)}
+        >
           <CreateSecond title={t('Create')} t={t} icon='add' balance={account.balance} />
           <Safekeeping title={t('Safekeeping')} t={t} step='revealing-step'
             icon='checkmark' header={header} message={message} />


### PR DESCRIPTION
### What was the problem?
The back button in the second passphrase creation didn't work

### How did I fix it?
By adding `prevPage` to the multistep

### How to test it?
Go to the second passphrase creation and click the back button

### Review checklist
- The PR solves #695

