### PR TITLE
Fix graph style error - Closes #785

### DIFF
--- a/src/components/dashboard/currencyGraph.css
+++ b/src/components/dashboard/currencyGraph.css
@@ -21,7 +21,10 @@
 }
 
 .errorMessage {
-  margin-top: 60px;
+  margin-top: 5px;
+  & img {
+    height: 60px;
+  }
 }
 
 .stepSwitchWrapper {


### PR DESCRIPTION
### What was the problem?
Not displaying the whole image on a graph when there is no data
### How did I fix it?
Added styles to make an image smaller
### How to test it?
Change the code in `CurrencyGraph.js` so it shows error animation.
Then Go on dashboard and see if you can see whole image
<img width="557" alt="screen shot 2018-05-14 at 07 19 01" src="https://user-images.githubusercontent.com/7786627/39979651-22eb8e5c-5748-11e8-9920-3051c663b032.png">

### Review checklist
- The PR solves #785
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
