### PR TITLE
Fix "Download was started" typo in autoupdater - Closes #807

### DIFF
--- a/app/src/modules/autoUpdater.js
+++ b/app/src/modules/autoUpdater.js
@@ -49,7 +49,7 @@ export default ({ autoUpdater, dialog, win, process, electron }) => {
         if (!updater.error) {
           dialog.showMessageBox({
             title: i18n.t('Dowload started'),
-            message: i18n.t('The download was started. Depending on your internet speed it can take up to several minutes. You will be informed then it is finished and prompted to restart the app.'),
+            message: i18n.t('The download has started. Depending on your internet speed, it can take several minutes. You will be informed when it is finished and be prompted to restart the app.'),
           });
         }
       }, 500);

--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -253,7 +253,7 @@
   "Testnet": "Testnet",
   "Thank you": "Thank you",
   "The Wallet will show your recent transactions.": "The Wallet will show your recent transactions.",
-  "The download was started. Depending on your internet speed it can take up to several minutes. You will be informed then it is finished and prompted to restart the app.": "The download was started. Depending on your internet speed it can take up to several minutes. You will be informed then it is finished and prompted to restart the app.",
+  "The download has started. Depending on your internet speed, it can take several minutes. You will be informed when it is finished and be prompted to restart the app.": "The download has started. Depending on your internet speed, it can take several minutes. You will be informed when it is finished and be prompted to restart the app.",
   "The easiest way to do this is to send LSK to yourself. It will cost you only the usual {{fee}} LSK transaction fee.": "The easiest way to do this is to send LSK to yourself. It will cost you only the usual {{fee}} LSK transaction fee.",
   "There are no {{filterName}} transactions.": "There are no {{filterName}} transactions.",
   "This is not reversible.": "This is not reversible.",


### PR DESCRIPTION
### What was the problem?
Typo in autoupdater
### How did I fix it?
Changed text to `The download has started. Depending on your internet speed, it can take several minutes. You will be informed when it is finished and be prompted to restart the app.`
### How to test it?
Launch autoupdater and check text or check code.
### Review checklist
- The PR solves #807
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
