### PR TITLE
Fix remove passphrase when locking an account - Closes #1022

### DIFF
--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -67,7 +67,7 @@ class Header extends React.Component {
                               date={this.props.account.expireTime}
                               renderer={CountDownTemplate}
                               onComplete={() => {
-                                this.props.removeSavedAccountPassphrase();
+                                this.props.removeSavedAccountPassphrase(this.props.account);
                               }}
                             >
                               <CustomCountDown

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -20,7 +20,7 @@ const mapDispatchToProps = dispatch => ({
   setActiveDialog: data => dispatch(dialogDisplayed(data)),
   logOut: () => dispatch(accountLoggedOut()),
   removePassphrase: data => dispatch(removePassphrase(data)),
-  removeSavedAccountPassphrase: () => dispatch(removeSavedAccountPassphrase()),
+  removeSavedAccountPassphrase: data => dispatch(removeSavedAccountPassphrase(data)),
   resetTimer: () => dispatch(accountUpdated({ expireTime: Date.now() + lockDuration })),
 });
 export default withRouter(connect(

--- a/src/components/savedAccounts/accountCard.js
+++ b/src/components/savedAccounts/accountCard.js
@@ -31,7 +31,7 @@ const AccountCard = ({
       null)}
     {(account.network !== networks.mainnet.code ?
       <strong className={styles.network}>
-        {account.address ? account.address : t(getNetwork(account.network).name)}
+        {account.peerAddress ? account.peerAddress : t(getNetwork(account.network).name)}
       </strong> :
       null)}
     <div className={styles.cardIcon}>

--- a/src/store/middlewares/login.js
+++ b/src/store/middlewares/login.js
@@ -13,14 +13,15 @@ const loginMiddleware = store => next => (action) => {
   }
   next(action);
 
-  const { passphrase, activePeer } = action.data;
+  const { passphrase, activePeer, options } = action.data;
   const publicKey = passphrase ? extractPublicKey(passphrase) : action.data.publicKey;
   const address = extractAddress(publicKey);
   const accountBasics = {
     passphrase,
     publicKey,
     address,
-    network: activePeer.currentNode,
+    network: options.code,
+    peerAddress: options.address,
   };
 
   store.dispatch(accountLoading());

--- a/src/store/middlewares/savedAccounts.js
+++ b/src/store/middlewares/savedAccounts.js
@@ -84,7 +84,7 @@ const savedAccountsMiddleware = (store) => {
           passphrase: action.data.passphrase,
           network: {
             ...getNetwork(action.data.network),
-            address: action.data.address,
+            address: action.data.peerAddress,
           },
         }));
         break;
@@ -103,7 +103,7 @@ const savedAccountsMiddleware = (store) => {
           balance: action.data.balance,
           publicKey: action.data.publicKey,
           network: peers.options.code,
-          address: action.data.network,
+          peerAddress: action.data.peerAddress,
         }));
         break;
       case actionTypes.accountRemoved:

--- a/src/store/middlewares/savedAccounts.js
+++ b/src/store/middlewares/savedAccounts.js
@@ -103,7 +103,7 @@ const savedAccountsMiddleware = (store) => {
           balance: action.data.balance,
           publicKey: action.data.publicKey,
           network: peers.options.code,
-          address: peers.options.address,
+          address: action.data.network,
         }));
         break;
       case actionTypes.accountRemoved:

--- a/src/store/middlewares/savedAccounts.js
+++ b/src/store/middlewares/savedAccounts.js
@@ -20,7 +20,7 @@ const savedAccountsMiddleware = (store) => {
 
       /* istanbul ignore if  */
       if (account.network === networks.customNode.code) {
-        network.address = account.address;
+        network.address = account.peerAddress;
       }
 
       store.dispatch(activePeerSet({

--- a/src/store/reducers/savedAccounts.js
+++ b/src/store/reducers/savedAccounts.js
@@ -47,7 +47,6 @@ const savedAccounts = (state = { accounts: [] }, action) => {
           passphrase: action.data,
         },
       };
-
     case actionTypes.accountSwitched:
       return {
         ...state,
@@ -65,7 +64,7 @@ const savedAccounts = (state = { accounts: [] }, action) => {
         ...state,
         accounts: state.accounts.map((account) => {
           if (!action.data ||
-            (action.data.network.indexOf(account.address) > -1 &&
+            (action.data.peerAddress === account.peerAddress &&
             action.data.passphrase === account.passphrase)) {
             delete account.passphrase;
           }

--- a/src/store/reducers/savedAccounts.js
+++ b/src/store/reducers/savedAccounts.js
@@ -64,7 +64,9 @@ const savedAccounts = (state = { accounts: [] }, action) => {
       return {
         ...state,
         accounts: state.accounts.map((account) => {
-          if (!action.data || (`${action.data.network}${action.data.passphrase}` === `${account.network}${account.passphrase}`)) {
+          if (!action.data ||
+            (action.data.network.indexOf(account.address) > -1 &&
+            action.data.passphrase === account.passphrase)) {
             delete account.passphrase;
           }
           return account;

--- a/src/utils/savedAccounts.js
+++ b/src/utils/savedAccounts.js
@@ -1,11 +1,11 @@
 import { validateUrl } from './login';
 import { extractAddress } from './account';
 
-const isValidSavedAccount = ({ publicKey, network, address }) => {
+const isValidSavedAccount = ({ publicKey, network, peerAddress }) => {
   try {
     return extractAddress(publicKey) &&
       network >= 0 && network <= 2 &&
-      (validateUrl(address).addressValidity === '' || network !== 2);
+      (validateUrl(peerAddress).addressValidity === '' || network !== 2);
   } catch (e) {
     return false;
   }
@@ -21,9 +21,9 @@ export const getSavedAccounts = () => {
 
 export const setSavedAccounts = (accounts) => {
   accounts = accounts.map(({
-    publicKey, network, address, balance,
+    publicKey, network, address, balance, peerAddress,
   }) => ({
-    publicKey, network, address, balance,
+    publicKey, network, address, balance, peerAddress,
   }));
   localStorage.setItem('accounts', JSON.stringify(accounts));
 };


### PR DESCRIPTION
### What was the problem?
#1022 
### How did I fix it?
- account.address was used in activePeerSet to reflect which url the account should connect to.
- this was misleading and colliding with account.address ID, I've renamed the key to be peerAddress, so that is not longer confusing.
### How to test it?

### Review checklist
- The PR solves #1022 
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
