### PR TITLE
Fix not clearing input after sending via "send to this address" - Closes #847

### DIFF
--- a/src/components/resultBox/resultBox.js
+++ b/src/components/resultBox/resultBox.js
@@ -47,6 +47,7 @@ class ResultBox extends React.Component {
                 this.props.finalCallback();
               }
               this.props.reset();
+              this.props.history.replace(this.props.history.location.pathname);
             }}>
             {this.props.t('Okay')}
           </Button>


### PR DESCRIPTION
### What was the problem?
Wallet: 'Send to address' field was still filled after sending via 'send to this address' in Explorer
### How did I fix it?
Removed parameter from URL after sending transaction
### How to test it?
Go to explorer, find `5201600508578320196L`, click in 'send to this address', send any LSK amount, check if 'Send to address' contains `5201600508578320196L`address
### Review checklist
- The PR solves #847 
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
