### PR TITLE
:bug: Fix amount of non-send transactions in the list - Closes #1033

### DIFF
--- a/src/components/transactions/amount.js
+++ b/src/components/transactions/amount.js
@@ -14,12 +14,12 @@ const Amount = (props) => {
     params.className = 'greenLabel';
     params.pre = '+';
   } else if ((props.value.type !== transactionTypes.send ||
-      props.value.recipientId !== props.address) && props.value.amount !== 0) {
+      props.value.recipientId !== props.address) && props.value.amount !== '0') {
     params.pre = '-';
     params.className = 'greyLabel';
     params.clickToSendEnabled = props.value.type === transactionTypes.send;
   }
-  const amount = props.value.amount === 0 ? '-' : <LiskAmount val={props.value.amount} />;
+  const amount = props.value.amount === '0' ? '-' : <LiskAmount val={props.value.amount} />;
   return <span id='transactionAmount' className={styles[params.className]}>
     { params.pre }{amount}
   </span>;


### PR DESCRIPTION
### What was the problem?
See #1033 because the amount field in the api changed from int to string. The code was expecting `0`, but got `'0'`.
### How did I fix it?
I changed `0` to `'0'` in the amount component.

### How to test it?
Follow steps in #1033

### Review checklist
- The PR solves #1033
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
