### PR TITLE
Hide Fee field on Request transfer - Closes #1052

### DIFF
--- a/src/components/converter/converter.js
+++ b/src/components/converter/converter.js
@@ -84,7 +84,7 @@ class Converter extends React.Component {
             : <div></div>
           }
         </div>
-        <div className={styles.fee}> {this.props.t('Fee: {{fee}} LSK', { fee: fromRawLsk(this.fee) })} </div>
+        { this.props.isRequesting ? null : <div className={styles.fee}> {this.props.t('Fee: {{fee}} LSK', { fee: fromRawLsk(this.fee) })} </div> }
       </Input>
     );
   }

--- a/src/components/request/specifyRequest.js
+++ b/src/components/request/specifyRequest.js
@@ -68,6 +68,7 @@ class SpecifyRequest extends React.Component {
             value={this.state.amount.value}
             onChange={this.handleChange.bind(this, 'amount')}
             t={this.props.t}
+            isRequesting
           />
         </div>
         <footer>


### PR DESCRIPTION
### What was the problem?
Fee field was show on requesting amount
### How did I fix it?
Hide fee field for request amount

### Review checklist
- The PR solves #1052
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
