### PR TITLE
Fix main menu to have always enabled Settings item - Closes #1036

### DIFF
--- a/src/components/mainMenu/mainMenu.js
+++ b/src/components/mainMenu/mainMenu.js
@@ -48,7 +48,7 @@ class MainMenu extends React.Component {
   navigate(history, tabs, index) {
     if (!isCurrent(history, index, tabs)) {
       this.setState({ active: false, index });
-      history.replace(tabs[index].route);
+      history.push(tabs[index].route);
     }
   }
 

--- a/src/components/mainMenu/mainMenu.js
+++ b/src/components/mainMenu/mainMenu.js
@@ -90,6 +90,7 @@ class MainMenu extends React.Component {
         route: `${routes.setting.path}`,
         id: 'settings',
         image: menuLogos.settings,
+        enabledWhenNotLoggedIn: true,
       },
     ];
 
@@ -102,9 +103,6 @@ class MainMenu extends React.Component {
       });
     }
 
-    const itemShouldBeDisabled = index =>
-      (isCurrent(history, index, tabs) || !account.address) && index !== 3;
-
     return (
       <Fragment>
         <aside className={styles.aside}>
@@ -115,13 +113,15 @@ class MainMenu extends React.Component {
               onChange={this.navigate.bind(this, history, tabs)}
               disableAnimatedBottomBorder={true}
               className={`${styles.tabs} main-tabs`}>
-              {tabs.map(({ label, image, id }, index) =>
+              {tabs.map(({
+                   label, image, id, enabledWhenNotLoggedIn,
+                  }, index) =>
                 <Tab
                   key={index}
                   label={<TabTemplate label={label} img={image} />}
                   className={styles.tab}
                   id={id}
-                  disabled={itemShouldBeDisabled(index)}
+                  disabled={!account.address && !enabledWhenNotLoggedIn}
                 />)}
             </ToolboxTabs>
             <Drawer theme={styles}
@@ -138,12 +138,14 @@ class MainMenu extends React.Component {
                   onChange={this.navigate.bind(this, history, tabs)}
                   disableAnimatedBottomBorder={true}
                   className={`${styles.tabs} main-tabs`}>
-                  {tabs.map(({ label, image, id }, index) =>
+                  {tabs.map(({
+                       label, image, id, enabledWhenNotLoggedIn,
+                      }, index) =>
                     <Tab
                       key={index}
                       label={<TabTemplate label={label} img={image} />}
                       id={id}
-                      disabled={itemShouldBeDisabled(index)}
+                      disabled={!account.address && !enabledWhenNotLoggedIn}
                     />)}
                 </ToolboxTabs>
               </div>

--- a/src/components/mainMenu/mainMenu.js
+++ b/src/components/mainMenu/mainMenu.js
@@ -19,9 +19,6 @@ const getIndex = (history, tabs) => {
   return index;
 };
 
-const isCurrent = (history, index, tabs) =>
-  history.location.pathname.indexOf(tabs[index].route) === 6; // after: /main/
-
 const TabTemplate = ({ img, label }) => (
   <div>
     <img src={img} />
@@ -46,10 +43,8 @@ class MainMenu extends React.Component {
   }
 
   navigate(history, tabs, index) {
-    if (!isCurrent(history, index, tabs)) {
-      this.setState({ active: false, index });
-      history.push(tabs[index].route);
-    }
+    this.setState({ active: false, index });
+    history.push(tabs[index].route);
   }
 
   settingToggle() {


### PR DESCRIPTION
### What was the problem?
The enabled menu item was defined as the one at index 3, which resulted in #1036

### How did I fix it?
I added `enabledWhenNotLoggedIn` property to settings menu item object to control if it's enabled.

### How to test it?
Follow steps in #1036

### Review checklist
- The PR solves #1036
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
