### PR TITLE
Vendor prefixes by stylelint - Closes

### DIFF
--- a/config/webpack.config.react.js
+++ b/config/webpack.config.react.js
@@ -123,7 +123,7 @@ module.exports = {
       template: './src/index.html',
       VERSION: bundleVersion,
       inject: false,
-      // inlineSource: '.(css)$',
+      inlineSource: '.(css)$',
     }),
     new HtmlWebpackInlineSourcePlugin(),
     new I18nScannerPlugin({

--- a/config/webpack.config.react.js
+++ b/config/webpack.config.react.js
@@ -110,6 +110,7 @@ module.exports = {
           'unit-whitelist': ['px', 'deg', '%', 'ms', 's'],
           'length-zero-no-unit': null,
           'at-rule-no-unknown': null,
+          'selector-no-vendor-prefix': true,
         },
       },
     }),
@@ -122,7 +123,7 @@ module.exports = {
       template: './src/index.html',
       VERSION: bundleVersion,
       inject: false,
-      inlineSource: '.(css)$',
+      // inlineSource: '.(css)$',
     }),
     new HtmlWebpackInlineSourcePlugin(),
     new I18nScannerPlugin({

--- a/src/components/transactions/delegateStatistics.css
+++ b/src/components/transactions/delegateStatistics.css
@@ -80,14 +80,6 @@
     border-bottom: solid 2px transparent;
     transition: all ease 250ms;
 
-    &:-moz-placeholder,
-    &::-moz-placeholder,
-    &::-webkit-input-placeholder {
-      font-weight: 400;
-      color: var(--color-grayscale-medium);
-      font-size: 15px;
-    }
-
     &.desktopInput {
       display: inline-block;
     }

--- a/src/components/votingListView/votingHeader.css
+++ b/src/components/votingListView/votingHeader.css
@@ -103,14 +103,6 @@
     border-bottom: solid 1px transparent;
     transition: all ease 250ms;
 
-    &:-moz-placeholder,
-    &::-moz-placeholder,
-    &::-webkit-input-placeholder {
-      font-weight: 400;
-      color: var(--color-grayscale-medium);
-      font-size: 15px;
-    }
-
     &.desktopInput {
       display: inline-block;
     }


### PR DESCRIPTION
### What was the problem?
We shouldn't use browser prefix in css base on project style guide
### How did I fix it?
Add a new rule to stylelint config witch prevents this problem before happening

### Review checklist
- The PR solves #806
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
