### PR TITLE
Fix unstable e2e tests - Closes #824

### DIFF
--- a/src/components/transactions/transactionDetailView.js
+++ b/src/components/transactions/transactionDetailView.js
@@ -31,7 +31,7 @@ class TransactionsDetailView extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (!nextProps.location.search) this.props.prevStep();
+    if (nextProps.location && !nextProps.location.search) this.props.prevStep();
   }
 
   getVoters(dataName) {

--- a/test/e2e/explorer.feature
+++ b/test/e2e/explorer.feature
@@ -57,9 +57,8 @@ Feature: Explorer page
     Given I'm logged in as "genesis"
     And I wait 1 seconds
     When I click "explorer" menu
-    When I fill in "4401082358022424760L" to "search input" field
+    When I fill in "18294919898268153226" to "search input" field
     And I click "input search button"
-    Then I click on "transactions row" element no. 2
     Then I should see 33 instances of "voter address"
     When I click "explorer" menu
     When I fill in "2581762640681118072L" to "search input" field

--- a/test/e2e/registerDelegate.feature
+++ b/test/e2e/registerDelegate.feature
@@ -11,7 +11,7 @@ Feature: Register delegate
     And I click "second-passphrase-next"
     And I wait 1 seconds
     And I click "confirm-delegate-registration"
-    And I wait 10 seconds
+    And I wait 15 seconds
     Then I should see text "Success!" in "success-header" element
     Then I should see text "Your registration is secured on the blockchain" in "success-description" element
     And I click "registration-success"

--- a/test/e2e/registerSecondPassphrase.feature
+++ b/test/e2e/registerSecondPassphrase.feature
@@ -14,7 +14,7 @@ Feature: Register second passphrase
     And I remember passphrase, click "yes its safe button", choose missing words
     And I wait 1 seconds
     And I swipe "confirm checkbox" to right
-    And I wait 10 seconds
+    And I wait 15 seconds
     And I click "get to your dashboard button"
     And I fill in "1" to "amount" field
     And I fill in "94495548317450502L" to "recipient" field

--- a/test/e2e/send.feature
+++ b/test/e2e/send.feature
@@ -11,7 +11,7 @@ Feature: Send dialog
     And I wait 1 seconds
     Then I should see text "Transaction is being processed and will be confirmed. It may take up to 15 minutes to be secured in the blockchain." in "result box message" element
     And I should see 5 rows
-    And I wait 10 seconds
+    And I wait 15 seconds
     When I click "seeAllLink"
     And I should see 25 rows
     When I scroll to the bottom of "transaction results"
@@ -21,7 +21,7 @@ Feature: Send dialog
   # and is failing when running isolated
   @advanced @pending
   Scenario: should be able to init account if needed
-    Given I wait 10 seconds
+    Given I wait 15 seconds
     And I'm logged in as "without initialization"
     Then I should see "account initialization" element
     When I click "account init button"


### PR DESCRIPTION
### What was the problem?
 - We needed to wait 15sec to ensure Tx is confirmed.
 - Because of the equal timestamps, The result of sorting of transactions isn't always the same. making the e2e tests unstable.

### How did I fix it?
 - Increased the waiting time to 15sec for transaction confirmation.
 - Searched for Tx ID instead of Lisk Id and clicking the second transaction.

### How to test it?
The e2e tests shouldn't fail 
https://jenkins.lisk.io/job/lisk-hub/job/PR-861/

### Review checklist
- The PR solves #824 
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)