### PR TITLE
Enable delegates after opening - Closes #701

### DIFF
--- a/src/components/voteUrlProcessor/index.js
+++ b/src/components/voteUrlProcessor/index.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import { translate } from 'react-i18next';
 import { withRouter } from 'react-router';
+import { settingsUpdated } from '../../actions/settings';
 
 import {
   urlVotesFound,
@@ -27,6 +28,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   urlVotesFound: data => dispatch(urlVotesFound(data)),
+  settingsUpdated: data => dispatch(settingsUpdated(data)),
   clearVoteLookupStatus: () => dispatch(voteLookupStatusCleared()),
 });
 

--- a/src/components/voteUrlProcessor/voteUrlProcessor.js
+++ b/src/components/voteUrlProcessor/voteUrlProcessor.js
@@ -13,6 +13,7 @@ export default class VoteUrlProcessor extends React.Component {
     if (params.votes || params.unvotes) {
       const upvotes = params.votes ? params.votes.split(',') : [];
       const unvotes = params.unvotes ? params.unvotes.split(',') : [];
+      this.props.settingsUpdated({ advancedMode: true })
       this.props.urlVotesFound({
         activePeer: this.props.activePeer,
         upvotes,

--- a/src/components/voteUrlProcessor/voteUrlProcessor.test.js
+++ b/src/components/voteUrlProcessor/voteUrlProcessor.test.js
@@ -10,31 +10,32 @@ describe('VoteUrlProcessor', () => {
   let wrapper;
   let props;
 
-  // beforeEach(() => {
-  //   const account = accounts.delegate;
+  beforeEach(() => {
+    const account = accounts.delegate;
 
-  //   props = {
-  //     activePeer: {},
-  //     account,
-  //     clearVoteLookupStatus: sinon.spy(),
-  //     urlVotesFound: sinon.spy(),
-  //     notVotedYet: [],
-  //     notFound: [],
-  //     alreadyVoted: [],
-  //     upvotes: [],
-  //     unvotes: [],
-  //     pending: [],
-  //     history: {
-  //       location: {
-  //         search: '',
-  //       },
-  //     },
-  //     urlVoteCount: 0,
-  //     t: key => key,
-  //   };
-  //   wrapper = mount(<VoteUrlProcessor {...props} />);
-  // });
-
+    props = {
+      activePeer: {},
+      account,
+      clearVoteLookupStatus: sinon.spy(),
+      urlVotesFound: sinon.spy(),
+      settingsUpdated: sinon.spy(),
+      notVotedYet: [],
+      notFound: [],
+      alreadyVoted: [],
+      upvotes: [],
+      unvotes: [],
+      pending: [],
+      history: {
+        location: {
+          search: '',
+        },
+      },
+      urlVoteCount: 0,
+      t: key => key,
+    };
+    wrapper = mount(<VoteUrlProcessor {...props} />);
+  });
+  //
   // it('renders ProgressBar component if props.pending.length > 0', () => {
   //   wrapper.setProps({
   //     pending: ['delegate_name'],
@@ -43,40 +44,41 @@ describe('VoteUrlProcessor', () => {
   //   expect(wrapper.find('ProgressBar')).to.have.length(1);
   // });
 
-  // it('calls props.urlVotesFound with upvotes if URL contains ?votes=delegate_name', () => {
-  //   wrapper = mount(<VoteUrlProcessor {...{
-  //     ...props,
-  //     history: {
-  //       location: {
-  //         search: '?votes=delegate_name',
-  //       },
-  //     },
-  //   }} />);
-  //   expect(props.urlVotesFound).to.have.been.calledWith({
-  //     activePeer: props.activePeer,
-  //     upvotes: ['delegate_name'],
-  //     unvotes: [],
-  //     address: props.account.address,
-  //   });
-  // });
+  it('calls props.urlVotesFound with upvotes if URL contains ?votes=delegate_name', () => {
+    wrapper = mount(<VoteUrlProcessor {...{
+      ...props,
+      history: {
+        location: {
+          search: '?votes=delegate_name',
+        },
+      },
+    }} />);
+    expect(props.urlVotesFound).to.have.been.calledWith({
+      activePeer: props.activePeer,
+      upvotes: ['delegate_name'],
+      unvotes: [],
+      address: props.account.address,
+    });
+    expect(props.settingsUpdated).to.have.been.calledWith({ advancedMode: true });
+    });
 
-
-  // it('calls props.urlVotesFound with unvotes if URL contains ?unvotes=delegate_name', () => {
-  //   wrapper = mount(<VoteUrlProcessor {...{
-  //     ...props,
-  //     history: {
-  //       location: {
-  //         search: '?unvotes=delegate_name',
-  //       },
-  //     },
-  //   }} />);
-  //   expect(props.urlVotesFound).to.have.been.calledWith({
-  //     activePeer: props.activePeer,
-  //     upvotes: [],
-  //     unvotes: ['delegate_name'],
-  //     address: props.account.address,
-  //   });
-  // });
+  it('calls props.urlVotesFound with unvotes if URL contains ?unvotes=delegate_name', () => {
+    wrapper = mount(<VoteUrlProcessor {...{
+      ...props,
+      history: {
+        location: {
+          search: '?unvotes=delegate_name',
+        },
+      },
+    }} />);
+    expect(props.urlVotesFound).to.have.been.calledWith({
+      activePeer: props.activePeer,
+      upvotes: [],
+      unvotes: ['delegate_name'],
+      address: props.account.address,
+    });
+    expect(props.settingsUpdated).to.have.been.calledWith({ advancedMode: true });
+  });
 
   // it('renders .upvotes-message element with a message if props.upvotes.length > 0', () => {
   //   wrapper.setProps({


### PR DESCRIPTION
### What was the problem?
Entering delegates page (e.g. via launch protocol) did not enable it in the menu

### How did I fix it?
By using `settingsUpdated` to set the delegates setting in `voteUrlProcessor`

### How to test it?
Open e.g. http://localhost:8080/#/main/voting?unvotes=genesis_77,genesis_91,genesis_88
while your delegates settings are turned off, and check that after opening the link, the setting is now turned on

### Review checklist
- The PR solves #701 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
