### PR TITLE
Currency set in converter is not remembered  - Closes #846

### DIFF
--- a/src/components/converter/index.js
+++ b/src/components/converter/index.js
@@ -2,6 +2,8 @@ import React from 'react';
 import liskServiceApi from '../../utils/api/liskService';
 import Input from '../toolbox/inputs/input';
 import { fromRawLsk } from '../../utils/lsk';
+import localJSONStorage from '../../utils/localJSONStorage';
+
 import fees from './../../constants/fees';
 
 import styles from './converter.css';
@@ -17,6 +19,11 @@ class Converter extends React.Component {
       currencies: ['USD', 'EUR'],
     };
     this.fee = fees.send;
+
+    const localStorageCurrency = localJSONStorage.get('currency', '');
+    if (localStorageCurrency) {
+      this.selectActive(localStorageCurrency);
+    }
     this.updateData();
   }
 
@@ -37,6 +44,7 @@ class Converter extends React.Component {
 
       currencies.push(currencies.shift(currencies[currencyIndex]));
       this.setState({ currencies });
+      localJSONStorage.set('currency', currency);
     }
   }
 

--- a/src/components/converter/index.test.js
+++ b/src/components/converter/index.test.js
@@ -11,9 +11,12 @@ import Converter from './index';
 describe('Converter', () => {
   let explorereApiMock;
   let wrapper;
+  const storage = {};
 
   beforeEach(() => {
     explorereApiMock = sinon.stub(liskServiceApi, 'getPriceTicker').returnsPromise();
+    window.localStorage.getItem = key => (storage[key]);
+    window.localStorage.setItem = (key, item) => { storage[key] = item; };
   });
 
   afterEach(() => {
@@ -50,7 +53,7 @@ describe('Converter', () => {
     expect(wrapper.state('currencies')[0]).to.have.equal('EUR');
   });
 
-  it('should convert price to USD', () => {
+  it('should convert price to EUR from localStorage', () => {
     const props = {
       t: () => {},
       value: 2,
@@ -66,7 +69,7 @@ describe('Converter', () => {
     explorereApiMock.resolves({ LSK: { USD: 123, EUR: 12 } });
     wrapper.update();
     expect(wrapper.state('LSK')).to.have.deep.equal({ USD: 123, EUR: 12 });
-    expect(wrapper.find('.converted-price').at(0).text()).to.have.equal('~ 246.00');
+    expect(wrapper.find('.converted-price').at(0).text()).to.have.equal('~ 24.00');
   });
 });
 


### PR DESCRIPTION
### What was the problem?
The currency was not saved
### How did I fix it?
Added an active converter to localStorage
### How to test it?
Find currency converter, change currency to `EUR`, refresh page and check if currency is still `EUR`
### Review checklist
- The PR solves #846
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
