### PR TITLE
Refactor api calls in middlewares - Closes #770

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -113,6 +113,18 @@ export const secondPassphraseRegistered = ({
     dispatch(passphraseUsed(passphrase));
   };
 
+
+export const updateDelegateAccount = ({ activePeer, publicKey }) =>
+  (dispatch) => {
+    getDelegate(activePeer, { publicKey })
+      .then((delegateData) => {
+        dispatch(accountUpdated(Object.assign(
+          {},
+          { delegate: delegateData.delegate, isDelegate: true },
+        )));
+      });
+  };
+
 /**
  *
  */

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -2,9 +2,10 @@ import i18next from 'i18next';
 import actionTypes from '../constants/actions';
 import { setSecondPassphrase, getAccount } from '../utils/api/account';
 import { registerDelegate, getDelegate, getVotes, getVoters } from '../utils/api/delegate';
-import { loadTransactionsFinish } from './transactions';
+import { loadTransactionsFinish, transactionsUpdated } from './transactions';
 import { delegateRegisteredFailure } from './delegate';
 import { errorAlertDialogDisplayed } from './dialog';
+import { activePeerUpdate } from './peers';
 import Fees from '../constants/fees';
 import transactionTypes from '../constants/transactionTypes';
 
@@ -159,7 +160,6 @@ export const loadAccount = ({
   transactionsResponse,
   isSameAccount,
 }) =>
-
   (dispatch) => {
     getAccount(activePeer, address)
       .then((response) => {
@@ -183,4 +183,47 @@ export const loadAccount = ({
         }
         dispatch(loadTransactionsFinish(accountDataUpdated));
       });
+  };
+
+export const updateTransactionsIfNeeded = ({ transactions, activePeer, account }, windowFocus) =>
+  (dispatch) => {
+    const hasRecentTransactions = txs => (
+      txs.confirmed.filter(tx => tx.confirmations < 1000).length !== 0 ||
+      txs.pending.length !== 0
+    );
+
+    if (windowFocus || !hasRecentTransactions(transactions)) {
+      const { filter } = transactions;
+      const address = transactions.account ? transactions.account.address : account.address;
+
+      dispatch(transactionsUpdated({
+        pendingTransactions: transactions.pending,
+        activePeer,
+        address,
+        limit: 25,
+        filter,
+      }));
+    }
+  };
+
+export const accountDataUpdated = ({
+  peers, account, windowIsFocused, transactions,
+}) =>
+  (dispatch) => {
+    getAccount(peers.data, account.address).then((result) => {
+      if (result.balance !== account.balance) {
+        dispatch(updateTransactionsIfNeeded(
+          {
+            transactions,
+            activePeer: peers.data,
+            account,
+          },
+          !windowIsFocused,
+        ));
+      }
+      dispatch(accountUpdated(result));
+      dispatch(activePeerUpdate({ online: true }));
+    }).catch((res) => {
+      dispatch(activePeerUpdate({ online: false, code: res.error.code }));
+    });
   };

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -1,12 +1,11 @@
 import i18next from 'i18next';
 import actionTypes from '../constants/actions';
-import { setSecondPassphrase, send, getAccount } from '../utils/api/account';
+import { setSecondPassphrase, getAccount } from '../utils/api/account';
 import { registerDelegate, getDelegate, getVotes, getVoters } from '../utils/api/delegate';
 import { loadTransactionsFinish } from './transactions';
 import { delegateRegisteredFailure } from './delegate';
 import { errorAlertDialogDisplayed } from './dialog';
 import Fees from '../constants/fees';
-import { toRawLsk } from '../utils/lsk';
 import transactionTypes from '../constants/transactionTypes';
 
 /**
@@ -141,36 +140,6 @@ export const delegateRegistered = ({
       });
     dispatch(passphraseUsed(passphrase));
   };
-
-/**
- *
- */
-export const sent = ({
-  activePeer, account, recipientId, amount, passphrase, secondPassphrase,
-}) =>
-  (dispatch) => {
-    send(activePeer, recipientId, toRawLsk(amount), passphrase, secondPassphrase)
-      .then((data) => {
-        dispatch({
-          data: {
-            id: data.transactionId,
-            senderPublicKey: account.publicKey,
-            senderId: account.address,
-            recipientId,
-            amount: toRawLsk(amount),
-            fee: Fees.send,
-            type: transactionTypes.send,
-          },
-          type: actionTypes.transactionAdded,
-        });
-      })
-      .catch((error) => {
-        const errorMessage = error && error.message ? `${error.message}.` : i18next.t('An error occurred while creating the transaction.');
-        dispatch({ data: { errorMessage }, type: actionTypes.transactionFailed });
-      });
-    dispatch(passphraseUsed(passphrase));
-  };
-
 
 export const loadDelegate = ({ activePeer, publicKey }) =>
   (dispatch) => {

--- a/src/actions/account.test.js
+++ b/src/actions/account.test.js
@@ -12,6 +12,7 @@ import {
   loadAccount,
   accountDataUpdated,
   updateTransactionsIfNeeded,
+  updateDelegateAccount,
 } from './account';
 import { errorAlertDialogDisplayed } from './dialog';
 import { delegateRegisteredFailure } from './delegate';
@@ -375,6 +376,31 @@ describe('actions: account', () => {
 
       updateTransactionsIfNeeded(data, false)(dispatch);
       expect(transactionsActionsStub).to.have.been.calledWith();
+    });
+  });
+
+  describe('updateDelegateAccount', () => {
+    const dispatch = spy();
+
+    beforeEach(() => {
+      stub(delegateApi, 'getDelegate').returnsPromise();
+    });
+
+    afterEach(() => {
+      delegateApi.getDelegate.restore();
+    });
+
+    it('should fetch delegate and update account', () => {
+      delegateApi.getDelegate.resolves({ delegate: 'delegate data' });
+      const data = {
+        activePeer: {},
+        publicKey: accounts.genesis.publicKey,
+      };
+
+      updateDelegateAccount(data)(dispatch);
+
+      const accountUpdatedAction = accountUpdated(Object.assign({}, { delegate: 'delegate data', isDelegate: true }));
+      expect(dispatch).to.have.been.calledWith(accountUpdatedAction);
     });
   });
 });

