### PR TITLE
Disable text marking

### DIFF
--- a/src/assets/css/styles.head.css
+++ b/src/assets/css/styles.head.css
@@ -1,7 +1,3 @@
-* {
-  user-select: none;
-}
-
 body {
   background-color: #013165;
 }

--- a/src/assets/css/styles.head.css
+++ b/src/assets/css/styles.head.css
@@ -1,3 +1,7 @@
+* {
+  user-select: none;
+}
+
 body {
   background-color: #013165;
 }

--- a/src/components/app/app.css
+++ b/src/components/app/app.css
@@ -2,6 +2,10 @@
 @import './global.css';
 @import './type.css';
 
+* {
+  user-select: none;
+}
+
 body {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
### What was the problem?
Both, the browsers and the electron apps, allowed the user to select text.  
It affects the UX insofar that Lisk Hub less feels like an app but more like a website with text.  
Included are pictures before and after the fix.

![bildschirmfoto 2018-04-25 um 23 46 30](https://user-images.githubusercontent.com/11890358/39274708-261538ee-48e3-11e8-84af-7dd065202a41.png)
![bildschirmfoto 2018-04-25 um 23 48 07](https://user-images.githubusercontent.com/11890358/39274709-27543e80-48e3-11e8-8058-b2422ae8d828.png)

### How did I fix it?
Globally applied the rule `user-select: none` in the app.css file.

### How to test it?
- Just try marking or press CTRL+A ;-)
- The change does **not** affect inputs. They still function like before (marking input contents, clicking buttons, ...)

### Review checklist
- The PR solves #INSERT_ISSUE_NUMBER
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
