### PR TITLE
Show conversion even with not Enough LSK error - Closes #987

### DIFF
--- a/src/components/converter/converter.css
+++ b/src/components/converter/converter.css
@@ -9,6 +9,10 @@
   --fee-color: var(--color-grayscale-dark);
 }
 
+.input input {
+  padding-right: 120px;
+}
+
 .form {
   position: relative;
   margin-bottom: 15px;

--- a/src/components/converter/converter.js
+++ b/src/components/converter/converter.js
@@ -4,6 +4,7 @@ import Input from '../toolbox/inputs/input';
 import { fromRawLsk } from '../../utils/lsk';
 
 import fees from './../../constants/fees';
+import converter from './../../constants/converter';
 
 import styles from './converter.css';
 
@@ -53,11 +54,10 @@ class Converter extends React.Component {
 
   render() {
     const { LSK, currencies } = this.state;
-    const maxLSKSupply = 125000000;
 
     let price = !!this.props.error && Number.isNaN(this.props.value) ?
       (0).toFixed(2) : (this.props.value * LSK[currencies[0]]).toFixed(2);
-    price = price > maxLSKSupply || price === 'NaN' ? (0).toFixed(2) : price;
+    price = price > converter.maxLSKSupply || price === 'NaN' ? (0).toFixed(2) : price;
 
     const currenciesObejects = currencies.map((currency, key) => (
       <div

--- a/src/components/converter/converter.js
+++ b/src/components/converter/converter.js
@@ -57,7 +57,7 @@ class Converter extends React.Component {
 
     let price = !!this.props.error && Number.isNaN(this.props.value) ?
       (0).toFixed(2) : (this.props.value * LSK[currencies[0]]).toFixed(2);
-    price = price > converter.maxLSKSupply || price === 'NaN' ? (0).toFixed(2) : price;
+    price = price > converter.maxLSKSupply || price === 'NaN' || price < 0 ? (0).toFixed(2) : price;
 
     const currenciesObejects = currencies.map((currency, key) => (
       <div

--- a/src/components/converter/converter.js
+++ b/src/components/converter/converter.js
@@ -53,8 +53,11 @@ class Converter extends React.Component {
 
   render() {
     const { LSK, currencies } = this.state;
-    const price = this.props.error ?
+    const maxLSKSupply = 125000000;
+
+    let price = !!this.props.error && Number.isNaN(this.props.value) ?
       (0).toFixed(2) : (this.props.value * LSK[currencies[0]]).toFixed(2);
+    price = price > maxLSKSupply || price === 'NaN' ? (0).toFixed(2) : price;
 
     const currenciesObejects = currencies.map((currency, key) => (
       <div

--- a/src/constants/converter.js
+++ b/src/constants/converter.js
@@ -1,0 +1,4 @@
+const converter = {
+  maxLSKSupply: 125000000,
+};
+export default converter;


### PR DESCRIPTION
### What was the problem?
#987
### How did I fix it?
Added additional conditions
### How to test it?
Go to transactions and check if conversion is shown even with not Enough LSK error
### Review checklist
- The PR solves #987
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
