### PR TITLE
Fix breaking app when removing last saved account - Closes #792

### DIFF
--- a/src/utils/savedAccounts.js
+++ b/src/utils/savedAccounts.js
@@ -29,9 +29,7 @@ export const setSavedAccounts = (accounts) => {
   return accounts;
 };
 
-export const getLastActiveAccount = () => (
-  getSavedAccounts()[localStorage.getItem('lastActiveAccountIndex') || 0]
-);
+export const getLastActiveAccount = () => (getSavedAccounts()[localStorage.getItem('lastActiveAccountIndex')] || getSavedAccounts()[0]);
 
 export const getIndexOfSavedAccount = (savedAccounts, { publicKey, network, address }) =>
   savedAccounts.findIndex(account => (
@@ -45,8 +43,8 @@ export const setLastActiveAccount = ({ publicKey, network, address }) => {
     getSavedAccounts(),
     { publicKey, network, address },
   );
+
   if (lastActiveAccountIndex > -1) {
     localStorage.setItem('lastActiveAccountIndex', lastActiveAccountIndex);
   }
-  return lastActiveAccountIndex;
 };

--- a/src/utils/savedAccounts.js
+++ b/src/utils/savedAccounts.js
@@ -26,7 +26,6 @@ export const setSavedAccounts = (accounts) => {
     publicKey, network, address, balance,
   }));
   localStorage.setItem('accounts', JSON.stringify(accounts));
-  return accounts;
 };
 
 export const getLastActiveAccount = () => (getSavedAccounts()[localStorage.getItem('lastActiveAccountIndex')] || getSavedAccounts()[0]);

--- a/src/utils/savedAccounts.test.js
+++ b/src/utils/savedAccounts.test.js
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import { mock } from 'sinon';
 import {
   getSavedAccounts,
   getLastActiveAccount,
@@ -8,7 +7,6 @@ import {
 } from './savedAccounts';
 
 describe('savedAccounts', () => {
-  let localStorageMock;
   const publicKey = 'fab9d261ea050b9e326d7e11587eccc343a20e64e29d8781b50fd06683cacc88';
   const accounts = [
     {
@@ -29,22 +27,23 @@ describe('savedAccounts', () => {
     },
   ];
 
+  let storage = {};
   beforeEach(() => {
-    localStorageMock = mock(localStorage);
+    window.localStorage.getItem = key => (storage[key]);
+    window.localStorage.setItem = (key, item) => { storage[key] = item; };
   });
 
   afterEach(() => {
-    localStorageMock.restore();
+    storage = {};
   });
 
   describe('getSavedAccounts', () => {
     it('returns [] if if localStorage.getItem(\'accounts\') returns undefined', () => {
-      localStorageMock.expects('getItem').withExactArgs('accounts').returns(undefined);
       expect(getSavedAccounts()).to.deep.equal([]);
     });
 
     it('returns [] if if localStorage.getItem(\'accounts\') returns invalid JSON string', () => {
-      localStorageMock.expects('getItem').withExactArgs('accounts').returns('{]');
+      window.localStorage.setItem('accounts', '{]');
       expect(getSavedAccounts()).to.deep.equal([]);
     });
 
@@ -55,49 +54,49 @@ describe('savedAccounts', () => {
           publicKey: 'invalid',
         },
       ];
-      localStorageMock.expects('getItem').withExactArgs('accounts').returns(JSON.stringify(invalidAccounts));
+      window.localStorage.setItem('accounts', JSON.stringify(invalidAccounts));
       expect(getSavedAccounts()).to.deep.equal([]);
     });
 
     it('returns array parsed from json in localStorage.getItem(\'accounts\')', () => {
-      localStorageMock.expects('getItem').withExactArgs('accounts').returns(JSON.stringify(accounts));
+      window.localStorage.setItem('accounts', JSON.stringify(accounts));
       expect(getSavedAccounts()).to.deep.equal(accounts);
     });
   });
 
   describe('getLastActiveAccount', () => {
     it('returns first account if localStorage.getItem(\'lastActiveAccountIndex\') returns undefined', () => {
-      localStorageMock.expects('getItem').withExactArgs('accounts').returns(JSON.stringify(accounts));
-      localStorageMock.expects('getItem').withExactArgs('lastActiveAccountIndex').returns(undefined);
+      window.localStorage.setItem('accounts', JSON.stringify(accounts));
       expect(getLastActiveAccount()).to.deep.equal(accounts[0]);
     });
 
     it('returns nth account if localStorage.getItem(\'lastActiveAccountIndex\') returns n', () => {
       const n = 2;
-      localStorageMock.expects('getItem').withExactArgs('accounts').returns(JSON.stringify(accounts));
-      localStorageMock.expects('getItem').withExactArgs('lastActiveAccountIndex').returns(n);
+      window.localStorage.setItem('accounts', JSON.stringify(accounts));
+      window.localStorage.setItem('lastActiveAccountIndex', n);
       expect(getLastActiveAccount()).to.deep.equal(accounts[n]);
     });
   });
 
   describe('setLastActiveAccount', () => {
     it('sets nothing in localStorage if passed account is not in localStorageMock.accounts and returns -1', () => {
-      localStorageMock.expects('getItem').withExactArgs('accounts').returns(JSON.stringify(accounts.slice(0, 1)));
-      expect(setLastActiveAccount(accounts[2])).to.equal(-1);
+      window.localStorage.setItem('accounts', JSON.stringify(accounts.slice(0, 1)));
+      setLastActiveAccount(accounts[2]);
+      expect(window.localStorage.getItem('lastActiveAccountIndex')).to.equal(undefined);
     });
 
     it('sets index of passed account in localStorage.acocunts into localStorage and returns n', () => {
       const n = 2;
-      localStorageMock.expects('getItem').withExactArgs('accounts').returns(JSON.stringify(accounts));
-      localStorageMock.expects('setItem').withExactArgs('lastActiveAccountIndex', n);
-      expect(setLastActiveAccount(accounts[n])).to.equal(n);
+      window.localStorage.setItem('accounts', JSON.stringify(accounts));
+      setLastActiveAccount(accounts[n]);
+      expect(window.localStorage.getItem('lastActiveAccountIndex')).to.equal(n);
     });
   });
 
   describe('setSavedAccounts', () => {
     it('sets accounts in localStorage with appended passed account and also returns it', () => {
-      localStorageMock.expects('setItem').withExactArgs('accounts', JSON.stringify([accounts[2]]));
-      expect(setSavedAccounts([accounts[2]])).to.deep.equal([accounts[2]]);
+      setSavedAccounts([accounts[2]]);
+      expect(JSON.parse(window.localStorage.getItem('accounts'))).to.deep.equal([accounts[2]]);
     });
   });
 });


### PR DESCRIPTION
### What was the problem?
see #792 

### How did I fix it?
By checking if the index of the last saved account is not larger than the actual list of saved accounts

### How to test it?
- Log into an account, then remove the last account in the account switcher (the one you are logged in with), then refresh the page -> before it broke, now it shouldnt anymore

### Review checklist
- The PR solves #792 
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
