### PR TITLE
Fix removing passphrase on lock timeout - Closes #1070

### DIFF
--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -68,6 +68,7 @@ class Header extends React.Component {
                               renderer={CountDownTemplate}
                               onComplete={() => {
                                 this.props.removeSavedAccountPassphrase(this.props.account);
+                                this.props.removePassphrase();
                               }}
                             >
                               <CustomCountDown


### PR DESCRIPTION
### What was the problem?
See #1070
### How did I fix it?
By calling the `removePassphrase` action.

### How to test it?
Folow steps in #1070

### Review checklist
- The PR solves #1070
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
