### PR TITLE
Fix failed login action to clear out account - Closes #976

### DIFF
--- a/src/store/middlewares/login.js
+++ b/src/store/middlewares/login.js
@@ -2,7 +2,7 @@ import i18next from 'i18next';
 import { getAccount } from '../../utils/api/account';
 import { extractAddress, extractPublicKey } from '../../utils/account';
 import { getDelegate } from '../../utils/api/delegate';
-import { accountLoggedIn, accountLoading } from '../../actions/account';
+import { accountLoggedIn, accountLoading, accountLoggedOut } from '../../actions/account';
 import actionTypes from '../../constants/actions';
 import accountConfig from '../../constants/account';
 import { errorToastDisplayed } from '../../actions/toaster';
@@ -46,7 +46,10 @@ const loginMiddleware = store => next => (action) => {
           ...{ delegate: {}, isDelegate: false, expireTime: duration },
         }));
       });
-  }).catch(() => store.dispatch(errorToastDisplayed({ label: i18next.t('Unable to connect to the node') })));
+  }).catch(() => {
+    store.dispatch(errorToastDisplayed({ label: i18next.t('Unable to connect to the node') }));
+    store.dispatch(accountLoggedOut());
+  });
 };
 
 export default loginMiddleware;

--- a/test/integration/accountSwitch.test.js
+++ b/test/integration/accountSwitch.test.js
@@ -44,6 +44,7 @@ describe('@integration: Account switch', () => {
 
   beforeEach(() => {
     getAccountStub = stub(accountApi, 'getAccount');
+    getAccountStub.returnsPromise().resolves(accounts.genesis);
     getAccountStub.withArgs(match.any, accounts.genesis.address)
       .returnsPromise().resolves(accounts.genesis);
     getAccountStub.withArgs(match.any, accounts.delegate.address)


### PR DESCRIPTION
### What was the problem?
The login page doesn't allow to log in to another account after a login attempt failed.

### How did I fix it?
By clearing the `pending` value form the redux store account object, using `accountLoggedOut` action.

### How to test it?
If you don't have a saved testnet account already, you can log in to mainnet and then edit the saved accounts local storage of that account and change its `network` from `0` to `1`.


### Review checklist
- The PR solves #976
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
