### PR TITLE
Fix transaction amount on pending non-send transactions - Close #1033

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,7 +100,7 @@ node('lisk-hub') {
 	    cp -r ~/lisk-docker/examples/development $WORKSPACE/$BRANCH_NAME
 	    cd $WORKSPACE/$BRANCH_NAME
 	    cp /home/lisk/blockchain_explorer.db.gz ./blockchain.db.gz
-	    LISK_VERSION=1.0.0-rc.2 make coldstart
+	    LISK_VERSION=1.0.0-rc.1 make coldstart
 	    LISK_PORT=$( docker-compose port lisk 4000 |cut -d ":" -f 2 )
 	    cd -
 

--- a/src/components/transactions/amount.js
+++ b/src/components/transactions/amount.js
@@ -13,13 +13,12 @@ const Amount = (props) => {
   } else if (props.value.senderId !== props.address) {
     params.className = 'greenLabel';
     params.pre = '+';
-  } else if ((props.value.type !== transactionTypes.send ||
-      props.value.recipientId !== props.address) && props.value.amount !== '0') {
+  } else if (props.value.type === transactionTypes.send &&
+      props.value.recipientId !== props.address) {
     params.pre = '-';
     params.className = 'greyLabel';
-    params.clickToSendEnabled = props.value.type === transactionTypes.send;
   }
-  const amount = props.value.amount === '0' ? '-' : <LiskAmount val={props.value.amount} />;
+  const amount = props.value.type !== transactionTypes.send ? '-' : <LiskAmount val={props.value.amount} />;
   return <span id='transactionAmount' className={styles[params.className]}>
     { params.pre }{amount}
   </span>;

--- a/test/e2e/send.feature
+++ b/test/e2e/send.feature
@@ -1,5 +1,5 @@
 Feature: Send dialog
-  # @testnet
+  @testnet
   Scenario: should allow to send when enough funds and correct address form
     Given I'm logged in as "genesis"
     And I fill in "1" to "amount" field
@@ -13,9 +13,9 @@ Feature: Send dialog
     And I should see 5 rows
     And I wait 15 seconds
     When I click "seeAllLink"
-    And I should see 26 rows
-    # When I scroll to the bottom of "transaction results"
-    # Then I should see 50 rows
+    And I should see 25 rows
+    When I scroll to the bottom of "transaction results"
+    Then I should see 50 rows
 
   Scenario: should allow to send when using launch protocol
     Given I'm logged in as "genesis"


### PR DESCRIPTION
### What was the problem?
See https://github.com/LiskHQ/lisk-hub/issues/1033#issuecomment-405560240

It used to check if the amount is '0' which is not the case with pending transactions

### How did I fix it?
I changed it to check the transaction type because send type cannot
have amount 0.
### How to test it?

### Review checklist
- The PR solves #1033
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