--- a/src/actions/account.test.js
+++ b/src/actions/account.test.js
@@ -1,14 +1,20 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import actionTypes from '../constants/actions';
-import { accountUpdated, accountLoggedOut,
-  secondPassphraseRegistered, delegateRegistered, sent, removePassphrase, passphraseUsed, loadDelegate } from './account';
+import {
+  accountUpdated,
+  accountLoggedOut,
+  secondPassphraseRegistered,
+  delegateRegistered,
+  removePassphrase,
+  passphraseUsed,
+  loadDelegate,
+} from './account';
 import { errorAlertDialogDisplayed } from './dialog';
 import { delegateRegisteredFailure } from './delegate';
 import * as accountApi from '../utils/api/account';
 import * as delegateApi from '../utils/api/delegate';
 import Fees from '../constants/fees';
-import { toRawLsk } from '../utils/lsk';
 import transactionTypes from '../constants/transactionTypes';
 import networks from '../constants/networks';
 import accounts from '../../test/constants/accounts';
@@ -187,79 +193,6 @@ describe('actions: account', () => {
         type: actionTypes.updateDelegate,
       };
       expect(dispatch).to.have.been.calledWith(updateDelegateAction);
-    });
-  });
-
-  describe('sent', () => {
-    let accountApiMock;
-    const data = {
-      activePeer: {},
-      recipientId: '15833198055097037957L',
-      amount: 100,
-      passphrase: 'sample passphrase',
-      secondPassphrase: null,
-      account: {
-        publicKey: 'test_public-key',
-        address: 'test_address',
-      },
-    };
-    const actionFunction = sent(data);
-    let dispatch;
-
-    beforeEach(() => {
-      accountApiMock = sinon.stub(accountApi, 'send');
-      dispatch = sinon.spy();
-    });
-
-    afterEach(() => {
-      accountApiMock.restore();
-    });
-
-    it('should create an action function', () => {
-      expect(typeof actionFunction).to.be.deep.equal('function');
-    });
-
-    it('should dispatch transactionAdded action if resolved', () => {
-      accountApiMock.returnsPromise().resolves({ transactionId: '15626650747375562521' });
-      const expectedAction = {
-        id: '15626650747375562521',
-        senderPublicKey: 'test_public-key',
-        senderId: 'test_address',
-        recipientId: data.recipientId,
-        amount: toRawLsk(data.amount),
-        fee: Fees.send,
-        type: transactionTypes.send,
-      };
-
-      actionFunction(dispatch);
-      expect(dispatch).to.have.been
-        .calledWith({ data: expectedAction, type: actionTypes.transactionAdded });
-    });
-
-    it('should dispatch transactionFailed action if caught', () => {
-      accountApiMock.returnsPromise().rejects({ message: 'sample message' });
-
-      actionFunction(dispatch);
-      const expectedAction = {
-        data: {
-          errorMessage: 'sample message.',
-        },
-        type: actionTypes.transactionFailed,
-      };
-      expect(dispatch).to.have.been.calledWith(expectedAction);
-    });
-
-    it('should dispatch transactionFailed action if caught but no message returned', () => {
-      accountApiMock.returnsPromise().rejects({});
-
-      actionFunction(dispatch);
-      const expectedAction = {
-        data: {
-          errorMessage: 'An error occurred while creating the transaction.',
-        },
-        type: actionTypes.transactionFailed,
-      };
-      expect(dispatch).to.have.been.calledWith(expectedAction);
     });
   });
 

