### PR TITLE
Switch 1 month graph option to 2 weeks - Closes #800

### DIFF
--- a/src/components/dashboard/currencyGraph.js
+++ b/src/components/dashboard/currencyGraph.js
@@ -137,7 +137,7 @@ const steps = [
   },
   // Not enough data from endpoint to make 1 month (max 19 days)
   {
-    title: '14d',
+    title: '2w',
     span: 'day',
     length: 14,
     timeFormat: {

--- a/src/components/dashboard/currencyGraph.js
+++ b/src/components/dashboard/currencyGraph.js
@@ -135,10 +135,11 @@ const steps = [
       minUnit: 'day',
     },
   },
+  // Not enough data from endpoint to make 1 month (max 19 days)
   {
-    title: '1m',
+    title: '14d',
     span: 'day',
-    length: 30,
+    length: 14,
     timeFormat: {
       minUnit: 'day',
     },


### PR DESCRIPTION
### What was the problem?
The graph didn't have enough data for 1 month
### How did I fix it?
Changed 1 month to 14 days
### How to test it?
Go to dashboard and check 14 days graph option
### Review checklist
- The PR solves #800
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
