### PR TITLE
Change address validation regex, no lowercase l - Closes #956

### DIFF
--- a/src/utils/regex.js
+++ b/src/utils/regex.js
@@ -1,5 +1,5 @@
 export default {
-  address: /^\d{1,21}[L|l]$/,
+  address: /^\d{1,21}[L]$/,
   transactionId: /^[0-9]+$/,
   amount: /^\d+(\.\d{1,8})?$/,
 };


### PR DESCRIPTION
### What was the problem?
Address allowed lowercase `l`
### How did I fix it?
CHanged regex for address validation
### How to test it?

### Review checklist
- The PR solves #956
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
