### PR TITLE
Fix liskID creator not scrollable - Closes #839

### DIFF
--- a/src/components/passphrase/create/create.css
+++ b/src/components/passphrase/create/create.css
@@ -15,6 +15,7 @@
   margin-right: 0px;
   margin-left: 0px;
   overflow-y: auto;
+  position: relative;
 }
 
 .missing {


### PR DESCRIPTION
### What was the problem?
The Lisk ID creator screen is not scrollable. This makes an access to Get Passphrase key impossible on smaller screens
### How did I fix it?
Enabled scroll option
### How to test it?
Run the Hub on a small screen ex. 1024x768. Create Lisk ID. Get Passphrase should be accessible.
### Review checklist
- The PR solves #839
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
