### PR TITLE
A tiny hack to fix the issue with border radius in Safari - Closes #749

### DIFF
--- a/src/components/passphrase/createSecond/progressBar.css
+++ b/src/components/passphrase/createSecond/progressBar.css
@@ -7,6 +7,8 @@
   max-width: 80%;
   background: var(--color-primary-dark);
   margin: 40px auto;
+  backface-visibility: hidden;
+  transform: translate3d(0, 0, 0);
 }
 
 .value {


### PR DESCRIPTION
### What was the problem?
Safari has a problem rendering round corners while animating a CSS transition. This issue is most likely happened when the parent has round corners and hides the overflow of its children.

### How did I fix it?
Used 3d transform while back-face visibility is disabled.

### How to test it?
Try registering the second passphrase for a random account. The progress bar should always have rounded corners.

### Review checklist
- The PR solves #749 
- All new code follows best practices