### PR TITLE
Add 404 page for all pages - Closes #584

### DIFF
--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
+import { isPathCorrect } from '../../utils/app';
 import styles from './app.css';
 import Toaster from '../toaster';
 import MainMenu from '../mainMenu';
@@ -50,17 +51,21 @@ class App extends React.Component {
               <div id='onboardingAnchor'></div>
               <Switch>
                 {this.state.loaded ?
-                  <Route path={routes.explorer.path} render={ () => (
-                    explorerRoutes.map((route, key) => (
-                      <CustomRoute
-                        pathPrefix={route.pathPrefix}
-                        path={route.path}
-                        pathSuffix={route.pathSuffix}
-                        component={route.component}
-                        isPrivate={route.isPrivate}
-                        exact={route.exact}
-                        key={key} />
-                    ))
+                  <Route path={routes.explorer.path} component={ ({ location }) => (
+                    isPathCorrect(location, explorerRoutes) ? (
+                      <div>
+                        {explorerRoutes.map((route, key) => (
+                          <CustomRoute
+                            pathPrefix={route.pathPrefix}
+                            path={route.path}
+                            pathSuffix={route.pathSuffix}
+                            component={route.component}
+                            isPrivate={route.isPrivate}
+                            exact={true}
+                            key={key} />
+                        ))}
+                      </div>
+                    ) : <Route path='*' component={NotFound} />
                   )} />
                   : null
                 }

--- a/src/components/customRoute/index.js
+++ b/src/components/customRoute/index.js
@@ -7,7 +7,6 @@ export const CustomRouteRender = ({ path, component, isPrivate, exact,
   isAuthenticated, pathSuffix = '', pathPrefix = '', ...rest }) => {
   const { pathname, search } = rest.history.location;
   const fullPath = pathPrefix + path + pathSuffix;
-
   return ((isPrivate && isAuthenticated) || !isPrivate ?
     <main className={isPrivate ? offlineStyle.disableWhenOffline : null}>
       <Route path={fullPath} component={component} exact={exact} />

--- a/src/components/search/keyAction.js
+++ b/src/components/search/keyAction.js
@@ -15,7 +15,7 @@ export const visit = (value, history) => {
   if (value.match(regex.address)) {
     history.push(`${routes.explorer.path}${routes.accounts.path}/${value}`);
   } else if (value.match(regex.transactionId)) {
-    history.push(`${routes.explorer.path}${routes.wallet.path}/${value}`);
+    history.push(`${routes.explorer.path}${routes.transactions.path}/${value}`);
   } else {
     history.push(`${routes.explorer.path}${routes.searchResult.path}/${value}`);
   }

--- a/src/components/search/keyAction.test.js
+++ b/src/components/search/keyAction.test.js
@@ -44,7 +44,7 @@ describe('Search KeyAction', () => {
 
     const expectedHistory = [
       `${routes.explorer.path}${routes.accounts.path}/${testValues[0]}`,
-      `${routes.explorer.path}${routes.wallet.path}/${testValues[1]}`,
+      `${routes.explorer.path}${routes.transactions.path}/${testValues[1]}`,
       `${routes.explorer.path}${routes.searchResult.path}/${testValues[2]}`,
     ];
 

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -88,9 +88,9 @@ export default {
     component: AccountTransactions,
     isPrivate: false,
   },
-  walletExplorer: {
+  transactions: {
     pathPrefix: '/explorer',
-    path: '/wallet',
+    path: '/transactions',
     pathSuffix: '/:id?',
     component: SingleTransaction,
     isPrivate: false,

--- a/src/utils/app.js
+++ b/src/utils/app.js
@@ -1,14 +1,14 @@
 export const isPathCorrect = (location, explorerRoutes) => {
-  const locationElements = location.pathname.split('/').slice(2);
+  const locationElements = location.pathname.split('/').slice(2).filter(x => x);
   const isValid = explorerRoutes.find((route) => {
     const fullRouteName = route.path + (route.pathSuffix || '');
     const routeElements = fullRouteName.split('/').slice(1);
     return locationElements[0] === routeElements[0]
-    && locationElements[locationElements.length - 1] !== ''
+    && (locationElements[locationElements.length - 1] !== '')
     && ((locationElements.length === 2 && !!route.pathSuffix)
       || (locationElements.length < 2 && !route.pathSuffix));
   });
-  return isValid;
+  return isValid ? location.pathname : false;
 };
 
 export default isPathCorrect;

--- a/src/utils/app.js
+++ b/src/utils/app.js
@@ -1,0 +1,14 @@
+export const isPathCorrect = (location, explorerRoutes) => {
+  const locationElements = location.pathname.split('/').slice(2);
+  const isValid = explorerRoutes.find((route) => {
+    const fullRouteName = route.path + (route.pathSuffix || '');
+    const routeElements = fullRouteName.split('/').slice(1);
+    return locationElements[0] === routeElements[0]
+    && locationElements[locationElements.length - 1] !== ''
+    && ((locationElements.length === 2 && !!route.pathSuffix)
+      || (locationElements.length < 2 && !route.pathSuffix));
+  });
+  return isValid;
+};
+
+export default isPathCorrect;

--- a/src/utils/app.test.js
+++ b/src/utils/app.test.js
@@ -1,0 +1,31 @@
+import { expect } from 'chai';
+import { isPathCorrect } from './app';
+import routes from '../constants/routes';
+
+describe('App Util', () => {
+  it('should detach wrong urls', () => {
+    const allRoutes = Object.values(routes);
+    const explorerRoutes = allRoutes.filter(routeObj =>
+      routeObj.pathPrefix && routeObj.pathPrefix === routes.explorer.path);
+
+    const invalidURLs = ['/explorer/search/123', '/explorer/search/',
+      '/explorer/accounts/16313739661670634666L/hi'];
+    for (let i = 0; i >= invalidURLs.length; i++) {
+      const data = isPathCorrect(invalidURLs[i], explorerRoutes);
+      expect(data).to.be.equal(undefined);
+    }
+  });
+
+  it('should detach wrong urls', () => {
+    const allRoutes = Object.values(routes);
+    const explorerRoutes = allRoutes.filter(routeObj =>
+      routeObj.pathPrefix && routeObj.pathPrefix === routes.explorer.path);
+
+    const invalidURLs = ['/explorer/search', '/explorer/accounts/16313739661670634666L'];
+    for (let i = 0; i >= invalidURLs.length; i++) {
+      const data = isPathCorrect(invalidURLs[i], explorerRoutes);
+      expect(data).to.not.be.equal(undefined);
+    }
+  });
+});
+

--- a/src/utils/app.test.js
+++ b/src/utils/app.test.js
@@ -8,23 +8,24 @@ describe('App Util', () => {
     const explorerRoutes = allRoutes.filter(routeObj =>
       routeObj.pathPrefix && routeObj.pathPrefix === routes.explorer.path);
 
-    const invalidURLs = ['/explorer/search/123', '/explorer/search/',
+    const invalidURLs = ['/explorer/search/123',
       '/explorer/accounts/16313739661670634666L/hi'];
-    for (let i = 0; i >= invalidURLs.length; i++) {
-      const data = isPathCorrect(invalidURLs[i], explorerRoutes);
-      expect(data).to.be.equal(undefined);
+    for (let i = 0; i < invalidURLs.length; i++) {
+      const data = isPathCorrect({ pathname: invalidURLs[i] }, explorerRoutes);
+      expect(data).to.be.equal(false);
     }
   });
 
-  it('should detach wrong urls', () => {
+  it('should detach right urls', () => {
     const allRoutes = Object.values(routes);
     const explorerRoutes = allRoutes.filter(routeObj =>
       routeObj.pathPrefix && routeObj.pathPrefix === routes.explorer.path);
 
-    const invalidURLs = ['/explorer/search', '/explorer/accounts/16313739661670634666L'];
-    for (let i = 0; i >= invalidURLs.length; i++) {
-      const data = isPathCorrect(invalidURLs[i], explorerRoutes);
-      expect(data).to.not.be.equal(undefined);
+    const invalidURLs = ['/explorer/search', '/explorer/search/',
+      '/explorer/accounts/16313739661670634666L'];
+    for (let i = 0; i < invalidURLs.length; i++) {
+      const data = isPathCorrect({ pathname: invalidURLs[i] }, explorerRoutes);
+      expect(data).to.be.equal(invalidURLs[i]);
     }
   });
 });


### PR DESCRIPTION
### What was the problem?
404 page worked only on root
### How did I fix it?
Added custom function that compares nested explorer route and renders 404 if it doesn't exist.
### How to test it?
Go to different pages that are nested and check if 404 renders
ex.
``` 
/explorer/search/123
/explorer/search/
/explorer/accounts/16313739661670634666L/hi
```

### Review checklist
- The PR solves #584
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
