### PR TITLE
:new: lock lolex dependency causing build failure on jenkins

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "js-sha256": "0.9.0",
     "lisk-js": "0.5.1",
     "lodash.throttle": "4.1.1",
+    "lolex": "=2.3.2",
     "moment": "2.20.1",
     "numeral": "git+https://github.com/LiskHQ/Numeral-js.git",
     "parallax-js": "3.1.0",


### PR DESCRIPTION
### What was the problem?
 see #802 
### How did I fix it?
-lock dependency to 2.3.2 version
### How to test it?
- verify next build in jenkins passes
### Review checklist
- The PR solves #802 
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
