### PR TITLE
Fix an issue in marking missing words - Closes #717

### DIFF
--- a/src/components/passphrase/confirm/form.css
+++ b/src/components/passphrase/confirm/form.css
@@ -60,14 +60,14 @@
     }
   }
 
-  & .clean {
+  &.clean {
     & input:checked + label {
       background-color: var(--color-primary-standard);
       color: var(--color-white);
     }
   }
 
-  & .invalid {
+  &.invalid {
     & input:checked + label {
       background-color: var(--color-action-dark);
       border-color: var(--color-action-dark);
@@ -75,7 +75,7 @@
     }
   }
 
-  & .outOfTrials {
+  &.outOfTrials {
     & input + label {
       opacity: 0.2;
       cursor: auto;
@@ -83,7 +83,7 @@
     }
   }
 
-  & .valid {
+  &.valid {
     & input:checked + label {
       background-color: var(--color-success-dark);
       border-color: var(--color-success-dark);


### PR DESCRIPTION
### What was the problem?
The logic to mark the word options validity was correct but CSS selector to depict the. status was wrong.

### How did I fix it?
Fixed the CSS selector

### How to test it?
Check if the passphrase confirmation form behaves as expected.

### Review checklist
- The PR solves #717 
- All new code follows best practices
