### PR TITLE
Add new api for delegate search autocomplete - Closes #832

### DIFF
--- a/src/utils/api/search.js
+++ b/src/utils/api/search.js
@@ -5,10 +5,7 @@ import regex from './../../utils/regex';
 const searchAddresses = ({ activePeer, searchTerm }) => new Promise((resolve, reject) =>
   getAccount(activePeer, searchTerm)
     .then(response => resolve({ addresses: [response.account] }))
-    .catch((err) => {
-      console.log('getAccount-->', err);
-      reject({ addresses: [] });
-    }));
+    .catch(() => reject({ addresses: [] })));
 
 const searchDelegates = ({ activePeer, searchTerm }) => new Promise((resolve, reject) =>
   listDelegates(activePeer, {

--- a/src/utils/api/search.js
+++ b/src/utils/api/search.js
@@ -1,62 +1,55 @@
 import { requestToActivePeer } from './peers';
 import regex from './../../utils/regex';
 
-
 export const searchAddresses = ({ activePeer, search }) => new Promise((resolve, reject) => {
-
-  console.log(activePeer, 'accounts', { address: search });
-  requestToActivePeer(activePeer, 'accounts', { address: search })
-    .then(response => resolve({ addresses: response.account }))
-    .catch(() => reject({ addresses: undefined }));
+  return requestToActivePeer(activePeer, 'accounts', {
+    address: search,
+  }).then(response => resolve({ addresses: [response.account] }))
+    .catch(() => reject({ addresses: [] }));
 });
+
 export const searchDelegates = ({ activePeer, search }) => new Promise((resolve, reject) => {
-  requestToActivePeer(activePeer, 'delegates/search', {
+  return requestToActivePeer(activePeer, 'delegates/search', {
     q: search,
     orderBy: 'username:asc',
   }).then(response => resolve({ delegates: response.delegates }))
-    .catch(() => reject({ delegates: undefined }));
+    .catch(() => reject({ delegates: [] }));
 });
+
 export const searchTransactions = ({ activePeer, search }) => new Promise((resolve, reject) => {
-  requestToActivePeer(activePeer, 'transactions/get', {
+  return requestToActivePeer(activePeer, 'transactions/get', {
     id: search,
-  }).then(response => resolve({ transactions: response.transaction }))
-    .catch(() => reject({ transactions: undefined }));
+  }).then(response => resolve({ transactions: [response.transaction] }))
+    .catch(() => reject({ transactions: [] }));
 });
 
 export const getSearches = (search) => {
   let allSearches = [];
   allSearches = search.match(regex.address) ?
-    [...allSearches, searchAddresses(search)] :
+    [...allSearches, searchAddresses] :
     [...allSearches];
-  // if transaction match, we also add address promise, 
-  // (not complete txId can also be a valid address search)
   allSearches = search.match(regex.transactionId) ?
-    [...allSearches, searchAddresses(search), searchTransactions(search)] :
+    [...allSearches, searchTransactions] :
     [...allSearches];
   // allways add delegates promise as they share format (address, tx)
-  allSearches = [...allSearches, searchDelegates(search)];
+  allSearches = [...allSearches, searchDelegates];
   return allSearches;
 };
 
-export const resolveAll = (promises) => {
-  const nonFailingPromises = promises.map((promise) => {
-    const catchedPromise = promise.catch ?
-      promise.catch(error => error) :
-      promise;
-    return catchedPromise;
-  });
-
+export const resolveAll = (activePeer, apiCalls, search) => {
+  const promises = apiCalls.map(apiCall =>
+    apiCall({ activePeer, search })
+      .catch(err => err));
   return new Promise((resolve, reject) => {
-    Promise.all(nonFailingPromises)
+    Promise.all(promises)
       .then(result => resolve(result))
       .catch(error => reject(error));
   });
 };
 
-
 const searchAll = ({ activePeer, search}) => {
-  const promises = getSearches(search);
-  return resolveAll(promises);
+  const apiCalls = getSearches(search);
+  return resolveAll(activePeer, apiCalls, search);
 };
 
 export default searchAll;

--- a/src/utils/api/search.js
+++ b/src/utils/api/search.js
@@ -1,9 +1,11 @@
-import requestToActivePeer from './peers';
+import { requestToActivePeer } from './peers';
 import regex from './../../utils/regex';
 
 
 export const searchAddresses = ({ activePeer, search }) => new Promise((resolve, reject) => {
-  resolve({ addresses: [] });
+  requestToActivePeer(activePeer, 'accounts', { address: search })
+    .then(response => ({ addresses: response.account }))
+    .catch(() => ({ addresses: undefined }));
 });
 export const searchDelegates = ({ activePeer, search }) => new Promise((resolve, reject) => {
   resolve({ delegates: [] });

--- a/src/utils/api/search.js
+++ b/src/utils/api/search.js
@@ -1,0 +1,42 @@
+import requestToActivePeer from './peers';
+import regex from './../../utils/regex';
+
+
+export const searchAddress = ({ activePeer, search }) => new Promise((resolve, reject) => {
+  resolve({ addresses: [] });
+});
+export const searchDelegate = ({ activePeer, search }) => new Promise((resolve, reject) => {
+  resolve({ delegates: [] });
+});
+export const searchTransaction = ({ activePeer, search }) => new Promise((resolve, reject) => {
+  resolve({ transactions: [] });
+});
+
+export const getSearches = (search) => {
+  let allSearches = [];
+  allSearches = search.match(regex.address) ?
+    [...allSearches, searchAddress(search)] :
+    [...allSearches];
+  allSearches = search.match(regex.transactionId) ?
+    [...allSearches, searchTransaction(search)] :
+    [...allSearches];
+  allSearches = [...allSearches, searchDelegate(search)];
+  // eslint-disable-next-line no-confusing-arrow
+  return allSearches;
+};
+
+const searchAll = ({ activePeer, search}) => {
+  const promises = getSearches(search);
+  let results = {};
+  return promises.map(promise =>
+    promise.then((response) => {
+      results = { ...results, response };
+      return results;
+    }).catch((error) => {
+      results = { ...results, error };
+      return results;
+    }),
+  );
+};
+
+export default searchAll;

--- a/src/utils/api/search.js
+++ b/src/utils/api/search.js
@@ -1,23 +1,39 @@
 import { requestToActivePeer } from './peers';
 import regex from './../../utils/regex';
 
+const reducers = {
+  addresses: ['address', 'balance'],
+  delegates: ['username', 'rank', 'address'],
+  transactions: ['id', 'height'],
+};
+const reduceResponseProps = (response, key, reducerKeys) => {
+  const reduced = response.map(result =>
+    Object.keys(result)
+      .filter(objKey => reducerKeys[key].includes(objKey))
+      .reduce((obj, objKey) => {
+        obj[objKey] = result[objKey];
+        return obj;
+      }, {}));
+  return reduced;
+};
+
 export const searchAddresses = ({ activePeer, search }) => new Promise((resolve, reject) =>
   requestToActivePeer(activePeer, 'accounts', {
     address: search,
-  }).then(response => resolve({ addresses: [response.account] }))
+  }).then(response => resolve({ addresses: reduceResponseProps([response.account], 'addresses', reducers) }))
     .catch(() => reject({ addresses: [] })));
 
 export const searchDelegates = ({ activePeer, search }) => new Promise((resolve, reject) =>
   requestToActivePeer(activePeer, 'delegates/search', {
     q: search,
     orderBy: 'username:asc',
-  }).then(response => resolve({ delegates: response.delegates }))
+  }).then(response => resolve({ delegates: reduceResponseProps(response.delegates, 'delegates', reducers) }))
     .catch(() => reject({ delegates: [] })));
 
 export const searchTransactions = ({ activePeer, search }) => new Promise((resolve, reject) =>
   requestToActivePeer(activePeer, 'transactions/get', {
     id: search,
-  }).then(response => resolve({ transactions: [response.transaction] }))
+  }).then(response => resolve({ transactions: reduceResponseProps([response.transaction], 'transactions', reducers) }))
     .catch(() => reject({ transactions: [] })));
 
 export const getSearches = (search) => {

--- a/src/utils/api/search.js
+++ b/src/utils/api/search.js
@@ -1,27 +1,24 @@
 import { requestToActivePeer } from './peers';
 import regex from './../../utils/regex';
 
-export const searchAddresses = ({ activePeer, search }) => new Promise((resolve, reject) => {
-  return requestToActivePeer(activePeer, 'accounts', {
+export const searchAddresses = ({ activePeer, search }) => new Promise((resolve, reject) =>
+  requestToActivePeer(activePeer, 'accounts', {
     address: search,
   }).then(response => resolve({ addresses: [response.account] }))
-    .catch(() => reject({ addresses: [] }));
-});
+    .catch(() => reject({ addresses: [] })));
 
-export const searchDelegates = ({ activePeer, search }) => new Promise((resolve, reject) => {
-  return requestToActivePeer(activePeer, 'delegates/search', {
+export const searchDelegates = ({ activePeer, search }) => new Promise((resolve, reject) =>
+  requestToActivePeer(activePeer, 'delegates/search', {
     q: search,
     orderBy: 'username:asc',
   }).then(response => resolve({ delegates: response.delegates }))
-    .catch(() => reject({ delegates: [] }));
-});
+    .catch(() => reject({ delegates: [] })));
 
-export const searchTransactions = ({ activePeer, search }) => new Promise((resolve, reject) => {
-  return requestToActivePeer(activePeer, 'transactions/get', {
+export const searchTransactions = ({ activePeer, search }) => new Promise((resolve, reject) =>
+  requestToActivePeer(activePeer, 'transactions/get', {
     id: search,
   }).then(response => resolve({ transactions: [response.transaction] }))
-    .catch(() => reject({ transactions: [] }));
-});
+    .catch(() => reject({ transactions: [] })));
 
 export const getSearches = (search) => {
   let allSearches = [];
@@ -47,7 +44,7 @@ export const resolveAll = (activePeer, apiCalls, search) => {
   });
 };
 
-const searchAll = ({ activePeer, search}) => {
+const searchAll = ({ activePeer, search }) => {
   const apiCalls = getSearches(search);
   return resolveAll(activePeer, apiCalls, search);
 };

--- a/src/utils/api/search.js
+++ b/src/utils/api/search.js
@@ -36,18 +36,11 @@ export const searchTransactions = ({ activePeer, search }) => new Promise((resol
   }).then(response => resolve({ transactions: reduceResponseProps([response.transaction], 'transactions', reducers) }))
     .catch(() => reject({ transactions: [] })));
 
-export const getSearches = (search) => {
-  let allSearches = [];
-  allSearches = search.match(regex.address) ?
-    [...allSearches, searchAddresses] :
-    [...allSearches];
-  allSearches = search.match(regex.transactionId) ?
-    [...allSearches, searchTransactions] :
-    [...allSearches];
-  // allways add delegates promise as they share format (address, tx)
-  allSearches = [...allSearches, searchDelegates];
-  return allSearches;
-};
+export const getSearches = search => ([
+  ...(search.match(regex.address) ? [searchAddresses] : []),
+  ...(search.match(regex.transactionId) ? [searchTransactions] : []),
+  searchDelegates, // allways add delegates promise as they share format (address, tx)
+]);
 
 export const resolveAll = (activePeer, apiCalls, search) => {
   const promises = apiCalls.map(apiCall =>

--- a/src/utils/api/search.js
+++ b/src/utils/api/search.js
@@ -3,15 +3,24 @@ import regex from './../../utils/regex';
 
 
 export const searchAddresses = ({ activePeer, search }) => new Promise((resolve, reject) => {
+
+  console.log(activePeer, 'accounts', { address: search });
   requestToActivePeer(activePeer, 'accounts', { address: search })
-    .then(response => ({ addresses: response.account }))
-    .catch(() => ({ addresses: undefined }));
+    .then(response => resolve({ addresses: response.account }))
+    .catch(() => reject({ addresses: undefined }));
 });
 export const searchDelegates = ({ activePeer, search }) => new Promise((resolve, reject) => {
-  resolve({ delegates: [] });
+  requestToActivePeer(activePeer, 'delegates/search', {
+    q: search,
+    orderBy: 'username:asc',
+  }).then(response => resolve({ delegates: response.delegates }))
+    .catch(() => reject({ delegates: undefined }));
 });
 export const searchTransactions = ({ activePeer, search }) => new Promise((resolve, reject) => {
-  resolve({ transactions: [] });
+  requestToActivePeer(activePeer, 'transactions/get', {
+    id: search,
+  }).then(response => resolve({ transactions: response.transaction }))
+    .catch(() => reject({ transactions: undefined }));
 });
 
 export const getSearches = (search) => {

--- a/src/utils/api/search.test.js
+++ b/src/utils/api/search.test.js
@@ -3,7 +3,7 @@ import { stub } from 'sinon';
 import searchAll from './search';
 import * as peersAPI from './peers';
 
-describe.only('Utils: Search', () => {
+describe('Utils: Search', () => {
   let peersAPIStub;
 
   const accountsResponse = { account: { address: '1337L' } };
@@ -45,19 +45,17 @@ describe.only('Utils: Search', () => {
     peersAPIStub.restore();
   });
 
-  it('should search {addresses,delegates} when only address pattern matched', () => {
-    return expect(searchAll({ search: '1337L' })).to.eventually.deep.equal([
+  it('should search {addresses,delegates} when only address pattern matched', () =>
+    expect(searchAll({ search: '1337L' })).to.eventually.deep.equal([
       { addresses: [accountsResponse.account] },
       { delegates: delegatesResponse.delegates },
-    ]);
-  });
+    ]));
 
-  it('should search {transactions,delegates} when only transaction pattern matched', () => {
-    return expect(searchAll({ search: '1337' })).to.eventually.deep.equal([
+  it('should search {transactions,delegates} when only transaction pattern matched', () =>
+    expect(searchAll({ search: '1337' })).to.eventually.deep.equal([
       { transactions: [transactionsResponse.transaction] },
       { delegates: delegatesResponse.delegates },
-    ]);
-  });
+    ]));
 
   it('should still search for {addresses} when failing {delegates} request', () => {
     peersAPIStub.withArgs(undefined, 'delegates/search', delegatesUrlParams).returnsPromise().rejects({ success: false });

--- a/src/utils/api/search.test.js
+++ b/src/utils/api/search.test.js
@@ -52,7 +52,7 @@ describe('Utils: Search', () => {
     getAccountStub.restore();
   });
 
-  it('should search {addresses,delegates} when only address pattern matched', () => 
+  it('should search {addresses,delegates} when only address pattern matched', () =>
     expect(searchAll({ searchTerm: '1337L' })).to.eventually.deep.equal([
       { addresses: [accountsResponse.account] },
       { transactions: [] },

--- a/src/utils/api/search.test.js
+++ b/src/utils/api/search.test.js
@@ -6,11 +6,23 @@ import * as peersAPI from './peers';
 describe('Utils: Search', () => {
   let peersAPIStub;
 
-  const accountsResponse = { account: { address: '1337L' } };
+  const accountsResponse = { account: { address: '1337L', balance: 1110, someOtherProperty: 'other property' } };
+  const accountExpectedResponse = { account: { address: '1337L', balance: 1110 } };
   const accountsUrlParams = { address: '1337L' };
   const accountsUrlParamsTxMatch = { address: '1337' };
 
-  const delegatesResponse = { delegates: [{ username: '1337', rank: 18 }, { username: '1337l', rank: 19 }] };
+  const delegatesResponse = {
+    delegates: [
+      { username: '1337', rank: 18, address: '123456', someOtherProperty: 'other property' },
+      { username: '1337l', rank: 19, address: '123456', someOtherProperty: 'other property' },
+    ],
+  };
+  const delegatesExpectedResponse = {
+    delegates: [
+      { username: '1337', rank: 18, address: '123456' },
+      { username: '1337l', rank: 19, address: '123456' },
+    ],
+  };
   const delegatesUrlParams = {
     q: '1337L',
     orderBy: 'username:asc',
@@ -20,7 +32,8 @@ describe('Utils: Search', () => {
     orderBy: 'username:asc',
   };
 
-  const transactionsResponse = { transaction: { id: '1337' } };
+  const transactionsResponse = { transaction: { id: '1337', height: 99, someOtherProperty: 'other property' } };
+  const transactionsExpectedResponse = { transaction: { id: '1337', height: 99 } };
   const transactionsUrlParams = {
     id: '1337L',
   };
@@ -47,20 +60,20 @@ describe('Utils: Search', () => {
 
   it('should search {addresses,delegates} when only address pattern matched', () =>
     expect(searchAll({ search: '1337L' })).to.eventually.deep.equal([
-      { addresses: [accountsResponse.account] },
-      { delegates: delegatesResponse.delegates },
+      { addresses: [accountExpectedResponse.account] },
+      { delegates: delegatesExpectedResponse.delegates },
     ]));
 
   it('should search {transactions,delegates} when only transaction pattern matched', () =>
     expect(searchAll({ search: '1337' })).to.eventually.deep.equal([
-      { transactions: [transactionsResponse.transaction] },
-      { delegates: delegatesResponse.delegates },
+      { transactions: [transactionsExpectedResponse.transaction] },
+      { delegates: delegatesExpectedResponse.delegates },
     ]));
 
   it('should still search for {addresses} when failing {delegates} request', () => {
     peersAPIStub.withArgs(undefined, 'delegates/search', delegatesUrlParams).returnsPromise().rejects({ success: false });
     return expect(searchAll({ search: '1337L' })).to.eventually.deep.equal([
-      { addresses: [accountsResponse.account] },
+      { addresses: [accountExpectedResponse.account] },
       { delegates: [] },
     ]);
   });
@@ -69,7 +82,7 @@ describe('Utils: Search', () => {
     peersAPIStub.withArgs(undefined, 'accounts', accountsUrlParams).returnsPromise().rejects({ success: false });
     return expect(searchAll({ search: '1337L' })).to.eventually.deep.equal([
       { addresses: [] },
-      { delegates: delegatesResponse.delegates },
+      { delegates: delegatesExpectedResponse.delegates },
     ]);
   });
 
@@ -77,7 +90,7 @@ describe('Utils: Search', () => {
     peersAPIStub.withArgs(undefined, 'transactions/get', transactionsUrlParamsTxMatch).returnsPromise().rejects({ success: false });
     return expect(searchAll({ search: '1337' })).to.eventually.deep.equal([
       { transactions: [] },
-      { delegates: delegatesResponse.delegates },
+      { delegates: delegatesExpectedResponse.delegates },
     ]);
   });
 });

--- a/src/utils/api/search.test.js
+++ b/src/utils/api/search.test.js
@@ -1,0 +1,83 @@
+import { expect } from 'chai';
+import { mock, stub } from 'sinon';
+import * as searchAPI from './search';
+
+describe.only('Utils: Search', () => {
+  let searchAddressesStub;
+  let searchDelegatesStub;
+  let searchTransactionsStub;
+
+  beforeEach(() => {
+    searchAddressesStub = stub(searchAPI, 'searchAddress');
+    searchDelegatesStub = stub(searchAPI, 'searchDelegate');
+    searchTransactionsStub = stub(searchAPI, 'searchTransaction');
+  });
+
+  afterEach(() => {
+    searchAddressesStub.restore();
+    searchDelegatesStub.restore();
+    searchTransactionsStub.restore();
+  });
+
+  describe('On all requests resolved', () => {
+    beforeEach(() => {
+      searchAddressesStub.returnsPromise().resolves({ addresses: [] });
+      searchDelegatesStub.returnsPromise().resolves({ delegates: [] });
+      searchTransactionsStub.returnsPromise().resolves({ transactions: [] });
+    });
+
+    afterEach(() => {
+      searchAddressesStub.restore();
+      searchDelegatesStub.restore();
+      searchTransactionsStub.restore();
+    });
+
+    it('should return {addresses,delegates} promises when only address pattern matched', () => {
+      const promises = searchAPI.default({ activePeer: {}, search: '1337L' });
+      expect(promises).to.have.length(2);
+    });
+
+    it.skip('should return {addresses,transactions,delegates} promises when only transaction pattern matched', () => {
+      const promises = searchAPI.default({ activePeer: {}, search: '1337' });
+      return expect(promises).to.eventually.equal({
+        addresses: [],
+        delegates: [],
+        transactions: [],
+      });
+    });
+  });
+
+  describe.skip('On some requests failed', () => {
+    beforeEach(() => {
+      searchAddressesStub.returnsPromise().resolves({ addresses: [] });
+      searchDelegatesStub.returnsPromise().resolves({ delegates: [] });
+      searchTransactionsStub.returnsPromise().resolves({ transactions: [] });
+    });
+
+    afterEach(() => {
+      searchAddressesStub.restore();
+      searchDelegatesStub.restore();
+      searchTransactionsStub.restore();
+    });
+
+    it('should still return {delegates} promises when addresses request failure', () => {
+      searchAddressesStub.returnsPromise().rejects({ success: false });
+      const promises = searchAPI.default({ activePeer: {}, search: '1337L' });
+      return expect(promises).to.eventually.equal({
+        accounts: { success: false },
+        delegates: [],
+      });
+    });
+
+    it('should still return {address,transactions} promises when delegates request failure', () => {
+      searchDelegatesStub.returnsPromise().rejects({ success: false });
+      const promises = searchAPI.default({ activePeer: {}, search: '1337L' });
+
+      return expect(promises).to.eventually.equal({
+        addresses: [],
+        delegates: { success: false },
+        transactions: [],
+      });
+    });
+  });
+});

--- a/src/utils/api/search.test.js
+++ b/src/utils/api/search.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { stub, match } from 'sinon';
+import { stub } from 'sinon';
 import searchAll from './search';
 import * as peersAPI from './peers';
 
@@ -7,83 +7,79 @@ describe.only('Utils: Search', () => {
   let peersAPIStub;
 
   const accountsResponse = { account: { address: '1337L' } };
-  const accountsUrlParams = accountsResponse.account;
+  const accountsUrlParams = { address: '1337L' };
+  const accountsUrlParamsTxMatch = { address: '1337' };
 
   const delegatesResponse = { delegates: [{ username: '1337', rank: 18 }, { username: '1337l', rank: 19 }] };
   const delegatesUrlParams = {
     q: '1337L',
     orderBy: 'username:asc',
   };
+  const delegatesUrlParamsTxMatch = {
+    q: '1337',
+    orderBy: 'username:asc',
+  };
 
   const transactionsResponse = { transaction: { id: '1337' } };
   const transactionsUrlParams = {
+    id: '1337L',
+  };
+  const transactionsUrlParamsTxMatch = {
     id: '1337',
   };
 
   beforeEach(() => {
     peersAPIStub = stub(peersAPI, 'requestToActivePeer');
-    peersAPIStub.withArgs(match.any, 'accounts', accountsUrlParams).returnsPromise().resolves(accountsResponse);
-    peersAPIStub.withArgs(match.any, 'delegaets/search', delegatesUrlParams).returnsPromise().resolves(delegatesResponse);
-    peersAPIStub.withArgs(match.any, 'transactions/get', transactionsUrlParams).returnsPromise().resolves(transactionsResponse);
+    // address match
+    peersAPIStub.withArgs(undefined, 'accounts', accountsUrlParams).returnsPromise().resolves(accountsResponse);
+    peersAPIStub.withArgs(undefined, 'delegates/search', delegatesUrlParams).returnsPromise().resolves(delegatesResponse);
+    peersAPIStub.withArgs(undefined, 'transactions/get', transactionsUrlParams).returnsPromise().resolves(transactionsResponse);
+
+    // txSearch match
+    peersAPIStub.withArgs(undefined, 'accounts', accountsUrlParamsTxMatch).returnsPromise().resolves(accountsResponse);
+    peersAPIStub.withArgs(undefined, 'delegates/search', delegatesUrlParamsTxMatch).returnsPromise().resolves(delegatesResponse);
+    peersAPIStub.withArgs(undefined, 'transactions/get', transactionsUrlParamsTxMatch).returnsPromise().resolves(transactionsResponse);
   });
 
   afterEach(() => {
     peersAPIStub.restore();
   });
 
-  it('should return {addresses,delegates} promises when only address pattern matched', () => {
+  it('should search {addresses,delegates} when only address pattern matched', () => {
     return expect(searchAll({ search: '1337L' })).to.eventually.deep.equal([
-      { addresses: [accountsResponse] },
+      { addresses: [accountsResponse.account] },
       { delegates: delegatesResponse.delegates },
     ]);
   });
 
-  it('should return {addresses,transactions,delegates} promises when only transaction pattern matched', () => {
+  it('should search {transactions,delegates} when only transaction pattern matched', () => {
     return expect(searchAll({ search: '1337' })).to.eventually.deep.equal([
-      { addresses: [] },
-      { transactions: [] },
+      { transactions: [transactionsResponse.transaction] },
+      { delegates: delegatesResponse.delegates },
+    ]);
+  });
+
+  it('should still search for {addresses} when failing {delegates} request', () => {
+    peersAPIStub.withArgs(undefined, 'delegates/search', delegatesUrlParams).returnsPromise().rejects({ success: false });
+    return expect(searchAll({ search: '1337L' })).to.eventually.deep.equal([
+      { addresses: [accountsResponse.account] },
       { delegates: [] },
     ]);
   });
 
-  it.skip('should still return {delegates} promises when addresses request failure', () => {
-
-    return expect(searchAPI.resolveAll([
-      searchAPI.searchAddresses({}),
-      searchAPI.searchDelegates({}),
-      searchAPI.searchTransactions({}),
-    ])).to.eventually.deep.equal([
-      { addresses: undefined },
-      { delegates: [] },
-      { transactions: [] },
+  it('should still search for {delegates} when failing {addresses} request', () => {
+    peersAPIStub.withArgs(undefined, 'accounts', accountsUrlParams).returnsPromise().rejects({ success: false });
+    return expect(searchAll({ search: '1337L' })).to.eventually.deep.equal([
+      { addresses: [] },
+      { delegates: delegatesResponse.delegates },
     ]);
   });
 
-  it.skip('should still return {address,transactions} promises when delegates request failure', () => {
-    searchDelegatesStub.returnsPromise().rejects({ delegates: undefined });
-
-    return expect(searchAPI.resolveAll([
-      searchAPI.searchAddresses({}),
-      searchAPI.searchDelegates({}),
-      searchAPI.searchTransactions({}),
-    ])).to.eventually.deep.equal([
-      { addresses: [] },
-      { delegates: undefined },
+  it('should still search for {delegates} when failing {transactions} request', () => {
+    peersAPIStub.withArgs(undefined, 'transactions/get', transactionsUrlParamsTxMatch).returnsPromise().rejects({ success: false });
+    return expect(searchAll({ search: '1337' })).to.eventually.deep.equal([
       { transactions: [] },
-    ]);
-  });
-
-  it.skip('should still return {address,delegates} promises when transactions request failure', () => {
-    searchTransactionsStub.returnsPromise().rejects({ transactions: undefined });
-
-    return expect(searchAPI.resolveAll([
-      searchAPI.searchAddresses({}),
-      searchAPI.searchDelegates({}),
-      searchAPI.searchTransactions({}),
-    ])).to.eventually.deep.equal([
-      { addresses: [] },
-      { delegates: [] },
-      { transactions: undefined },
+      { delegates: delegatesResponse.delegates },
     ]);
   });
 });

--- a/src/utils/api/search.test.js
+++ b/src/utils/api/search.test.js
@@ -33,17 +33,20 @@ describe.only('Utils: Search', () => {
     });
 
     it('should return {addresses,delegates} promises when only address pattern matched', () => {
-      const promises = searchAPI.default({ activePeer: {}, search: '1337L' });
-      expect(promises).to.have.length(2);
+      const promises = searchAPI.getSearches('1337L');
+      return expect(Promise.all(promises)).to.eventually.deep.equal([
+        { addresses: [] },
+        { delegates: [] },
+      ]);
     });
 
-    it.skip('should return {addresses,transactions,delegates} promises when only transaction pattern matched', () => {
-      const promises = searchAPI.default({ activePeer: {}, search: '1337' });
-      return expect(promises).to.eventually.equal({
-        addresses: [],
-        delegates: [],
-        transactions: [],
-      });
+    it('should return {addresses,transactions,delegates} promises when only transaction pattern matched', () => {
+      const promises = searchAPI.getSearches('1337');
+      return expect(Promise.all(promises)).to.eventually.deep.equal([
+        { addresses: [] },
+        { transactions: [] },
+        { delegates: [] },
+      ]);
     });
   });
 


### PR DESCRIPTION
### What was the problem?
- See #832
### How did I fix it?
- Implement a promise.all pattern to retrieve accounts, delegates, transactions, where if one request fails the remaining ones still resolve. 
- Reduce responses to only include properties used for autosuggest
- use three object keys for results 
```
{ 
addresses: ...
transactions: ...
delegates: ...
}
```
### How to test it?
- ```npm run test```
### Review checklist
- The PR solves #832
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
