### PR TITLE
Autosuggest should not collide with main content on signin - Closes #958

### DIFF
--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -24,7 +24,7 @@
   & .searchBar {
     display: inline-block;
     float: left;
-    margin-bottom: 33px;
+    margin-bottom: 30px;
   }
 }
 

--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -15,7 +15,6 @@
 }
 
 .wrapper {
-  margin: 0 0 30px;
   text-align: right;
 
   & .noPadding {
@@ -25,6 +24,7 @@
   & .searchBar {
     display: inline-block;
     float: left;
+    margin-bottom: 33px;
   }
 }
 
@@ -212,6 +212,7 @@
 
     & .searchBar {
       width: 100%;
+      margin-bottom: 0;
     }
   }
 


### PR DESCRIPTION
### What was the problem?
- There were margin added to a wrapper which, in Safari, entered in conflict with some negative margins used by the box wrapper. 

### How did I fix it?
- Add those margins only to the searchBar class selector, and not the wrapper. 

### How to test it?
- go to `/#/?referrer=/dashboard` and check position of search bar not colliding with `signUp__signUp___`, 
- make sure margins stay the same for a regular content page. 

### Review checklist
- The PR solves #958 
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
