### PR TITLE
Limit linux builds to x86_64

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,7 +89,7 @@ node('lisk-hub') {
         rsync -axl --delete --rsync-path="mkdir -p /var/www/test/${JOB_NAME%/*}/$BRANCH_NAME/ && rsync" $WORKSPACE/app/build/ jenkins@master-01:/var/www/test/${JOB_NAME%/*}/$BRANCH_NAME/
         npm run --silent bundlesize
         if [ -z $CHANGE_BRANCH ]; then
-          USE_SYSTEM_XORRISO=true npm run dist
+          USE_SYSTEM_XORRISO=true npm run dist:linux
         else
           echo "Skipping desktop build for Linux because we're not on 'development' branch"
         fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,22 +82,24 @@ node('lisk-hub') {
 
     stage ('Build and Deploy') {
       try {
-        sh '''
-        cp ~/.coveralls.yml-hub .coveralls.yml
-        npm run --silent build
-        npm run --silent build:testnet
-        rsync -axl --delete --rsync-path="mkdir -p /var/www/test/${JOB_NAME%/*}/$BRANCH_NAME/ && rsync" $WORKSPACE/app/build/ jenkins@master-01:/var/www/test/${JOB_NAME%/*}/$BRANCH_NAME/
-        npm run --silent bundlesize
-        if [ -z $CHANGE_BRANCH ]; then
-          USE_SYSTEM_XORRISO=true npm run dist:linux
-        else
-          echo "Skipping desktop build for Linux because we're not on 'development' branch"
-        fi
-        '''
-        archiveArtifacts artifacts: 'app/build/'
-        archiveArtifacts artifacts: 'app/build-testnet/'
-        archiveArtifacts allowEmptyArchive: true, artifacts: 'dist/lisk-hub*'
-        githubNotify context: 'Jenkins test deployment', description: 'Commit was deployed to test', status: 'SUCCESS', targetUrl: "${HUDSON_URL}test/" + "${JOB_NAME}".tokenize('/')[0] + "/${BRANCH_NAME}"
+        withCredentials([string(credentialsId: 'github-lisk-token', variable: 'GH_TOKEN')]) {
+          sh '''
+          cp ~/.coveralls.yml-hub .coveralls.yml
+          npm run --silent build
+          npm run --silent build:testnet
+          rsync -axl --delete --rsync-path="mkdir -p /var/www/test/${JOB_NAME%/*}/$BRANCH_NAME/ && rsync" $WORKSPACE/app/build/ jenkins@master-01:/var/www/test/${JOB_NAME%/*}/$BRANCH_NAME/
+          npm run --silent bundlesize
+          if [ -z $CHANGE_BRANCH ]; then
+            USE_SYSTEM_XORRISO=true npm run dist:linux
+          else
+            echo "Skipping desktop build for Linux because we're not on 'development' branch"
+          fi
+          '''
+          archiveArtifacts artifacts: 'app/build/'
+          archiveArtifacts artifacts: 'app/build-testnet/'
+          archiveArtifacts allowEmptyArchive: true, artifacts: 'dist/lisk-hub*'
+          githubNotify context: 'Jenkins test deployment', description: 'Commit was deployed to test', status: 'SUCCESS', targetUrl: "${HUDSON_URL}test/" + "${JOB_NAME}".tokenize('/')[0] + "/${BRANCH_NAME}"
+        }
       } catch (err) {
         echo "Error: ${err}"
         fail('Stopping build: build or deploy failed')

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dist": "build --ia32 --x64 --publish onTag",
     "dist:win": "build --win --ia32 --x64 --publish onTag",
     "dist:mac": "build --mac",
-    "dist:linux": "build --linux --ia32 --x64 --armv7l",
+    "dist:linux": "build --linux --x64 --publish onTag",
     "copy-files": "cpx \"./src/{index.html,assets/**/*}\" ./app/build/",
     "clean-build": "rm -rf app/build",
     "clean-dist": "rm -rf dist",


### PR DESCRIPTION
### What was the problem?

The jenkins job was creating artifacts of both 32 and 64 bits of Linux builds, taking too much disk space. Only 64bit ones are needed.

### How did I fix it?

Changing the linux builds to use `--x64` only

### How to test it?


