### PR TITLE
Disable dragging of images and links

### DIFF
--- a/src/components/app/app.css
+++ b/src/components/app/app.css
@@ -8,6 +8,11 @@ body {
   width: 100%;
 }
 
+img,
+a {
+  -webkit-user-drag: none;
+}
+
 .bodyWrapper {
   position: absolute;
   width: 100%;


### PR DESCRIPTION
### What was the problem?
This is an addition to #766 to improve the UX.
Users will no longer be able to drag images (e.g. from the menu) or links (e.g. the "See all transactions" button).

### How did I fix it?
Applying the rule `-webkit-user-drag: none` to img and a.  
There is no way to do this with other browsers yet, thus the property 'user-drag' does not exist (which would be the preferred way due to the auto-prefixer).

### How to test it?
Try dragging images and links.

### Review checklist
- The PR solves #INSERT_ISSUE_NUMBER
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
