### PR TITLE
Register delegate should pass e2e tests migration 1.0.0 - Closes #940

### DIFF
--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -9,6 +9,7 @@ exports.config = {
     'test/e2e/*followedAccounts.feature',
     'test/e2e/*signMessage.feature',
     'test/e2e/*savedAccounts.feature',
+    'test/e2e/*registerDelegate.feature',
   ],
 
   directConnect: true,

--- a/test/e2e/registerDelegate.feature
+++ b/test/e2e/registerDelegate.feature
@@ -11,7 +11,7 @@ Feature: Register delegate
     And I click "second-passphrase-next"
     And I wait 1 seconds
     And I click "confirm-delegate-registration"
-    And I wait 45 seconds
+    And I wait 20 seconds
     Then I should see text "Success!" in "success-header" element
     Then I should see text "Your registration is secured on the blockchain" in "success-description" element
     And I click "registration-success"

--- a/test/e2e/registerDelegate.feature
+++ b/test/e2e/registerDelegate.feature
@@ -11,7 +11,7 @@ Feature: Register delegate
     And I click "second-passphrase-next"
     And I wait 1 seconds
     And I click "confirm-delegate-registration"
-    And I wait 25 seconds
+    And I wait 30 seconds
     Then I should see text "Success!" in "success-header" element
     Then I should see text "Your registration is secured on the blockchain" in "success-description" element
     And I click "registration-success"

--- a/test/e2e/registerDelegate.feature
+++ b/test/e2e/registerDelegate.feature
@@ -11,7 +11,7 @@ Feature: Register delegate
     And I click "second-passphrase-next"
     And I wait 1 seconds
     And I click "confirm-delegate-registration"
-    And I wait 35 seconds
+    And I wait 45 seconds
     Then I should see text "Success!" in "success-header" element
     Then I should see text "Your registration is secured on the blockchain" in "success-description" element
     And I click "registration-success"

--- a/test/e2e/registerDelegate.feature
+++ b/test/e2e/registerDelegate.feature
@@ -11,7 +11,7 @@ Feature: Register delegate
     And I click "second-passphrase-next"
     And I wait 1 seconds
     And I click "confirm-delegate-registration"
-    And I wait 30 seconds
+    And I wait 35 seconds
     Then I should see text "Success!" in "success-header" element
     Then I should see text "Your registration is secured on the blockchain" in "success-description" element
     And I click "registration-success"

--- a/test/e2e/registerDelegate.feature
+++ b/test/e2e/registerDelegate.feature
@@ -11,7 +11,7 @@ Feature: Register delegate
     And I click "second-passphrase-next"
     And I wait 1 seconds
     And I click "confirm-delegate-registration"
-    And I wait 20 seconds
+    And I wait 25 seconds
     Then I should see text "Success!" in "success-header" element
     Then I should see text "Your registration is secured on the blockchain" in "success-description" element
     And I click "registration-success"


### PR DESCRIPTION
### What was the problem?
- registerDelegate still had some requests using lisk-js pattern
### How did I fix it?
- update requests to use lisk-elements pattern

### How to test it?

### Review checklist
- The PR solves #940 
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
