### PR TITLE
Verify that passphrase used belongs to active account - Cooses #921

### DIFF
--- a/src/components/signMessage/confirmMessage.js
+++ b/src/components/signMessage/confirmMessage.js
@@ -4,6 +4,7 @@ import styles from './confirmMessage.css';
 import { Button } from '../toolbox/buttons/button';
 import Input from '../toolbox/inputs/input';
 import { passphraseIsValid } from '../../utils/form';
+import { extractPublicKey } from '../../utils/account';
 // eslint-disable-next-line import/no-named-as-default
 import PassphraseInput from '../passphraseInput';
 import TransitionWrapper from '../toolbox/transitionWrapper';
@@ -31,6 +32,18 @@ class ConfirmMessage extends React.Component {
   }
 
   handleChange(name, value, error) {
+    if (!error) {
+      const publicKeyMap = {
+        passphrase: 'publicKey',
+        secondPassphrase: 'secondPublicKey',
+      };
+
+      const expectedPublicKey = this.props.account[publicKeyMap[name]];
+
+      if (expectedPublicKey && expectedPublicKey !== extractPublicKey(value)) {
+        error = this.props.t('Entered passphrase does not belong to the active account');
+      }
+    }
     this.setState({
       [name]: {
         value,


### PR DESCRIPTION
### What was the problem?
Sign Message didnt Verify That Passphrase Used to Sign Message Belongs to Account that User is Logged Into
### How did I fix it?
Added condition that checks to whom passphrase belong to
### How to test it?
Go to `/sign-message` try to signMessage with passphrase that is not from an active account
### Review checklist
- The PR solves #921
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
