### PR TITLE
Fix sign message shouldn't ask for passphrase if account is unlocked - Closes #864

### DIFF
--- a/src/components/signMessage/confirmMessage.js
+++ b/src/components/signMessage/confirmMessage.js
@@ -24,6 +24,12 @@ class ConfirmMessage extends React.Component {
     };
   }
 
+  componentWillMount() {
+    if (this.props.account.passphrase) {
+      this.signMessage();
+    }
+  }
+
   handleChange(name, value, error) {
     this.setState({
       [name]: {

--- a/src/components/signMessage/signMessage.test.js
+++ b/src/components/signMessage/signMessage.test.js
@@ -62,12 +62,23 @@ describe('SignMessage', () => {
       expect(history.goBack).to.have.been.calledWith();
     });
 
-    it('should render ConfirmMessage step "verify"', () => {
+    it('should render step "done" when account unlocked', () => {
       wrapper.find('Input').props().onChange('message', '123aaa');
       wrapper.update();
       const nextButton = wrapper.find('button');
       nextButton.first().simulate('click');
-      expect(wrapper).to.have.descendants('ConfirmMessage');
+      expect(wrapper).to.have.descendants('.account-information-address');
+    });
+
+    it('should render PassphraseInput step "verify" when account locked', () => {
+      const propsWithoutPassprase = { ...props };
+      delete propsWithoutPassprase.account.passphrase;
+      wrapper = mount(<SignMessage {...propsWithoutPassprase} />, options);
+      wrapper.find('Input').props().onChange('message', '123aaa');
+      wrapper.update();
+      const nextButton = wrapper.find('button');
+      nextButton.first().simulate('click');
+      expect(wrapper).to.have.descendants('PassphraseInput');
     });
 
     it('should render ConfirmMessage step "done"', () => {


### PR DESCRIPTION
### What was the problem?
sign message shouldn't ask for a passphrase if an account is unlocked
### How did I fix it?
Added condition for checking if an account is unlocked
### How to test it?
Go to `http://localhost:8080/#/sign-message` and go through all steps while an account is unlocked.
It should not ask for password.
### Review checklist
- The PR solves #864 
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
