### PR TITLE
Fix incorrect symbol for outgoing transactions in transaction detail - Closes #850

### DIFF
--- a/src/components/singleTransaction/index.js
+++ b/src/components/singleTransaction/index.js
@@ -51,6 +51,7 @@ class SingleTransaction extends React.Component {
             <div className={styles.detailsWrapper}>
               <TransactionDetails
                 transaction={this.props.transaction}
+                address={this.props.address}
                 t={this.props.t}
                 match={this.props.match} />
             </div>
@@ -64,6 +65,7 @@ class SingleTransaction extends React.Component {
 }
 
 const mapStateToProps = state => ({
+  address: state.account.address,
   transaction: state.transaction,
   peers: state.peers,
 });


### PR DESCRIPTION
### What was the problem?
Outgoing transactions had a `+` symbol in the single transaction explorer view

### How did I fix it?
By adding the account address in the singleTransaction component

### How to test it?
View an outgoing transaction in the explorer

### Review checklist
- The PR solves #850
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
