### PR TITLE
Redirect to valid entity results page when no autosuggestion result used - Closes #946

### DIFF
--- a/src/components/autoSuggest/index.js
+++ b/src/components/autoSuggest/index.js
@@ -9,6 +9,7 @@ import keyCodes from './../../constants/keyCodes';
 import localJSONStorage from './../../utils/localJSONStorage';
 import regex from './../../utils/regex';
 import { saveSearch } from './../search/keyAction';
+import { searchEntities } from './../../constants/search';
 
 class AutoSuggest extends React.Component {
   constructor(props) {
@@ -27,7 +28,7 @@ class AutoSuggest extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     this.selectedRow = null;
-    const resultsLength = ['delegates', 'addresses', 'transactions'].reduce((total, resultKey) =>
+    const resultsLength = Object.keys(searchEntities).reduce((total, resultKey) =>
       total + nextProps.results[resultKey].length, 0);
     let placeholder = '';
     let selectedIdx = -1;
@@ -41,11 +42,11 @@ class AutoSuggest extends React.Component {
   onResultClick(id, type, value) {
     let urlSearch;
     switch (type) {
-      case 'addresses':
-      case 'delegates':
+      case searchEntities.addresses:
+      case searchEntities.delegates:
         urlSearch = `${routes.accounts.pathPrefix}${routes.accounts.path}/${id}`;
         break;
-      case 'transactions':
+      case searchEntities.transactions:
         urlSearch = `${routes.transactions.pathPrefix}${routes.transactions.path}/${id}`;
         break;
       /* istanbul ignore next */
@@ -55,7 +56,7 @@ class AutoSuggest extends React.Component {
     saveSearch(id);
     this.props.searchClearSuggestions();
 
-    if (['addresses', 'transactions'].filter(entity =>
+    if ([searchEntities.addresses, searchEntities.transactions].filter(entity =>
       entity === type).length > 0) {
       this.setState({ value: id });
     } else if (value) {
@@ -83,9 +84,9 @@ class AutoSuggest extends React.Component {
   submitAnySearch() {
     let searchType = null;
     if (this.state.value.match(regex.address)) {
-      searchType = 'addresses';
+      searchType = searchEntities.addresses;
     } else if (this.state.value.match(regex.transactionId)) {
-      searchType = 'transactions';
+      searchType = searchEntities.transactions;
     }
 
     if (!searchType) {
@@ -221,7 +222,7 @@ class AutoSuggest extends React.Component {
       valueLeft: delegate.username,
       valueRight: delegate.rank,
       isSelected: idx === this.state.selectedIdx,
-      type: 'delegates',
+      type: searchEntities.delegates,
     }));
   }
 
@@ -231,7 +232,7 @@ class AutoSuggest extends React.Component {
       valueLeft: account.address,
       valueRight: <span><LiskAmount val={account.balance}/> LSK</span>,
       isSelected: this.props.results.delegates.length + idx === this.state.selectedIdx,
-      type: 'addresses',
+      type: searchEntities.addresses,
     }));
   }
 
@@ -242,16 +243,16 @@ class AutoSuggest extends React.Component {
       valueRight: transaction.height,
       isSelected: this.props.results.delegates.length +
       this.props.results.addresses.length + idx === this.state.selectedIdx,
-      type: 'transactions',
+      type: searchEntities.transactions,
     }));
   }
 
   getRecentSearchResults() {
     this.recentSearches = localJSONStorage.get('searches', [])
       .map((result, idx) => {
-        let type = 'addresses';
+        let type = searchEntities.addresses;
         if (result.match(regex.transactionId)) {
-          type = 'transactions';
+          type = searchEntities.transactions;
         }
         return {
           id: result,
@@ -299,7 +300,7 @@ class AutoSuggest extends React.Component {
         </Input>
         <div className={`${styles.autoSuggest} ${this.state.show ? styles.show : ''} autosuggest-dropdown`}>
           <ResultsList
-            key='delegates'
+            key={searchEntities.delegates}
             results={this.getDelegatesResults()}
             header={{
               titleLeft: t('Delegate'),
@@ -309,7 +310,7 @@ class AutoSuggest extends React.Component {
             setSelectedRow={this.setSelectedRow.bind(this)}
           />
           <ResultsList
-            key='addresses'
+            key={searchEntities.addresses}
             results={this.getAddressesResults()}
             header={{
               titleLeft: t('Address'),
@@ -319,7 +320,7 @@ class AutoSuggest extends React.Component {
             setSelectedRow={this.setSelectedRow.bind(this)}
           />
           <ResultsList
-            key='transactions'
+            key={searchEntities.transactions}
             results={this.getTransactionsResults()}
             header={{
               titleLeft: t('Transaction'),

--- a/src/components/autoSuggest/index.js
+++ b/src/components/autoSuggest/index.js
@@ -81,8 +81,18 @@ class AutoSuggest extends React.Component {
   }
 
   submitAnySearch() {
-    this.inputRef.blur();
-    this.props.history.push(`${routes.searchResult.pathPrefix}${routes.searchResult.path}/${encodeURIComponent(this.state.value)}`);
+    let searchType = null;
+    if (this.state.value.match(regex.address)) {
+      searchType = 'addresses';
+    } else if (this.state.value.match(regex.transactionId)) {
+      searchType = 'transactions';
+    }
+
+    if (!searchType) {
+      this.props.history.push(`${routes.searchResult.pathPrefix}${routes.searchResult.path}/${encodeURIComponent(this.state.value)}`);
+      return;
+    }
+    this.onResultClick(this.state.value, searchType, this.state.value);
   }
 
   search(searchTerm) {

--- a/src/components/autoSuggest/index.test.js
+++ b/src/components/autoSuggest/index.test.js
@@ -156,6 +156,27 @@ describe('AutoSuggest', () => {
       .calledWith(`${routes.searchResult.pathPrefix}${routes.searchResult.path}/notExistingDelegate`);
   });
 
+  it('should redirect to entity result page when not yet suggestions and pattern matching', () => {
+    wrapper.setProps({
+      results: {
+        delegates: [],
+        addresses: [],
+        transactions: [],
+      },
+    });
+    wrapper.update();
+    const autosuggestInput = wrapper.find('.autosuggest-input').find('input').first();
+    autosuggestInput.simulate('change', { target: { value: '123' } });
+    autosuggestInput.simulate('keyDown', {
+      keyCode: keyCodes.enter,
+      which: keyCodes.enter,
+    });
+    expect(saveSearchSpy).to.have.been.calledWith();
+    expect(submitSearchAnythingSpy).to.have.been.calledWith();
+    expect(props.history.push).to.have.been
+      .calledWith(`${routes.transactions.pathPrefix}${routes.transactions.path}/123`);
+  });
+
   it('should update placeholder on events {arrowUp/arrowDown} and redirect to entity page on keyboard event {tab}', () => {
     const autosuggestInput = wrapper.find('.autosuggest-input').find('input').first();
 

--- a/src/constants/search.js
+++ b/src/constants/search.js
@@ -1,0 +1,6 @@
+// eslint-disable-next-line import/prefer-default-export
+export const searchEntities = {
+  delegates: 'delegates',
+  addresses: 'addresses',
+  transactions: 'transactions',
+};


### PR DESCRIPTION
### What was the problem?
- using a valid address, or transaction id, was not redirecting properly to the entity results page. 

### How did I fix it?
- add pattern matching and reuse redirection method in case of match
### How to test it?
- copy a valid {transactionId, addressId}, really quickly paste it on the autosuggest field and immediately press enter without giving time for the search to be triggered. 
- the result should be the same, as when suggestion is shown and a click is performed on it. 
### Review checklist
- The PR solves #946 
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
