### PR TITLE
Remove malformed html in index.html - Closes #581

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,18 +2,18 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <meta data-lisk-hub-version="<%= htmlWebpackPlugin.options.VERSION %>">
+        <meta name="version" data-lisk-hub-version="<%= htmlWebpackPlugin.options.VERSION %>">
         <meta name="viewport" content="width=device-width">
         <meta name="keywords" content="Lisk, Lisk Hub, wallet">
         <meta property="og:title" content="Lisk Hub">
         <meta property="og:description" name="description" content="Lisk Hub is an all-in-one solution to manage your Lisk ID, access and send LSK tokens, as well as vote for delegates.">
         <meta property="og:image" content="https://lisk.io/hub/assets/images/og-logo.png">
         <title>Lisk Hub</title>
-        <style type="text/css">
+        <style>
           <%= compilation.assets['head.css'].source() %>
         </style>
         <link rel="icon" type="image/png" href="./assets/images/LISK.png" />
-        <script type="text/javascript">
+        <script>
           /* Following comment is a placeholder used by `npm run build:testnet`, do not remove */
           var defaultNet = "mainnet";//defaultNetwork
           (function(targetNet) {

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <meta name="version" data-lisk-hub-version="<%= htmlWebpackPlugin.options.VERSION %>">
+        <meta name="application-name" content="lisk-hub-<%= htmlWebpackPlugin.options.VERSION %>" data-lisk-hub-version="<%= htmlWebpackPlugin.options.VERSION %>">
         <meta name="viewport" content="width=device-width">
         <meta name="keywords" content="Lisk, Lisk Hub, wallet">
         <meta property="og:title" content="Lisk Hub">

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
     <head>
         <meta charset="utf-8">
         <meta name="application-name" content="lisk-hub-<%= htmlWebpackPlugin.options.VERSION %>" data-lisk-hub-version="<%= htmlWebpackPlugin.options.VERSION %>">


### PR DESCRIPTION
### What was the problem?
- there was a double closing body tag, and some warnings related to metas
### How did I fix it?
- add suggestions from https://validator.w3.org/
### How to test it?
- https://validator.w3.org/ on the test branch url
### Review checklist
- The PR solves #581 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
