### PR TITLE
Fix the logic to disable checking pending transactions - Closes #1029

### DIFF
--- a/src/actions/transactions.js
+++ b/src/actions/transactions.js
@@ -188,8 +188,8 @@ export const transactionsUpdated = ({
           type: actionTypes.transactionsUpdated,
         });
         // eslint-disable-next-line no-constant-condition
-        if (pendingTransactions.length || true) {
-          // "|| true" above was added to disable this, because this caused pending transactions
+        if (pendingTransactions.length && false) {
+          // "&& false" above was added to disable this, because this caused pending transactions
           // to disappear from the list before they appeared again as confirmed.
           // Currently, the problem is that a pending transaction will not be removed
           // from the list if it fails. Caused by Lisk Core 1.0.0

--- a/src/actions/transactions.js
+++ b/src/actions/transactions.js
@@ -188,17 +188,19 @@ export const transactionsUpdated = ({
           type: actionTypes.transactionsUpdated,
         });
         // eslint-disable-next-line no-constant-condition
-        if (pendingTransactions.length && false) {
-          // "&& false" above was added to disable this, because this caused pending transactions
+        if (pendingTransactions.length) {
+          // this was disabled, because this caused pending transactions
           // to disappear from the list before they appeared again as confirmed.
           // Currently, the problem is that a pending transaction will not be removed
           // from the list if it fails. Caused by Lisk Core 1.0.0
           // TODO: figure out how to make this work again
+          /*
           dispatch(transactionsUpdateUnconfirmed({
             activePeer,
             address,
             pendingTransactions,
           }));
+          */
         }
       });
   };


### PR DESCRIPTION
### What was the problem?
The condition to disable checking pending transactions was wrong.
The original PR tried to disable one function that checks if there are unconfirmed transactions on the server. The problem was that Core is telling us that after the new transactions is forged into a block, there are no unconfirmed transactions, but it doesn't show the new transactions in the confirmed transactions either.

### How did I fix it?
Now the condition is always false, so that `transactionsUpdateUnconfirmed` is never dispatched, so  it doesn't try to check unconfirmed transactions. The effect that a transaction stays in the `pending` state until it is found in the confirmed transactions. So we don't have disappearing transactions anymore. 


### How to test it?

### Review checklist
- The PR solves #1029
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
