### PR TITLE
Prevent page-not-found after auto update on windows - Closes #870

### DIFF
--- a/src/utils/externalLinks.js
+++ b/src/utils/externalLinks.js
@@ -6,17 +6,20 @@ export default {
 
     if (ipc) {
       ipc.on('openUrl', (action, url) => {
-        const normalizedUrl = url
-          .replace('lisk://', '/')
-          .replace('/main/transactions/send', '/wallet')
-          .replace('/main/voting/vote', '/delegates/vote');
-        history.push(normalizedUrl);
-        history.replace(normalizedUrl);
-        // Tests are throwing error which cannot be handled
-        // ERROR Some of your tests did a full page reload!
-        /* istanbul ignore if  */
-        if (normalizedUrl.includes('votes')) {
-          window.location.reload();
+        const protocol = url.split(':/')[0];
+        let normalizedUrl = url.split(':/')[1];
+        if (protocol && protocol.toLowerCase() === 'lisk' && normalizedUrl) {
+          normalizedUrl = normalizedUrl
+            .replace('/main/transactions/send', '/wallet')
+            .replace('/main/voting/vote', '/delegates/vote');
+          history.push(normalizedUrl);
+          history.replace(normalizedUrl);
+          // Tests are throwing error which cannot be handled
+          // ERROR Some of your tests did a full page reload!
+          /* istanbul ignore if  */
+          if (normalizedUrl.includes('votes')) {
+            window.location.reload();
+          }
         }
       });
     }


### PR DESCRIPTION
### What was the problem?
Autoupdater opened the app with `--updated` param which was transformed into url path

### How did I fix it?
Check that the param contains `lisk://` and only then use it as url path
### How to test it?
That's close to impossible because you need the change to be released.


### Review checklist
- The PR solves #870
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
