### PR TITLE
Fix passphrase saved in localstorage - Closes #1054

### DIFF
--- a/src/components/login/login.js
+++ b/src/components/login/login.js
@@ -124,7 +124,9 @@ class Login extends React.Component {
       ...validator(value, error),
     });
 
-    this.props.settingsUpdated({ [name]: value });
+    if (name === 'network') {
+      this.props.settingsUpdated({ network: value });
+    }
   }
 
   onFormSubmit(event) {


### PR DESCRIPTION
### What was the problem?
#1054
### How did I fix it?
Added condition to save only network changes
### How to test it?
Login on your account and check localstorage is passphrase is saved there


### Review checklist
- The PR solves #1054
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
