### PR TITLE
Fix displaying statistics for non-delegate - Closes #883

### DIFF
--- a/src/components/transactions/transactionOverview.js
+++ b/src/components/transactions/transactionOverview.js
@@ -67,8 +67,7 @@ class TransactionsOverview extends React.Component {
         className: 'filter-out',
       },
     ];
-
-    if (this.props.delegate) {
+    if (Object.keys(this.props.delegate).length !== 0) {
       filters.push({
         name: this.isSmallScreen() ? this.props.t('Stats') : this.props.t('Delegate statistics'),
         value: txFilters.statistics,

--- a/src/components/transactions/transactionOverview.js
+++ b/src/components/transactions/transactionOverview.js
@@ -67,7 +67,7 @@ class TransactionsOverview extends React.Component {
         className: 'filter-out',
       },
     ];
-    if (Object.keys(this.props.delegate).length !== 0) {
+    if (this.props.delegate && Object.keys(this.props.delegate).length !== 0) {
       filters.push({
         name: this.isSmallScreen() ? this.props.t('Stats') : this.props.t('Delegate statistics'),
         value: txFilters.statistics,


### PR DESCRIPTION
### What was the problem?
Delegate statistics showed on non-delegate account
### How did I fix it?
Added condition that checkes is person is a delegate
### How to test it?
Go to non delegate account
### Review checklist
- The PR solves #883
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
