### PR TITLE
Add @pending to account init e2e test

### DIFF
--- a/test/e2e/send.feature
+++ b/test/e2e/send.feature
@@ -13,7 +13,10 @@ Feature: Send dialog
     And I should see 26 rows
     When I scroll to the bottom of "transaction results"
     Then I should see 51 rows
-  @advanced
+
+  # pending because this test currently depends on the prior one
+  # and is failing when running isolated
+  @advanced @pending
   Scenario: should be able to init account if needed
     Given I wait 10 seconds
     And I'm logged in as "without initialization"


### PR DESCRIPTION
### What was the problem?
see #723 

### How did I fix it?
By adding @pending

### How to test it?
When you run the tests with `npm run e2e-test -- --cucumberOpts.tags @advanced` you should see that the account init test is skipped

### Review checklist
- The PR solves #723 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
