### PR TITLE
Add currency switcher to settings - Closes #845

### DIFF
--- a/src/components/send/index.js
+++ b/src/components/send/index.js
@@ -54,11 +54,8 @@ class Send extends React.Component {
             {t('Send')}
           </span>
           <span className={`request-menu-item ${styles.mobileMenuItem}`}
-            onClick={this.setActiveOnMobile.bind(
-this,
-              { isActiveOnMobile: true, isActiveTabSend: false },
-)
-            }>
+            onClick={this.setActiveOnMobile.bind(this,
+              { isActiveOnMobile: true, isActiveTabSend: false })}>
             {t('Request')}
           </span>
         </span>

--- a/src/components/send/index.js
+++ b/src/components/send/index.js
@@ -54,8 +54,9 @@ class Send extends React.Component {
             {t('Send')}
           </span>
           <span className={`request-menu-item ${styles.mobileMenuItem}`}
-            onClick={this.setActiveOnMobile.bind(this,
-              { isActiveOnMobile: true, isActiveTabSend: false })}>
+            onClick={
+              this.setActiveOnMobile.bind(this, { isActiveOnMobile: true, isActiveTabSend: false })
+            }>
             {t('Request')}
           </span>
         </span>

--- a/src/components/setting/setting.js
+++ b/src/components/setting/setting.js
@@ -17,6 +17,7 @@ class Setting extends React.Component {
     super();
     this.state = {
       activeSlide: 0,
+      currencies: ['USD', 'EUR'],
     };
   }
 
@@ -56,6 +57,8 @@ class Setting extends React.Component {
       t, settings, settingsUpdated,
       hasSecondPassphrase,
     } = this.props;
+
+    const activeCurrency = settings.currency || 'USD';
 
     return (<Box className={styles.wrapper}>
       <aside>
@@ -118,16 +121,21 @@ class Setting extends React.Component {
               checked: settings.advancedMode,
             }}/>
         </div>
-        {/* TODO: will be re-enabled when the functionality is updated
-          <h4>{t('Local')}</h4>
-          <div className={styles.item}>
-            <label>{t('Currency')}</label>
-            <ul className={styles.currencyList}>
-              <li className={styles.active}>USD</li>
-              <li>EUR</li>
-            </ul>
-          </div>
-        */}
+        {/* TODO: will be re-enabled when the functionality is updated */}
+        <h4>{t('Local')}</h4>
+        <div className={styles.item}>
+          <label>{t('Currency')}</label>
+          <ul className={styles.currencyList}>
+            {this.state.currencies.map(currency => (
+              <li
+                key={`currency-${currency}`}
+                className={`currency ${currency === activeCurrency ? styles.active : 'unactive'}`}
+                onClick={() => settingsUpdated({ currency })}>
+                {currency}
+              </li>
+            ))}
+          </ul>
+        </div>
         {/* TODO: will be re-enabled when the functionality is updated
         {/* TODO: will be re-enabled when the functionality is updated
         <div>

--- a/src/components/setting/setting.js
+++ b/src/components/setting/setting.js
@@ -59,7 +59,7 @@ class Setting extends React.Component {
       hasSecondPassphrase,
     } = this.props;
 
-    const activeCurrency = settings.currency || 'USD';
+    const activeCurrency = settings.currency || settingsConst.currencies[0];
 
     return (<Box className={styles.wrapper}>
       <aside>

--- a/src/components/setting/setting.js
+++ b/src/components/setting/setting.js
@@ -6,6 +6,7 @@ import styles from './setting.css';
 import i18n from '../../i18n';
 import accountConfig from '../../constants/account';
 import breakpoints from './../../constants/breakpoints';
+import settingsConst from './../../constants/settings';
 // TODO: will be re-enabled when the functionality is updated
 import routes from '../../constants/routes';
 import { FontIcon } from '../fontIcon';
@@ -17,7 +18,7 @@ class Setting extends React.Component {
     super();
     this.state = {
       activeSlide: 0,
-      currencies: ['USD', 'EUR'],
+      currencies: settingsConst.currencies,
     };
   }
 
@@ -121,7 +122,6 @@ class Setting extends React.Component {
               checked: settings.advancedMode,
             }}/>
         </div>
-        {/* TODO: will be re-enabled when the functionality is updated */}
         <h4>{t('Local')}</h4>
         <div className={styles.item}>
           <label>{t('Currency')}</label>
@@ -129,7 +129,7 @@ class Setting extends React.Component {
             {this.state.currencies.map(currency => (
               <li
                 key={`currency-${currency}`}
-                className={`currency ${currency === activeCurrency ? styles.active : 'unactive'}`}
+                className={`currency ${currency === activeCurrency ? styles.active : ''}`}
                 onClick={() => settingsUpdated({ currency })}>
                 {currency}
               </li>

--- a/src/components/setting/setting.test.js
+++ b/src/components/setting/setting.test.js
@@ -9,6 +9,7 @@ import Setting from './setting';
 import accounts from '../../../test/constants/accounts';
 import i18n from '../../i18n';
 import breakpoints from './../../constants/breakpoints';
+import settingsConst from './../../constants/settings';
 
 describe('Setting', () => {
   const history = {
@@ -20,7 +21,7 @@ describe('Setting', () => {
   const settings = {
     autoLog: true,
     advancedMode: true,
-    currency: 'USD',
+    currency: settingsConst.currencies[0],
   };
 
   const account = {
@@ -131,7 +132,7 @@ describe('Setting', () => {
     wrapper.find('.currency').at(1).simulate('click');
     wrapper.update();
     const expectedCallToSettingsUpdated = {
-      currency: 'EUR',
+      currency: settingsConst.currencies[1],
     };
     expect(props.settingsUpdated).to.have.been.calledWith(expectedCallToSettingsUpdated);
   });

--- a/src/components/setting/setting.test.js
+++ b/src/components/setting/setting.test.js
@@ -20,6 +20,7 @@ describe('Setting', () => {
   const settings = {
     autoLog: true,
     advancedMode: true,
+    currency: 'USD',
   };
 
   const account = {
@@ -126,6 +127,14 @@ describe('Setting', () => {
     expect(props.settingsUpdated).to.have.been.calledWith(expectedCallToSettingsUpdated);
   });
 
+  it('should change active currency setting to EUR', () => {
+    wrapper.find('.currency').at(1).simulate('click');
+    wrapper.update();
+    const expectedCallToSettingsUpdated = {
+      currency: 'EUR',
+    };
+    expect(props.settingsUpdated).to.have.been.calledWith(expectedCallToSettingsUpdated);
+  });
 
   it('should update expireTime when updating autolog', () => {
     const accountToExpireTime = { ...account };

--- a/src/components/votingListView/voteCheckbox.js
+++ b/src/components/votingListView/voteCheckbox.js
@@ -14,8 +14,8 @@ const VoteCheckbox = ({ data, status, toggle }) => {
         id={`vote-${publicKey}`}
         checked={status ? status.unconfirmed : false}
         onChange={toggle.bind(null, {
- username, publicKey, rank, productivity, address,
-})} />
+          username, publicKey, rank, productivity, address,
+        })} />
       <FontIcon value='checkmark-check' className={styles.checked} />
       <FontIcon value='checkmark-uncheck' className={styles.unchecked} />
     </label>;

--- a/src/constants/settings.js
+++ b/src/constants/settings.js
@@ -1,0 +1,4 @@
+const settings = {
+  currencies: ['USD', 'EUR'],
+};
+export default settings;


### PR DESCRIPTION
### What was the problem?
Not implemented currency switcher on settings
### How did I fix it?
Implemented currency switcher
### How to test it?
Go to settings page, switch to ON then go to dashboard and check in transaction input if defaut currency cahnged.

### Review checklist
- The PR solves #845
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
