### PR TITLE
Show reference field on confirmation screen - Closes #1018

### DIFF
--- a/src/components/sendReadable/send.js
+++ b/src/components/sendReadable/send.js
@@ -119,6 +119,15 @@ class SendReadable extends React.Component {
               onChange={this.handleChange.bind(this, 'recipient')}
               disabled={true}
             />
+            {this.state.reference.value ?
+              <Input label={this.props.t('Reference')}
+                className={`reference ${styles.disabledInput}`}
+                error={this.state.reference.error}
+                value={this.state.reference.value}
+                disabled={true}
+                theme={styles}
+              /> : null
+            }
 
             <Input label={this.props.t('Total incl. {{fee}} LSK Fee', { fee: fromRawLsk(fees.send) })}
               className={`amount ${styles.disabledInput}`}


### PR DESCRIPTION
### What was the problem?
No reference field on a confirmation screen
### How did I fix it?
added reference field
### How to test it?
Send transactoin with reference field and check if it is on confirmation page
### Review checklist
- The PR solves #1018
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
