### PR TITLE
Fix for autoupdate error - Closes #808

### DIFF
--- a/app/src/modules/autoUpdater.test.js
+++ b/app/src/modules/autoUpdater.test.js
@@ -161,7 +161,6 @@ describe('autoUpdater', () => {
     clock.tick(1001);
     ipcRenderer.send('update', { text: 'update' });
     clock.tick(100);
-    expect(close).to.has.been.calledWith();
 
     expect(params.autoUpdater.downloadUpdate).to.have.been.calledWithExactly();
   });

--- a/app/src/modules/updateModal.js
+++ b/app/src/modules/updateModal.js
@@ -30,6 +30,8 @@ export default (electron, releaseNotes, updateCallBack, versions) => {
     });
     win.show();
   }, 1000);
+
+  ipcMain.removeAllListeners('update');
   ipcMain.on('update', () => {
     updateCallBack();
   });

--- a/app/src/modules/updateModal.js
+++ b/app/src/modules/updateModal.js
@@ -31,7 +31,6 @@ export default (electron, releaseNotes, updateCallBack, versions) => {
     win.show();
   }, 1000);
   ipcMain.on('update', () => {
-    win.close();
     updateCallBack();
   });
 };

--- a/app/src/modules/updateModal.test.js
+++ b/app/src/modules/updateModal.test.js
@@ -7,7 +7,6 @@ describe('Electron update modal', () => {
   const updateCallBack = spy();
   const loadURL = spy();
   const show = spy();
-  const close = spy();
   const callbacks = {};
   const events = [];
   const { ipcMain, ipcRenderer } = ipcMock();
@@ -21,7 +20,6 @@ describe('Electron update modal', () => {
         webPreferences,
         loadURL,
         show,
-        close,
         on: (item, callback) => {
           callbacks[item] = callback;
         },
@@ -64,7 +62,6 @@ describe('Electron update modal', () => {
     updateModal(electron, 'test notes', updateCallBack, versions);
     ipcRenderer.send('update', { text: 'update' });
     clock.tick(100);
-    expect(close).to.has.been.calledWith();
     expect(updateCallBack).to.has.been.calledWith();
   });
   it('trigger "will-navigate" shouldn\'t fire "shell.openExternal" on electron when url isn\'t equal getURL', () => {

--- a/app/src/update.html
+++ b/app/src/update.html
@@ -45,6 +45,7 @@
         } 
         function updateApp() {
           ipc.send('update', { text: 'update' });
+          window.close();
         }
         updateElm.addEventListener("mouseup", updateApp, false);
         closeElm.addEventListener("mouseup", closeWindow, false);


### PR DESCRIPTION
### What was the problem?
https://github.com/LiskHQ/lisk-hub/issues/808
### How did I fix it?
Added `window.close();` to UpdateApp
### How to test it?
Click "Update now" after clicking menu -> Help -> "Check for updates..."
### Review checklist
- The PR solves #808
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
