### PR TITLE
Close transaction detail on menu click - Closes #843

### DIFF
--- a/src/components/transactions/transactionDetailView.js
+++ b/src/components/transactions/transactionDetailView.js
@@ -22,13 +22,16 @@ class TransactionsDetailView extends React.Component {
     const params = new URLSearchParams(search);
     const transactionId = params.get('id');
 
-    if (props.peers.data &&
-      transactionId) {
+    if (props.peers.data && transactionId) {
       this.props.loadTransaction({
         activePeer: props.peers.data,
         id: transactionId,
       });
     }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (!nextProps.location.search) this.props.prevStep();
   }
 
   getVoters(dataName) {
@@ -118,10 +121,8 @@ class TransactionsDetailView extends React.Component {
           this.props.prevStep ?
             <header>
               <h3>
-                <small className={`${styles.backButton} transaction-details-back-button`} onClick={() => {
-                  this.props.history.push(this.props.history.location.pathname);
-                  this.props.prevStep();
-                }}>
+                <small className={`${styles.backButton} transaction-details-back-button`}
+                  onClick={() => this.props.history.push(this.props.history.location.pathname)}>
                   <FontIcon className={`${styles.arrow}`} value='arrow-left'/>
                   <span className={`${styles.text}`}>{this.props.t('Back to overview')}</span>
                 </small>

--- a/src/components/transactions/transactionDetailView.test.js
+++ b/src/components/transactions/transactionDetailView.test.js
@@ -35,14 +35,14 @@ describe('TransactionDetailView', () => {
         id: '',
       },
       match: { params: {} },
-      history: { push: () => {}, location: { search: '' } },
+      history: { push: spy(), location: { search: '' } },
     };
     const wrapper = mountWithContext(<TransactionDetailView {...props} />, context);
     const expectedValue = /flexboxgrid__row/g;
     const html = wrapper.html();
     expect(html.match(expectedValue)).to.have.lengthOf(6);
     wrapper.find('.transaction-details-back-button').simulate('click');
-    expect(props.prevStep).to.have.been.calledWith();
+    expect(props.history.push).to.have.been.calledWith();
   });
 
   it('should display 2 voter-address Links', () => {


### PR DESCRIPTION
### What was the problem?
Clicking on wallet (icon in sidebar) did not close transaction detail or reset the view

### How did I fix it?
By checking if the props changed and then going to the previous step

### Review checklist
- The PR solves #843
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
