### PR TITLE
Decrease likelihood of the blue line of price chart toolitp - Closes #893

### DIFF
--- a/src/components/dashboard/currencyGraph.css
+++ b/src/components/dashboard/currencyGraph.css
@@ -1,7 +1,7 @@
 @import '../app/variables';
 
 :root {
-  --stepSwitch-font-size: 15px;
+  --stepSwitch-font-size: 16px;
 }
 
 .wrapper {
@@ -43,17 +43,15 @@
 }
 
 .stepSwitch {
-  padding: 10px 16px;
+  padding: 10px 14px;
   cursor: pointer;
   font-size: var(--stepSwitch-font-size);
-  font-weight: 500;
-  color: var(--color-grayscale-medium);
+  font-weight: 600;
+  font-family: var(--heading-font);
+  color: var(--color-grayscale-light);
 
   &.active {
-    color: var(--color-white);
-    background: var(--gradient-tertiary);
-    border-radius: var(--border-radius-normal);
-    font-weight: 300;
+    color: var(--color-grayscale-dark);
   }
 }
 

--- a/src/components/dashboard/currencyGraph.css
+++ b/src/components/dashboard/currencyGraph.css
@@ -11,7 +11,7 @@
 }
 
 .chartWrapper {
-  height: calc(100% - 70px);
+  height: 100%;
   min-height: 130px;
   width: calc(100% + 50px);
   margin: 0 -25px;
@@ -38,6 +38,8 @@
 .stepSwitchWrapper {
   float: right;
   margin: 50px;
+  z-index: 10;
+  position: relative;
 }
 
 .stepSwitch {

--- a/src/components/dashboard/currencyGraph.js
+++ b/src/components/dashboard/currencyGraph.js
@@ -44,7 +44,7 @@ const chartOptions = step => ({
     padding: {
       left: 0,
       right: 0,
-      top: 0,
+      top: 80,
       bottom: bottomPadding,
     },
   },
@@ -174,7 +174,7 @@ class CurrencyGraph extends React.Component {
       afterDraw(chartInstance) {
         drawGradientRectangle(chartInstance, {
           bottomPosition: bottomPadding + 32,
-          height: 5,
+          height: 10,
         });
       },
     });


### PR DESCRIPTION
### What was the problem?
Blue line over price chart tooltip

### How did I fix it?
by giving the chart more padding top and thus increase the likelihood
of the toolitp going up and not intersecting with the blue line.
The blue line has to be there to cover black x-axix what cannot be
changed in chart.js

One downside is that the tooltip is under the 24h/7d/2w switcher, because the switcher has to be on top of the canvas to be clickable. To make it less apparent I updated the switcher to the latest design without blue background https://taikonauten.invisionapp.com/d/main/#/console/12665756/302633917/inspect

### How to test it?
Wiew dashboard with small screen size, hover the price chart to see the tooltip

### Review checklist
- The PR solves #893
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
