### PR TITLE
Fix the issue with infinite scroll in delegates list - Closes #729

### DIFF
--- a/src/components/votingListView/index.js
+++ b/src/components/votingListView/index.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { translate } from 'react-i18next';
-import { voteToggled, votesFetched, delegatesFetched } from '../../actions/voting';
+import { voteToggled, votesFetched, delegatesFetched, delegatesAdded } from '../../actions/voting';
 import VotingListView from './votingListView';
 
 const mapStateToProps = state => ({
@@ -18,6 +18,9 @@ const mapDispatchToProps = dispatch => ({
   voteToggled: data => dispatch(voteToggled(data)),
   votesFetched: data => dispatch(votesFetched(data)),
   delegatesFetched: data => dispatch(delegatesFetched(data)),
+  delegatesCleared: () => dispatch(delegatesAdded({
+    list: [], totalDelegates: 0, refresh: true,
+  })),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(translate()(VotingListView));

--- a/src/components/votingListView/votingListView.js
+++ b/src/components/votingListView/votingListView.js
@@ -52,6 +52,10 @@ class VotingListView extends React.Component {
     }
   }
 
+  componentWillUnmount() {
+    this.props.delegatesCleared();
+  }
+
   loadVotedDelegates(refresh) {
     /* istanbul-ignore-else */
     if (!this.freezeLoading) {

--- a/test/e2e/explorer.feature
+++ b/test/e2e/explorer.feature
@@ -60,7 +60,7 @@ Feature: Explorer page
     When I fill in "4401082358022424760L" to "search input" field
     And I click "input search button"
     Then I click on "transactions row" element no. 2
-    Then I should see 2 instances of "voter address"
+    Then I should see 33 instances of "voter address"
     When I click "explorer" menu
     When I fill in "2581762640681118072L" to "search input" field
     And I click "input search button"

--- a/test/e2e/step_definitions/generic.step.js
+++ b/test/e2e/step_definitions/generic.step.js
@@ -309,13 +309,5 @@ defineSupportCode(({ Given, When, Then, setDefaultTimeout }) => {
       .catch(error => console.error(`${error}`)); // eslint-disable-line no-console
     optionElem.click().then(callback).catch(callback);
   });
-
-  Then('I click on "{className}" element no. {index}', (className, index, callback) => {
-    browser.sleep(500);
-    const optionElem = element.all(by.css(className)).get(index - 1);
-    browser.wait(EC.presenceOf(optionElem), waitTime)
-      .catch(error => console.error(`${error}`)); // eslint-disable-line no-console
-    optionElem.click().then(callback).catch(callback);
-  });
 });
 


### PR DESCRIPTION
### What was the problem?
The component was designed to start from the top of the list every time it mounts, ut the count of delegates was wrong if it was mounted before and some delegates were already loaded.

### How did I fix it?
I refresh the list everytime the component is mounted.

### How to test it?
You should be able to load more delegates by infinite-scrolling at all times.

### Review checklist
- The PR solves #729 
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
