### PR TITLE
Strip initial, traling and multiple white spaces of Passphrase - Closes #750

### DIFF
--- a/src/components/passphraseInput/index.js
+++ b/src/components/passphraseInput/index.js
@@ -23,7 +23,7 @@ class PassphraseInput extends React.Component {
   }
 
   handleValueChange(index, value) {
-    let insertedValue = value;
+    let insertedValue = value.trim().replace(/\W+/g, ' ');
     const insertedValueAsArray = insertedValue.split(' ');
     let passphrase = this.props.value.split(' ');
 


### PR DESCRIPTION
### What was the problem?
Posted passphrases which include initial, trailing and multiple whitespaces, would cause empty inputs in our Passphrase inputs group and spoil the user experience.

### How did I fix it?
I'm stripping all extra whitespaces.

### How to test it?
Try the passphrase input in Login page with a passphrase which includes all or any of the aforementioned whitespaces. it shouldn't affect the experience of pasting a passphrase.

### Review checklist
- The PR solves #750 
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)