### PR TITLE
Fix forged and missed blocks numbers in delegate statistics - Closes #1034

### DIFF
--- a/src/components/transactions/delegateStatistics.js
+++ b/src/components/transactions/delegateStatistics.js
@@ -41,7 +41,7 @@ class DelegateStatistics extends React.Component {
           <div className={`${grid['col-xs-12']} ${grid['col-sm-8']} ${grid['col-md-8']} blocks`}>
             <div className={styles.label}>{this.props.t('Blocks')}</div>
             <div className={styles.value}>
-              {`${delegate && delegate.producedblocks} (${delegate && delegate.missedblocks} ${missed})`}
+              {`${delegate && delegate.producedBlocks} (${delegate && delegate.missedBlocks} ${missed})`}
             </div>
           </div>
         </div>


### PR DESCRIPTION
### What was the problem?
See  #1034

### How did I fix it?
`producedblocks` changed to `producedBlocks` 
`missedblocks` changed to `missedBlocks`
because it changed in the Lisk Core 1.0.0 API

### How to test it?
Follow steps in  #1034

### Review checklist
- The PR solves #1034
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
