### PR TITLE
Remove lisk_1 output from jenkins - Closes #980

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,12 +130,6 @@ node('lisk-hub') {
     }
   } catch(err) {
     echo "Error: ${err}"
-    ansiColor('xterm') {
-      sh '''
-      cd $WORKSPACE/$BRANCH_NAME
-      docker-compose logs
-      '''
-    }
   } finally {
     ansiColor('xterm') {
       sh '''


### PR DESCRIPTION
### What was the problem?
lisk_1 output after failed e2e tests

### How did I fix it?
remove docker-compose logs output

### Review checklist
- The PR solves #980 
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
