### PR TITLE
Onboarding overlay should not allow to click on UI - Closes 957

### DIFF
--- a/src/components/app/app.css
+++ b/src/components/app/app.css
@@ -16,6 +16,7 @@ body {
   top: 0;
   align-items: center;
   display: flex;
+  z-index: 0;
 
   & > section {
     width: 100%;

--- a/src/components/onboarding/index.js
+++ b/src/components/onboarding/index.js
@@ -97,7 +97,7 @@ class Onboarding extends React.Component {
 
   render() {
     const { isDesktop, skip, intro } = this.state;
-    return <Joyride
+    return <div className={this.props.isAuthenticated && this.props.start && isDesktop ? 'joyride-showing' : ''}> <Joyride
       ref={(el) => { this.joyride = el; }}
       steps={this.state.steps}
       run={this.props.isAuthenticated && this.props.start && isDesktop}
@@ -112,7 +112,7 @@ class Onboarding extends React.Component {
       autoStart={true}
       type='continuous'
       holePadding={0}
-    />;
+    /></div>;
   }
 }
 

--- a/src/components/onboarding/onboarding.css
+++ b/src/components/onboarding/onboarding.css
@@ -51,13 +51,42 @@
   width: 100%;
 }
 
-:global .joyride-overlay {
+:global .joyride {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  right: 0;
   bottom: 0;
   left: 0;
+}
+
+:global .joyride-showing {
+  & .joyride {
+    z-index: 1;
+  }
+}
+
+:global .joyride-overlay {
   position: absolute;
-  right: 0;
+  width: 100%;
+  height: 0;
   top: 0;
-  z-index: 1500;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 25;
+
+  &::after {
+    position: absolute;
+    content: '';
+    display: block;
+    height: 100%;
+    width: 100%;
+    z-index: 25;
+    background-color: rgba(0,26,62, 0.9);
+    pointer-events: none;
+  }
 }
 
 :global .joyride-hole {

--- a/test/e2e/login.feature
+++ b/test/e2e/login.feature
@@ -8,6 +8,8 @@ Feature: Login
     And I click "login button"
     Then I should be logged in as "genesis" account
     And I should see no "peer network"
+    And I click "joyride-tooltip__button--skip"
+    And I click "joyride-tooltip__button--skip"
     When I click "transactions" menu
     And I should see 0 rows
     Then I should see text "No activity yet" in "empty message" element
@@ -23,6 +25,8 @@ Feature: Login
     And I click "login button"
     Then I should be logged in as "genesis" account
     And I should see text "testnet" in "peer network" element
+    And I click "joyride-tooltip__button--skip"
+    And I click "joyride-tooltip__button--skip"
     When I click "transactions" menu
     Then I should see 25 rows
 
@@ -36,5 +40,7 @@ Feature: Login
     And I click "login button"
     Then I should be logged in as "genesis" account
     And I should see text "custom node" in "peer network" element
+    And I click "joyride-tooltip__button--skip"
+    And I click "joyride-tooltip__button--skip"
     When I click "transactions" menu
     Then I should see 25 rows


### PR DESCRIPTION
### What was the problem?
- onboarding allowed to click UI elements behind the overlay background
### How did I fix it?
- a mix of changes in css, to make a layer block the pointer events
- a flag in onboarding template to apply a z-index only when is showing
### How to test it?
- start onboarding and verify none elements can be clicked when it's open, but only the onboarding widget actions. 
### Review checklist
- The PR solves #957
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
