### PR TITLE
Random failing e2etests due to reseting transaction filter - Closes #875

### DIFF
--- a/src/components/transactions/explorerTransactions/explorerTransactions.js
+++ b/src/components/transactions/explorerTransactions/explorerTransactions.js
@@ -4,6 +4,7 @@ import styles from './../transactions.css';
 import TransactionOverview from './../transactionOverview';
 import TransactionDetailView from './../transactionDetailView';
 import Box from './../../box';
+import txFilters from './../../../constants/transactionFilters';
 
 class ExplorerTransactions extends React.Component {
   onInit() {
@@ -15,7 +16,7 @@ class ExplorerTransactions extends React.Component {
       activePeer: this.props.activePeer,
       address: this.props.address,
       limit: 25,
-      filter: this.props.activeFilter,
+      filter: txFilters.all,
     });
   }
   onLoadMore() {

--- a/src/components/transactions/transactionOverview.js
+++ b/src/components/transactions/transactionOverview.js
@@ -14,10 +14,6 @@ class TransactionsOverview extends React.Component {
     this.props.onInit();
   }
 
-  componentWillUnmount() {
-    this.setTransactionsFilter(txFilters.all);
-  }
-
   loadMore() {
     if (this.canLoadMore) {
       this.canLoadMore = false;

--- a/src/components/transactions/walletTransactions/index.js
+++ b/src/components/transactions/walletTransactions/index.js
@@ -1,10 +1,11 @@
 import { connect } from 'react-redux';
 import { translate } from 'react-i18next';
 import { withRouter } from 'react-router-dom';
-import { loadTransactions, transactionsRequested, transactionsFilterSet } from '../../../actions/transactions';
+import { transactionsRequested, transactionsFilterSet } from '../../../actions/transactions';
 import { accountVotersFetched, accountVotesFetched } from '../../../actions/account';
 import WalletTransactions from './walletTransactions';
 
+/* istanbul ignore next */
 const mapStateToProps = state => ({
   activePeer: state.peers.data,
   account: state.account,
@@ -18,7 +19,6 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  loadTransactions: data => dispatch(loadTransactions(data)),
   transactionsRequested: data => dispatch(transactionsRequested(data)),
   transactionsFilterSet: data => dispatch(transactionsFilterSet(data)),
   accountVotersFetched: data => dispatch(accountVotersFetched(data)),

--- a/src/components/transactions/walletTransactions/index.test.js
+++ b/src/components/transactions/walletTransactions/index.test.js
@@ -57,6 +57,7 @@ describe('WalletTransactions Component', () => {
       activePeer: match.any,
       address: accounts.genesis.address,
       limit: 25,
+      filter: txFilters.all,
     }).returnsPromise().resolves({ transactions: [{ id: 'Some ID' }], count: 1000 });
 
 

--- a/src/components/transactions/walletTransactions/walletTransactions.js
+++ b/src/components/transactions/walletTransactions/walletTransactions.js
@@ -4,13 +4,15 @@ import styles from './../transactions.css';
 import TransactionOverview from './../transactionOverview';
 import TransactionDetailView from './../transactionDetailView';
 import Box from './../../box';
+import txFilters from './../../../constants/transactionFilters';
 
 class WalletTransactions extends React.Component {
   onInit() {
-    this.props.loadTransactions({
+    this.props.transactionsFilterSet({
       activePeer: this.props.activePeer,
       address: this.props.account.address,
-      publicKey: this.props.account.publicKey,
+      limit: 25,
+      filter: txFilters.all,
     });
 
     if (this.props.account.isDelegate &&
@@ -22,14 +24,14 @@ class WalletTransactions extends React.Component {
       });
       this.props.accountVotesFetched({
         activePeer: this.props.activePeer,
-        address: this.props.address,
+        address: this.props.account.address,
       });
     }
   }
   onLoadMore() {
     this.props.transactionsRequested({
       activePeer: this.props.activePeer,
-      address: this.props.address,
+      address: this.props.account.address,
       limit: 25,
       offset: this.props.transactions.length,
       filter: this.props.activeFilter,
@@ -38,7 +40,7 @@ class WalletTransactions extends React.Component {
   onFilterSet(filter) {
     this.props.transactionsFilterSet({
       activePeer: this.props.activePeer,
-      address: this.props.address,
+      address: this.props.account.address,
       limit: 25,
       filter,
     });

--- a/src/components/transactions/walletTransactions/walletTransactions.js
+++ b/src/components/transactions/walletTransactions/walletTransactions.js
@@ -24,14 +24,14 @@ class WalletTransactions extends React.Component {
       });
       this.props.accountVotesFetched({
         activePeer: this.props.activePeer,
-        address: this.props.account.address,
+        address: this.props.address,
       });
     }
   }
   onLoadMore() {
     this.props.transactionsRequested({
       activePeer: this.props.activePeer,
-      address: this.props.account.address,
+      address: this.props.address,
       limit: 25,
       offset: this.props.transactions.length,
       filter: this.props.activeFilter,
@@ -40,7 +40,7 @@ class WalletTransactions extends React.Component {
   onFilterSet(filter) {
     this.props.transactionsFilterSet({
       activePeer: this.props.activePeer,
-      address: this.props.account.address,
+      address: this.props.address,
       limit: 25,
       filter,
     });

--- a/test/e2e/registerDelegate.feature
+++ b/test/e2e/registerDelegate.feature
@@ -11,7 +11,7 @@ Feature: Register delegate
     And I click "second-passphrase-next"
     And I wait 1 seconds
     And I click "confirm-delegate-registration"
-    And I wait 10 seconds
+    And I wait 15 seconds
     Then I should see text "Success!" in "success-header" element
     Then I should see text "Your registration is secured on the blockchain" in "success-description" element
     And I click "registration-success"

--- a/test/integration/wallet.test.js
+++ b/test/integration/wallet.test.js
@@ -339,9 +339,9 @@ describe('@integration: Wallet', () => {
 
     describe('Scenario: should allow to view transactions', () => {
       step('Given I\'m on "wallet" as "genesis" account', () => setupStep('genesis'));
-      step('Then I should see 50 rows', () => helper.shouldSeeCountInstancesOf(50, 'TransactionRow'));
+      step('Then I should see 25 rows', () => helper.shouldSeeCountInstancesOf(25, 'TransactionRow'));
       step('When I scroll to the bottom of "transactions box"', () => { wrapper.find('Waypoint').props().onEnter(); });
-      step('Then I should see 75 rows', () => { wrapper.update(); helper.shouldSeeCountInstancesOf(75, 'TransactionRow'); });
+      step('Then I should see 50 rows', () => { wrapper.update(); helper.shouldSeeCountInstancesOf(50, 'TransactionRow'); });
     });
 
     describe.skip('Scenario: should allow to filter transactions', () => {


### PR DESCRIPTION
### What was the problem?
- there is logic to reset a filter after component will unmount, 
- when reseting the filter a request is made, 
- this request happens when e.g. changing the address searched, therefore  in this scenario what happens is:

- search url changes A-> B
- componentWillUnmount triggers request to load transacions of A
- component constructor triggers load transactions request with B
- load transactions B resolves and updates store
- load transactions A resolves and updates store clearing results for B
### How did I fix it?

- remove reseting filter, 
- separate issue must address reseting the filter

### How to test it?

### Review checklist
- The PR solves #875 
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
