### PR TITLE
Don't hide explorer elements while loading - Closes #928

### DIFF
--- a/src/components/accountTransactions/index.js
+++ b/src/components/accountTransactions/index.js
@@ -14,7 +14,6 @@ class AccountTransactions extends React.Component {
         <SendTo
           address={this.props.match.params.address}
           t={this.props.t}
-          notLoading={this.props.notLoading}
           account={this.props.account}
           delegate={this.props.delegate}
         />
@@ -32,7 +31,6 @@ class AccountTransactions extends React.Component {
 const mapStateToProps = state => ({
   publicKey: state.account.publicKey,
   activePeer: state.peers.data,
-  notLoading: state.loading.length === 0,
   peers: state.peers,
   account: state.search.accounts[state.search.lastSearch] || {},
   delegate: state.search.delegates[state.search.lastSearch] || {},

--- a/src/components/sendTo/send.js
+++ b/src/components/sendTo/send.js
@@ -17,7 +17,7 @@ import styles from './sendTo.css';
 class SendTo extends React.Component {
   render() {
     const {
-      accounts, account, address, delegate, notLoading, nextStep, t, removeAccount,
+      accounts, account, address, delegate, nextStep, t, removeAccount,
     } = this.props;
 
     const isFollowing = getIndexOfFollowedAccount(accounts, account) !== -1;
@@ -60,11 +60,8 @@ class SendTo extends React.Component {
         `}>
               <h2>
               <span>
-                {
-                  notLoading
-                    ? <LiskAmount val={account.balance}/>
-                    : null
-                } <small className={styles.balanceUnit}>LSK</small>
+                <LiskAmount val={account.balance}/>
+                <small className={styles.balanceUnit}>LSK</small>
               </span>
               </h2>
               <CopyToClipboard value={account.address} className={`${styles.address}`} copyClassName={styles.copy} />

--- a/src/components/sendTo/sendTo.test.js
+++ b/src/components/sendTo/sendTo.test.js
@@ -15,7 +15,6 @@ describe('SendTo Component', () => {
     isDelegate: true,
   };
   const props = {
-    notLoading: false,
     nextStep: spy(),
     account,
     delegate: {
@@ -37,9 +36,7 @@ describe('SendTo Component', () => {
       wrapper.setProps({ account });
     });
 
-    it('shows balance when loaded', () => {
-      expect(wrapper.find('LiskAmount')).to.have.length(0);
-      wrapper.setProps({ notLoading: true });
+    it('shows balance', () => {
       expect(wrapper.find('LiskAmount')).to.have.length(1);
     });
 

--- a/src/components/transactions/transactionList.js
+++ b/src/components/transactions/transactionList.js
@@ -57,6 +57,7 @@ class TransactionsList extends React.Component {
     };
 
     if (loading) return null;
+
     // istanbul ignore else
     if (transactions.length === 0) {
       // istanbul ignore else

--- a/src/components/transactions/transactionList.js
+++ b/src/components/transactions/transactionList.js
@@ -36,7 +36,6 @@ class TransactionsList extends React.Component {
   render() {
     const {
       transactions,
-      loading,
       dashboard,
       address,
       onClick,
@@ -55,8 +54,6 @@ class TransactionsList extends React.Component {
 
       return !(isFilterIncoming && (isTypeNonSend || isAccountInit));
     };
-
-    if (loading) return null;
 
     // istanbul ignore else
     if (transactions.length === 0) {

--- a/src/components/transactions/transactionList.test.js
+++ b/src/components/transactions/transactionList.test.js
@@ -66,12 +66,6 @@ describe('TransactionsList', () => {
     history: { location: { search: { id: transactions[0].id } } },
   };
 
-  it('should render nothing while loading', () => {
-    const propsOnLoading = Object.assign({}, props, { loading: true });
-    wrapper = mount(<TransactionsList {...propsOnLoading} />, options);
-    expect(wrapper.html()).to.be.equal(null);
-  });
-
   it('should render empty state template if transactions list is empty', () => {
     const propsNoTx = Object.assign({}, props, { transactions: emptyTx });
     wrapper = mount(<TransactionsList {...propsNoTx} />, options);


### PR DESCRIPTION
### What was the problem?
- there were some flags used to hide elements while a request was being resolved. 

### How did I fix it?
- I removed the flags as there is already a UI visual indicator that data is being loaded, and therefore is expected that UI element will update values once finishing. 
### How to test it?

### Review checklist
- The PR solves #928 
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
