### PR TITLE
Add hash to icons - Closes #871

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -37,13 +37,16 @@ module.exports = {
         test: /\.(eot|svg|ttf|woff|woff2)$/,
         exclude: [/images/],
         options: {
-          name: '[path][name].[ext]',
+          name: '[path][name]-[hash:6].[ext]',
         },
         loader: 'file-loader',
       },
       {
         test: /\.(png|svg)$/,
         exclude: [/fonts/],
+        options: {
+          name: '[path][name].[ext]',
+        },
         loader: 'url-loader',
       },
       {

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -44,9 +44,6 @@ module.exports = {
       {
         test: /\.(png|svg)$/,
         exclude: [/fonts/],
-        options: {
-          name: '[path][name].[ext]',
-        },
         loader: 'url-loader',
       },
       {


### PR DESCRIPTION
### What was the problem?
Icons got cached
### How did I fix it?
Added hash to icons url
### How to test it?
![screen shot 2018-06-04 at 17 50 56](https://user-images.githubusercontent.com/7786627/40927805-f49496aa-681f-11e8-90ba-9f69b8289d53.png)

### Review checklist
- The PR solves #871 
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
