### PR TITLE
Fix explorer transaction details redirection - Closes #995

### DIFF
--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -161,7 +161,7 @@
   "Mainnet": "Mainnet",
   "Manage your application": "Manage your application",
   "Max 20 characters a-z 0-1, no special characters except “!@$&_.”": "Max 20 characters a-z 0-1, no special characters except “!@$&_.”",
-  "Max 64 bytes message": "Max 64 bytes message",
+  "Maximum length exceeded": "Maximum length exceeded",
   "Maximum of 101 votes in total": "Maximum of 101 votes in total",
   "Maximum of {{maxcount}} votes at a time": "Maximum of {{maxcount}} votes at a time",
   "Menu": "Menu",

--- a/src/actions/transactions.js
+++ b/src/actions/transactions.js
@@ -108,8 +108,19 @@ export const loadTransaction = ({ activePeer, id }) =>
     dispatch({ type: actionTypes.transactionCleared });
     getSingleTransaction({ activePeer, id })
       .then((response) => {
-        const added = response.data[0].asset.votes.filter(item => item.startsWith('+')).map(item => item.replace('+', '')) || [];
-        const deleted = response.data[0].asset.votes.filter(item => item.startsWith('-')).map(item => item.replace('-', '')) || [];
+        let added = [];
+        let deleted = [];
+
+        if (!response.data.length > 0) {
+          dispatch({ data: { error: 'Transaction not found' }, type: actionTypes.transactionLoadFailed });
+          return;
+        }
+
+        if ('votes' in response.data[0].asset) {
+          added = response.data[0].asset.votes.filter(item => item.startsWith('+')).map(item => item.replace('+', ''));
+          deleted = response.data[0].asset.votes.filter(item => item.startsWith('-')).map(item => item.replace('-', ''));
+        }
+
         const localStorageDelegates = loadDelegateCache(activePeer);
         deleted.forEach((publicKey) => {
           const address = extractAddress(publicKey);
@@ -155,7 +166,7 @@ export const loadTransaction = ({ activePeer, id }) =>
         });
         dispatch({ data: response.data[0], type: actionTypes.transactionLoaded });
       }).catch((error) => {
-        dispatch({ data: error, type: actionTypes.transactionLoadFailed });
+        dispatch({ data: { error }, type: actionTypes.transactionLoadFailed });
       });
   };
 

--- a/src/actions/transactions.js
+++ b/src/actions/transactions.js
@@ -111,7 +111,7 @@ export const loadTransaction = ({ activePeer, id }) =>
         let added = [];
         let deleted = [];
 
-        if (!response.data.length > 0) {
+        if (!response.data.length) {
           dispatch({ data: { error: 'Transaction not found' }, type: actionTypes.transactionLoadFailed });
           return;
         }

--- a/test/e2e/explorer.feature
+++ b/test/e2e/explorer.feature
@@ -62,12 +62,15 @@ Feature: Explorer page
     When I click "send to address"
     Then I should see "16313739661670634666L" in "recipient" field
     When I click "home link"
+    And I click "autosuggest btn close"
     When I fill in "9938914350729699234" to "autosuggest input" field
     And I hit "ENTER" key in "autosuggest input" input
     Then I should see text "No results" in "empty message" element
     And I click "autosuggest btn close"
     And I fill in "1465651642158264047" to "autosuggest input" field
+    And I wait 1 seconds
     When I click "transactions result"
+    And I wait 3 seconds
     Then I should see ID "1465651642158264047" in transaction header
 
   Scenario: should show added voters in "voted delegate" transaction type while being logged in


### PR DESCRIPTION
### What was the problem?
- Processing added/deleted votes of a transaction was causing an error, when the tx didn't have this field in the response
### How did I fix it?
- check that the flag exists and provide default empty arrays. 
### How to test it?

### Review checklist
- The PR solves #995 
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
