### PR TITLE
Fix e2e fails asserting number of rows in transaction table - Closes 1138

### DIFF
--- a/test/e2e/send.feature
+++ b/test/e2e/send.feature
@@ -10,8 +10,10 @@ Feature: Send dialog
     And I click "send button"
     And I wait 1 seconds
     Then I should see text "Transaction is being processed and will be confirmed. It may take up to 15 minutes to be secured in the blockchain." in "result box message" element
+
+  Scenario: should be correct number of transactions in a table
+    Given I'm logged in as "genesis"
     And I should see 5 rows
-    And I wait 15 seconds
     When I click "seeAllLink"
     And I should see 25 rows
     When I scroll to the bottom of "transaction results"


### PR DESCRIPTION
### What was the problem?
The test fails to check the number of transactions - it could be 25 or 26 because of the transaction sent previously in the scenario.

### How did I fix it?
I put these assertions in a separate scenario. What they are testing is unrelated to the rest of the scenario. Therefore it will always be 25 transactions

### How to test it?

### Review checklist
- The PR solves #1138 
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
