### PR TITLE
Enable signMessage e2e tests - Closes #1019

### DIFF
--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -6,6 +6,7 @@ exports.config = {
     'test/e2e/*explorer.feature',
     'test/e2e/*onboarding.feature',
     'test/e2e/*followedAccounts.feature',
+    'test/e2e/*signMessage.feature',
   ],
 
   directConnect: true,

--- a/src/components/signMessage/confirmMessage.js
+++ b/src/components/signMessage/confirmMessage.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Lisk from 'lisk-js';
+import Lisk from 'lisk-elements';
 import styles from './confirmMessage.css';
 import { Button } from '../toolbox/buttons/button';
 import Input from '../toolbox/inputs/input';
@@ -61,14 +61,16 @@ class ConfirmMessage extends React.Component {
 
   sign() {
     const { message } = this.props;
-    const signedMessage = Lisk.crypto.signMessageWithSecret(
+    const signedMessage = Lisk.cryptography.signMessageWithPassphrase(
       message,
-      this.state.passphrase.value,
+      this.state.passphrase.value || this.props.account.passphrase,
+      this.props.account.publicKey,
     );
-    const result = Lisk.crypto.printSignedMessage(
+    const result = Lisk.cryptography.printSignedMessage({
       message,
-      signedMessage, this.props.account.publicKey,
-    );
+      publicKey: this.props.account.publicKey,
+      signature: signedMessage.signature,
+    });
     return result;
   }
 

--- a/test/e2e/signMessage.feature
+++ b/test/e2e/signMessage.feature
@@ -3,4 +3,15 @@ Feature: Sign message
     Given I'm logged in as "genesis"
     When I go to "/sign-message?message=my message"
     Then I click "next"
-    Then I should see "result" element
+    And I wait 2 seconds
+    Then I should see in "result" field:
+    """
+    -----BEGIN LISK SIGNED MESSAGE-----
+    -----MESSAGE-----
+    my message
+    -----PUBLIC KEY-----
+    c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f
+    -----SIGNATURE-----
+    b4f4f29fb8bc3c540581137e522103e33e1ccac9ef5f652da53239adae3fbb990d6a25c935dd3ff5026b26095ded100cd8b45c9b2311ec2687957145f09aa50f
+    -----END LISK SIGNED MESSAGE-----
+    """


### PR DESCRIPTION
### What was the problem?
- signMessage e2e tests were not enabled
### How did I fix it?
- enabling them, and updating e2e asserting the output is valid
### How to test it?

### Review checklist
- The PR solves #1019
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