--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -63,7 +63,9 @@ export const searchTransactions = ({
 }) =>
   (dispatch) => {
     if (showLoading) loadingStarted(actionTypes.searchTransactions);
-    getTransactions({ activePeer, address, limit, filter })
+    getTransactions({
+      activePeer, address, limit, filter,
+    })
       .then((transactionsResponse) => {
         dispatch({
           data: {
@@ -82,7 +84,9 @@ export const searchMoreTransactions = ({
   activePeer, address, limit, offset, filter,
 }) =>
   (dispatch) => {
-    getTransactions({ activePeer, address, limit, offset, filter })
+    getTransactions({
+      activePeer, address, limit, offset, filter,
+    })
       .then((transactionsResponse) => {
         dispatch({
           data: {

--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -1,6 +1,7 @@
 import actionTypes from '../constants/actions';
 import { loadingStarted, loadingFinished } from '../utils/loading';
-import { transactions, getAccount } from '../utils/api/account';
+import { getAccount } from '../utils/api/account';
+import { getTransactions } from '../utils/api/transactions';
 import { getDelegate, getVoters, getVotes } from '../utils/api/delegate';
 import { searchAll } from '../utils/api/search';
 
@@ -62,9 +63,7 @@ export const searchTransactions = ({
 }) =>
   (dispatch) => {
     if (showLoading) loadingStarted(actionTypes.searchTransactions);
-    transactions({
-      activePeer, address, limit, filter,
-    })
+    getTransactions({ activePeer, address, limit, filter })
       .then((transactionsResponse) => {
         dispatch({
           data: {
@@ -83,9 +82,7 @@ export const searchMoreTransactions = ({
   activePeer, address, limit, offset, filter,
 }) =>
   (dispatch) => {
-    transactions({
-      activePeer, address, limit, offset, filter,
-    })
+    getTransactions({ activePeer, address, limit, offset, filter })
       .then((transactionsResponse) => {
         dispatch({
           data: {

--- a/src/actions/transactions.js
+++ b/src/actions/transactions.js
@@ -72,9 +72,13 @@ export const loadTransactions = ({ activePeer, publicKey, address }) =>
       });
   };
 
-export const transactionsRequested = ({ activePeer, address, limit, offset, filter }) =>
+export const transactionsRequested = ({
+  activePeer, address, limit, offset, filter,
+}) =>
   (dispatch) => {
-    getTransactions({ activePeer, address, limit, offset, filter })
+    getTransactions({
+      activePeer, address, limit, offset, filter,
+    })
       .then((response) => {
         dispatch({
           data: {
@@ -144,9 +148,13 @@ export const loadTransaction = ({ activePeer, id }) =>
       });
   };
 
-export const transactionsUpdated = ({ activePeer, address, limit, filter, pendingTransactions }) =>
+export const transactionsUpdated = ({
+  activePeer, address, limit, filter, pendingTransactions,
+}) =>
   (dispatch) => {
-    getTransactions({ activePeer, address, limit, filter })
+    getTransactions({
+      activePeer, address, limit, filter,
+    })
       .then((response) => {
         dispatch({
           data: {
@@ -165,7 +173,9 @@ export const transactionsUpdated = ({ activePeer, address, limit, filter, pendin
       });
   };
 
-export const sent = ({ activePeer, account, recipientId, amount, passphrase, secondPassphrase }) =>
+export const sent = ({
+  activePeer, account, recipientId, amount, passphrase, secondPassphrase,
+}) =>
   (dispatch) => {
     send(activePeer, recipientId, toRawLsk(amount), passphrase, secondPassphrase)
       .then((data) => {

--- a/src/actions/transactions.test.js
+++ b/src/actions/transactions.test.js
@@ -32,7 +32,7 @@ describe('actions: transactions', () => {
       transactionsApiMock.restore();
     });
 
-    it('should dispatch transactionsLoaded action if resolved', () => {
+    it('should dispatch transactionsUpdated action if resolved', () => {
       transactionsApiMock.returnsPromise().resolves({ transactions: [], count: '0' });
       const expectedAction = {
         count: 0,

--- a/src/actions/transactions.test.js
+++ b/src/actions/transactions.test.js
@@ -2,14 +2,53 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import actionTypes from '../constants/actions';
 import txFilters from './../constants/transactionFilters';
-import { transactionsRequested, loadTransaction } from './transactions';
-import * as accountApi from '../utils/api/account';
+import { sent, transactionsRequested, loadTransaction, transactionsUpdated } from './transactions';
+import * as transactionsApi from '../utils/api/transactions';
 import * as delegateApi from '../utils/api/delegate';
 import accounts from '../../test/constants/accounts';
+import transactionTypes from '../constants/transactionTypes';
+import Fees from '../constants/fees';
+import { toRawLsk } from '../utils/lsk';
 
 describe('actions: transactions', () => {
+  describe('transactionsUpdated', () => {
+    let transactionsApiMock;
+    const data = {
+      activePeer: {},
+      address: '15626650747375562521',
+      limit: 20,
+      offset: 0,
+      filter: txFilters.all,
+    };
+    const actionFunction = transactionsUpdated(data);
+    let dispatch;
+
+    beforeEach(() => {
+      transactionsApiMock = sinon.stub(transactionsApi, 'getTransactions');
+      dispatch = sinon.spy();
+    });
+
+    afterEach(() => {
+      transactionsApiMock.restore();
+    });
+
+    it('should dispatch transactionsLoaded action if resolved', () => {
+      transactionsApiMock.returnsPromise().resolves({ transactions: [], count: '0' });
+      const expectedAction = {
+        count: 0,
+        confirmed: [],
+      };
+
+      actionFunction(dispatch);
+      expect(dispatch).to.have.been.calledWith({
+        data: expectedAction,
+        type: actionTypes.transactionsUpdated,
+      });
+    });
+  });
+
   describe('transactionsRequested', () => {
-    let accountApiMock;
+    let transactionsApiMock;
     const data = {
       activePeer: {},
       address: '15626650747375562521',
@@ -21,12 +60,12 @@ describe('actions: transactions', () => {
     let dispatch;
 
     beforeEach(() => {
-      accountApiMock = sinon.stub(accountApi, 'transactions');
+      transactionsApiMock = sinon.stub(transactionsApi, 'getTransactions');
       dispatch = sinon.spy();
     });
 
     afterEach(() => {
-      accountApiMock.restore();
+      transactionsApiMock.restore();
     });
 
     it('should create an action function', () => {
@@ -34,7 +73,7 @@ describe('actions: transactions', () => {
     });
 
     it('should dispatch transactionsLoaded action if resolved', () => {
-      accountApiMock.returnsPromise().resolves({ transactions: [], count: '0' });
+      transactionsApiMock.returnsPromise().resolves({ transactions: [], count: '0' });
       const expectedAction = {
         count: 0,
         confirmed: [],
@@ -49,7 +88,7 @@ describe('actions: transactions', () => {
   });
 
   describe('loadTransaction', () => {
-    let accountApiMock;
+    let transactionApiMock;
     let delegateApiMock;
     const data = {
       activePeer: {
@@ -66,13 +105,13 @@ describe('actions: transactions', () => {
     let dispatch;
 
     beforeEach(() => {
-      accountApiMock = sinon.stub(accountApi, 'transaction');
+      transactionApiMock = sinon.stub(transactionsApi, 'getSingleTransaction');
       delegateApiMock = sinon.stub(delegateApi, 'getDelegate');
       dispatch = sinon.spy();
     });
 
     afterEach(() => {
-      accountApiMock.restore();
+      transactionApiMock.restore();
       delegateApiMock.restore();
     });
 
@@ -83,7 +122,7 @@ describe('actions: transactions', () => {
     it('should dispatch one transactionAddDelegateName action when transaction contains one vote added', () => {
       const delegateResponse = { delegate: { username: 'peterpan' } };
       const transactionResponse = { transaction: { votes: { added: [accounts.delegate.publicKey] }, count: '0' } };
-      accountApiMock.returnsPromise().resolves(transactionResponse);
+      transactionApiMock.returnsPromise().resolves(transactionResponse);
       delegateApiMock.returnsPromise().resolves(delegateResponse);
       const expectedActionPayload = {
         ...delegateResponse,
@@ -100,7 +139,7 @@ describe('actions: transactions', () => {
     it('should dispatch one transactionAddDelegateName action when transaction contains one vote deleted', () => {
       const delegateResponse = { delegate: { username: 'peterpan' } };
       const transactionResponse = { transaction: { votes: { deleted: [accounts.delegate.publicKey] }, count: '0' } };
-      accountApiMock.returnsPromise().resolves(transactionResponse);
+      transactionApiMock.returnsPromise().resolves(transactionResponse);
       delegateApiMock.returnsPromise().resolves(delegateResponse);
       const expectedActionPayload = {
         ...delegateResponse,
@@ -114,4 +153,82 @@ describe('actions: transactions', () => {
         .calledWith({ data: expectedActionPayload, type: actionTypes.transactionAddDelegateName });
     });
   });
+
+  describe('sent', () => {
+    let transactionsApiMock;
+    const data = {
+      activePeer: {},
+      recipientId: '15833198055097037957L',
+      amount: 100,
+      passphrase: 'sample passphrase',
+      secondPassphrase: null,
+      account: {
+        publicKey: 'test_public-key',
+        address: 'test_address',
+      },
+    };
+    const actionFunction = sent(data);
+    let dispatch;
+
+    beforeEach(() => {
+      transactionsApiMock = sinon.stub(transactionsApi, 'send');
+      dispatch = sinon.spy();
+    });
+
+    afterEach(() => {
+      transactionsApiMock.restore();
+    });
+
+    it('should create an action function', () => {
+      expect(typeof actionFunction).to.be.deep.equal('function');
+    });
+
+    it('should dispatch transactionAdded action if resolved', () => {
+      transactionsApiMock.returnsPromise().resolves({ transactionId: '15626650747375562521' });
+      const expectedAction = {
+        id: '15626650747375562521',
+        senderPublicKey: 'test_public-key',
+        senderId: 'test_address',
+        recipientId: data.recipientId,
+        amount: toRawLsk(data.amount),
+        fee: Fees.send,
+        type: transactionTypes.send,
+      };
+
+      actionFunction(dispatch);
+      expect(dispatch).to.have.been
+        .calledWith({ data: expectedAction, type: actionTypes.transactionAdded });
+    });
+
+    it('should dispatch transactionFailed action if caught', () => {
+      transactionsApiMock.returnsPromise().rejects({ message: 'sample message' });
+
+      actionFunction(dispatch);
+      const expectedAction = {
+        data: {
+          errorMessage: 'sample message.',
+        },
+        type: actionTypes.transactionFailed,
+      };
+      expect(dispatch).to.have.been.calledWith(expectedAction);
+    });
+
+    it('should dispatch transactionFailed action if caught but no message returned', () => {
+      transactionsApiMock.returnsPromise().rejects({});
+
+      actionFunction(dispatch);
+      const expectedAction = {
+        data: {
+          errorMessage: 'An error occurred while creating the transaction.',
+        },
+        type: actionTypes.transactionFailed,
+      };
+      expect(dispatch).to.have.been.calledWith(expectedAction);
+    });
+  });
+
+
+  // describe('accountLoggedOut', () => {
+  //   it('should create an action to reset the account', () => {
+  // });
 });

--- a/src/components/sendReadable/index.js
+++ b/src/components/sendReadable/index.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { translate } from 'react-i18next';
 
-import { sent } from '../../actions/account';
+import { sent } from '../../actions/transactions';
 import Send from './send';
 
 const mapStateToProps = state => ({

--- a/src/components/transactions/explorerTransactions/index.test.js
+++ b/src/components/transactions/explorerTransactions/index.test.js
@@ -8,6 +8,7 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { prepareStore } from '../../../../test/utils/applicationInit';
 import * as accountAPI from '../../../../src/utils/api/account';
 import * as delegateAPI from '../../../../src/utils/api/delegate';
+import * as transactionsAPI from '../../../../src/utils/api/transactions';
 import peersReducer from '../../../store/reducers/peers';
 import accountReducer from '../../../store/reducers/account';
 import transactionReducer from '../../../store/reducers/transaction';
@@ -44,8 +45,8 @@ describe('ExplorerTransactions Component', () => {
   }, [thunk]);
 
   beforeEach(() => {
-    transactionsActionStub = stub(accountAPI, 'transactions');
-    transactionActionStub = stub(accountAPI, 'transaction');
+    transactionsActionStub = stub(transactionsAPI, 'getTransactions');
+    transactionActionStub = stub(transactionsAPI, 'getSingleTransaction');
     accountStub = stub(accountAPI, 'getAccount');
     delegateStub = stub(delegateAPI, 'getDelegate');
     delegateVotesStub = stub(delegateAPI, 'getVotes');

--- a/src/components/transactions/walletTransactions/index.test.js
+++ b/src/components/transactions/walletTransactions/index.test.js
@@ -6,8 +6,8 @@ import { expect } from 'chai';
 import { Provider } from 'react-redux';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { prepareStore } from '../../../../test/utils/applicationInit';
-import * as accountAPI from '../../../../src/utils/api/account';
 import * as delegateAPI from '../../../../src/utils/api/delegate';
+import * as transactionsAPI from '../../../../src/utils/api/transactions';
 import peersReducer from '../../../store/reducers/peers';
 import accountReducer from '../../../store/reducers/account';
 import transactionsReducer from '../../../store/reducers/transactions';
@@ -40,7 +40,7 @@ describe('WalletTransactions Component', () => {
   }, [thunk]);
 
   beforeEach(() => {
-    transactionsActionsStub = stub(accountAPI, 'transactions');
+    transactionsActionsStub = stub(transactionsAPI, 'getTransactions');
     delegateVotesStub = stub(delegateAPI, 'getVotes');
     delegateVotersStub = stub(delegateAPI, 'getVoters');
 

--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -1,8 +1,11 @@
-import { accountUpdated, accountDataUpdated, updateTransactionsIfNeeded } from '../../actions/account';
+import { accountUpdated,
+  accountDataUpdated,
+  updateTransactionsIfNeeded,
+  updateDelegateAccount,
+} from '../../actions/account';
 import { votesFetched } from '../../actions/voting';
 import actionTypes from '../../constants/actions';
 import accountConfig from '../../constants/account';
-import { getDelegate } from '../../utils/api/delegate';
 import transactionTypes from '../../constants/transactionTypes';
 
 const { lockDuration } = accountConfig;
@@ -34,13 +37,10 @@ const delegateRegistration = (store, action) => {
   const state = store.getState();
 
   if (delegateRegistrationTx) {
-    getDelegate(state.peers.data, { publicKey: state.account.publicKey })
-      .then((delegateData) => {
-        store.dispatch(accountUpdated(Object.assign(
-          {},
-          { delegate: delegateData.delegate, isDelegate: true },
-        )));
-      });
+    store.dispatch(updateDelegateAccount({
+      activePeer: state.peers.data,
+      publicKey: state.account.publicKey,
+    }));
   }
 };
 

--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -1,4 +1,4 @@
-import { getAccount, transactions as getTransactions } from '../../utils/api/account';
+import { getAccount } from '../../utils/api/account';
 import { accountUpdated } from '../../actions/account';
 import { transactionsUpdateUnconfirmed } from '../../actions/transactions';
 import { activePeerUpdate } from '../../actions/peers';
@@ -6,6 +6,7 @@ import { votesFetched } from '../../actions/voting';
 import actionTypes from '../../constants/actions';
 import accountConfig from '../../constants/account';
 import { getDelegate } from '../../utils/api/delegate';
+import { getTransactions } from '../../utils/api/transactions';
 import transactionTypes from '../../constants/transactionTypes';
 
 const { lockDuration } = accountConfig;
@@ -45,6 +46,7 @@ const hasRecentTransactions = txs => (
 const updateAccountData = (store, action) => {
   const { peers, account, transactions } = store.getState();
 
+  // all dispatches
   getAccount(peers.data, account.address).then((result) => {
     if (result.balance !== account.balance) {
       if (!action.data.windowIsFocused || !hasRecentTransactions(transactions)) {
@@ -74,6 +76,7 @@ const delegateRegistration = (store, action) => {
   const state = store.getState();
 
   if (delegateRegistrationTx) {
+    // all dispatches no api calls and no dispatches after api call
     getDelegate(state.peers.data, { publicKey: state.account.publicKey })
       .then((delegateData) => {
         store.dispatch(accountUpdated(Object.assign(

--- a/src/store/middlewares/account.test.js
+++ b/src/store/middlewares/account.test.js
@@ -5,6 +5,7 @@ import accountConfig from '../../constants/account';
 import { activePeerUpdate } from '../../actions/peers';
 import * as votingActions from '../../actions/voting';
 import * as accountApi from '../../utils/api/account';
+import * as transactionsApi from '../../utils/api/transactions';
 import accounts from '../../../test/constants/accounts';
 import actionTypes from '../../constants/actions';
 import * as delegateApi from '../../utils/api/delegate';
@@ -82,7 +83,7 @@ describe('Account middleware', () => {
 
     next = spy();
     stubGetAccount = stub(accountApi, 'getAccount').returnsPromise();
-    stubTransactions = stub(accountApi, 'transactions').returnsPromise().resolves(true);
+    stubTransactions = stub(transactionsApi, 'getTransactions').returnsPromise().resolves(true);
   });
 
   afterEach(() => {

--- a/src/utils/api/account.js
+++ b/src/utils/api/account.js
@@ -1,5 +1,4 @@
 import { requestToActivePeer } from './peers';
-import txFilters from './../../constants/transactionFilters';
 
 export const getAccount = (activePeer, address) =>
   new Promise((resolve, reject) => {
@@ -24,37 +23,4 @@ export const getAccount = (activePeer, address) =>
 
 export const setSecondPassphrase = (activePeer, secondSecret, publicKey, secret) =>
   requestToActivePeer(activePeer, 'signatures', { secondSecret, publicKey, secret });
-
-export const send = (activePeer, recipientId, amount, secret, secondSecret = null) =>
-  requestToActivePeer(
-    activePeer, 'transactions',
-    {
-      recipientId, amount, secret, secondSecret,
-    },
-  );
-
-export const transactions = ({
-  activePeer, address, limit = 20, offset = 0, orderBy = 'timestamp:desc', filter = txFilters.all,
-}) => {
-  let params = {
-    recipientId: (filter === txFilters.incoming || filter === txFilters.all) ? address : undefined,
-    senderId: (filter === txFilters.outgoing || filter === txFilters.all) ? address : undefined,
-    limit,
-    offset,
-    orderBy,
-  };
-  params = JSON.parse(JSON.stringify(params));
-  return requestToActivePeer(activePeer, 'transactions', params);
-};
-
-export const transaction = ({ activePeer, id }) => requestToActivePeer(activePeer, 'transactions/get', { id });
-
-export const unconfirmedTransactions = (activePeer, address, limit = 20, offset = 0, orderBy = 'timestamp:desc') =>
-  requestToActivePeer(activePeer, 'transactions/unconfirmed', {
-    senderId: address,
-    recipientId: address,
-    limit,
-    offset,
-    orderBy,
-  });
 

--- a/src/utils/api/account.test.js
+++ b/src/utils/api/account.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { mock } from 'sinon';
-import { getAccount, setSecondPassphrase, send, transactions, unconfirmedTransactions } from './account';
+import { getAccount, setSecondPassphrase } from './account';
 
 describe('Utils: Account API', () => {
   const address = '1449310910991872227L';
@@ -50,27 +50,6 @@ describe('Utils: Account API', () => {
   describe('setSecondPassphrase', () => {
     it('should return a promise', () => {
       const promise = setSecondPassphrase();
-      expect(typeof promise.then).to.be.equal('function');
-    });
-  });
-
-  describe('send', () => {
-    it('should return a promise', () => {
-      const promise = send();
-      expect(typeof promise.then).to.be.equal('function');
-    });
-  });
-
-  describe('transactions', () => {
-    it('should return a promise', () => {
-      const promise = transactions({ activePeer: {} });
-      expect(typeof promise.then).to.be.equal('function');
-    });
-  });
-
-  describe('unconfirmedTransactions', () => {
-    it('should return a promise', () => {
-      const promise = unconfirmedTransactions();
       expect(typeof promise.then).to.be.equal('function');
     });
   });

--- a/src/utils/api/search.js
+++ b/src/utils/api/search.js
@@ -1,4 +1,5 @@
-import { getAccount, transaction } from './account';
+import { getAccount } from './account';
+import { getSingleTransaction } from './transactions';
 import { listDelegates } from './delegate';
 import regex from './../../utils/regex';
 
@@ -16,7 +17,7 @@ const searchDelegates = ({ activePeer, searchTerm }) => new Promise((resolve, re
     .catch(() => reject({ delegates: [] })));
 
 const searchTransactions = ({ activePeer, searchTerm }) => new Promise((resolve, reject) =>
-  transaction({
+  getSingleTransaction({
     activePeer,
     id: searchTerm,
   }).then(response => resolve({ transactions: [response.transaction] }))

--- a/src/utils/api/transactions.js
+++ b/src/utils/api/transactions.js
@@ -1,0 +1,30 @@
+import { requestToActivePeer } from './peers';
+import txFilters from './../../constants/transactionFilters';
+
+export const send = (activePeer, recipientId, amount, secret, secondSecret = null) =>
+  requestToActivePeer(activePeer, 'transactions',
+    { recipientId, amount, secret, secondSecret });
+
+export const getTransactions = ({ activePeer, address, limit = 20, offset = 0, orderBy = 'timestamp:desc', filter = txFilters.all }) => {
+  let params = {
+    recipientId: (filter === txFilters.incoming || filter === txFilters.all) ? address : undefined,
+    senderId: (filter === txFilters.outgoing || filter === txFilters.all) ? address : undefined,
+    limit,
+    offset,
+    orderBy,
+  };
+  params = JSON.parse(JSON.stringify(params));
+  return requestToActivePeer(activePeer, 'transactions', params);
+};
+
+export const getSingleTransaction = ({ activePeer, id }) => requestToActivePeer(activePeer, 'transactions/get', { id });
+
+export const unconfirmedTransactions = (activePeer, address, limit = 20, offset = 0, orderBy = 'timestamp:desc') =>
+  requestToActivePeer(activePeer, 'transactions/unconfirmed', {
+    senderId: address,
+    recipientId: address,
+    limit,
+    offset,
+    orderBy,
+  });
+

--- a/src/utils/api/transactions.js
+++ b/src/utils/api/transactions.js
@@ -2,10 +2,16 @@ import { requestToActivePeer } from './peers';
 import txFilters from './../../constants/transactionFilters';
 
 export const send = (activePeer, recipientId, amount, secret, secondSecret = null) =>
-  requestToActivePeer(activePeer, 'transactions',
-    { recipientId, amount, secret, secondSecret });
+  requestToActivePeer(
+    activePeer, 'transactions',
+    {
+      recipientId, amount, secret, secondSecret,
+    },
+  );
 
-export const getTransactions = ({ activePeer, address, limit = 20, offset = 0, orderBy = 'timestamp:desc', filter = txFilters.all }) => {
+export const getTransactions = ({
+  activePeer, address, limit = 20, offset = 0, orderBy = 'timestamp:desc', filter = txFilters.all,
+}) => {
   let params = {
     recipientId: (filter === txFilters.incoming || filter === txFilters.all) ? address : undefined,
     senderId: (filter === txFilters.outgoing || filter === txFilters.all) ? address : undefined,

--- a/src/utils/api/transactions.test.js
+++ b/src/utils/api/transactions.test.js
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import { send, getTransactions, unconfirmedTransactions } from './transactions';
+
+describe('Utils: Transactions API', () => {
+  describe('send', () => {
+    it('should return a promise', () => {
+      const promise = send();
+      expect(typeof promise.then).to.be.equal('function');
+    });
+  });
+
+  describe('transactions', () => {
+    it('should return a promise', () => {
+      const promise = getTransactions({ activePeer: {} });
+      expect(typeof promise.then).to.be.equal('function');
+    });
+  });
+
+  describe('unconfirmedTransactions', () => {
+    it('should return a promise', () => {
+      const promise = unconfirmedTransactions();
+      expect(typeof promise.then).to.be.equal('function');
+    });
+  });
+});

--- a/test/integration/wallet.test.js
+++ b/test/integration/wallet.test.js
@@ -6,6 +6,7 @@ import { stub, match, spy } from 'sinon';
 
 import * as peers from '../../src/utils/api/peers';
 import * as accountAPI from '../../src/utils/api/account';
+import * as transactionsAPI from '../../src/utils/api/transactions';
 import * as delegateAPI from '../../src/utils/api/delegate';
 import * as liskServiceApi from '../../src/utils/api/liskService';
 import { prepareStore, renderWithRouter } from '../utils/applicationInit';
@@ -317,7 +318,7 @@ describe('@integration: Wallet', () => {
 
   describe('Transactions', () => {
     beforeEach(() => {
-      getTransactionsStub = stub(accountAPI, 'transactions');
+      getTransactionsStub = stub(transactionsAPI, 'getTransactions');
 
       getTransactionsStub.withArgs({
         activePeer: match.any,


### PR DESCRIPTION
### What was the problem?
There were api calls in the account middleware and some transaction actions and api calls in the account actions that didnt belong in there

### How did I fix it?
Moved transaction related api calls to `src/utils/api/transactions.js` and actions to `src/actions/transactions.js`
And transformed further direct api calls in the account middleware into actions in `src/actions/account.js`

Adjusted all tests

### How to test it?
Everything should work exactly like before - be careful testing the tests as well

### Review checklist
- The PR solves #770
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
