### PR TITLE
Update design network indicator - Closes #1103

### DIFF
--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -63,6 +63,7 @@
   "Confirmation in the next step": "Confirmation in the next step",
   "Confirmation in the next step.": "Confirmation in the next step.",
   "Confirmations": "Confirmations",
+  "Connected to ": "Connected to ",
   "Connecting to network": "Connecting to network",
   "Connection re-established": "Connection re-established",
   "Continue to Dashboard": "Continue to Dashboard",

--- a/src/components/account/account.css
+++ b/src/components/account/account.css
@@ -75,12 +75,6 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-
-  &:hover {
-    & span {
-      display: inline-block;
-    }
-  }
 }
 
 .testnetTitle,
@@ -92,7 +86,7 @@
   color: var(--color-grayscale-medium);
   margin-top: 8px;
   margin-left: 32px;
-  display: none;
+  display: inline-block;
 }
 
 .peer {

--- a/src/components/account/account.css
+++ b/src/components/account/account.css
@@ -6,6 +6,7 @@
 
 .network {
   margin-right: 8px;
+  margin-top: -3px;
 }
 
 .value-wrapper {

--- a/src/components/account/account.css
+++ b/src/components/account/account.css
@@ -77,12 +77,15 @@
   justify-content: center;
 
   &:hover {
-    color: var(--color-grayscale-medium);
-
     & span {
       display: inline-block;
     }
   }
+}
+
+.testnetTitle,
+.devnetTitle {
+  color: var(--color-grayscale-medium);
 }
 
 .current {

--- a/src/components/account/account.css
+++ b/src/components/account/account.css
@@ -76,6 +76,8 @@
   justify-content: center;
 
   &:hover {
+    color: var(--color-grayscale-medium);
+
     & span {
       display: inline-block;
     }
@@ -84,6 +86,7 @@
 
 .current {
   color: var(--color-grayscale-medium);
+  margin-top: 8px;
   margin-left: 32px;
   display: none;
 }
@@ -92,8 +95,7 @@
   font-size: 16px;
   display: inline-block;
   text-align: left;
-  display: inline-block;
-  width: 250px;
+  width: auto;
   height: 56px;
 }
 

--- a/src/components/account/account.css
+++ b/src/components/account/account.css
@@ -1,20 +1,11 @@
 @import './../app/variables.css';
 
-:root {
-  --online: #73cba9;
-  --offline: #f45d4c;
-}
-
 .wrapper {
   margin: 8px -8px 16px;
 }
 
-:global .online {
-  color: var(--online);
-}
-
-:global .offline {
-  color: var(--offline);
+.network {
+  margin-right: 8px;
 }
 
 .value-wrapper {
@@ -79,16 +70,31 @@
 
 .title {
   color: white;
+  height: 56px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  &:hover {
+    & span {
+      display: inline-block;
+    }
+  }
 }
 
 .current {
   color: var(--color-grayscale-medium);
+  margin-left: 32px;
+  display: none;
 }
 
 .peer {
   font-size: 16px;
   display: inline-block;
   text-align: left;
+  display: inline-block;
+  width: 250px;
+  height: 56px;
 }
 
 @media (--medium-viewport) {

--- a/src/components/account/account.js
+++ b/src/components/account/account.js
@@ -12,8 +12,6 @@ import styles from './account.css';
 const Account = ({ peers, t }) => {
   const iconMap = ['mainnet', 'testnet', 'devnet'];
   const translations = iconMap.map(code => t(code));
-
-  
   const status = (peers.status && peers.status.online) ?
     <FontIcon className={styles.network} value={iconMap[peers.options.code]} /> :
     <FontIcon className='offline' value='error' />;

--- a/src/components/account/account.js
+++ b/src/components/account/account.js
@@ -30,7 +30,7 @@ const Account = ({ peers, t, showNetworkIndicator }) => {
   return ((showNetworkIndicator && peers.data &&
       peers.options.code !== networks.mainnet.code) ?
     <section className={styles.peer}>
-      <div className={`${styles.title} ${`${styles[`${iconMap[iconCode]}Title`]}`} inner primary peer-network`}>
+      <div className={`${styles.title} ${`${styles[`${iconMap[iconCode]}Title`]}`} inner primary peer-network ${iconMap[iconCode]}-title`}>
         <span id="accountStatus" className={`${styles.status} status`}>
           {status}
           {t('Connected to ')}{translations[iconCode]}

--- a/src/components/account/account.js
+++ b/src/components/account/account.js
@@ -31,7 +31,7 @@ const Account = ({ peers, t, showNetworkIndicator }) => {
       peers.options.code !== networks.mainnet.code) ?
     <section className={styles.peer}>
       <div className={`${styles.title} ${`${styles[`${iconMap[iconCode]}Title`]}`} inner primary peer-network ${iconMap[iconCode]}-title`}>
-        <span id="accountStatus" className={`${styles.status} status`}>
+        <span id="accountStatus" className={`${styles.status} network-status`}>
           {status}
           {t('Connected to ')}{translations[iconCode]}
         </span>

--- a/src/components/account/account.js
+++ b/src/components/account/account.js
@@ -9,14 +9,14 @@ import styles from './account.css';
  * @param {object} props - include properties of component
  */
 
-const Account = ({ peers, t }) => {
+const Account = ({ peers, t, showNetworkIndicator }) => {
   const iconMap = ['mainnet', 'testnet', 'devnet'];
   const translations = iconMap.map(code => t(code));
   const status = (peers.status && peers.status.online) ?
     <FontIcon className={`${styles.network} online`} value={iconMap[peers.options.code]} /> :
     <FontIcon className='offline' value='error' />;
 
-  return ((peers.data &&
+  return ((showNetworkIndicator && peers.data &&
       peers.options.code !== networks.mainnet.code) ?
     <section className={styles.peer}>
       <div className={`${styles.title} inner primary peer-network`}>

--- a/src/components/account/account.js
+++ b/src/components/account/account.js
@@ -1,7 +1,9 @@
 import React from 'react';
+import Lisk from 'lisk-elements';
 import { FontIcon } from '../fontIcon';
 import networks from '../../constants/networks';
 import styles from './account.css';
+
 
 /**
  * Contains some of the important and basic information about the account
@@ -12,14 +14,23 @@ import styles from './account.css';
 const Account = ({ peers, t, showNetworkIndicator }) => {
   const iconMap = ['mainnet', 'testnet', 'devnet'];
   const translations = iconMap.map(code => t(code));
+
+  let iconCode = peers.options.code;
+  if (iconCode === 2) {
+    iconCode = (peers.options.nethash === Lisk.APIClient.constants.MAINNET_NETHASH) ?
+      networks.mainnet.code : iconCode;
+    iconCode = (peers.options.nethash === Lisk.APIClient.constants.TESTNET_NETHASH) ?
+      networks.testnet.code : iconCode;
+  }
+
   const status = (peers.status && peers.status.online) ?
-    <FontIcon className={`${styles.network} online`} value={iconMap[peers.options.code]} /> :
+    <FontIcon className={`${styles.network} online`} value={iconMap[iconCode]} /> :
     <FontIcon className='offline' value='error' />;
 
   return ((showNetworkIndicator && peers.data &&
       peers.options.code !== networks.mainnet.code) ?
     <section className={styles.peer}>
-      <div className={`${styles.title} inner primary peer-network`}>
+      <div className={`${styles.title} ${`${styles[iconMap[iconCode]]}Title`} inner primary peer-network`}>
         <span id="accountStatus" className={`${styles.status} status`}>
           {status}
           {t('Connected to ')}{translations[peers.options.code]}

--- a/src/components/account/account.js
+++ b/src/components/account/account.js
@@ -13,7 +13,7 @@ const Account = ({ peers, t }) => {
   const iconMap = ['mainnet', 'testnet', 'devnet'];
   const translations = iconMap.map(code => t(code));
   const status = (peers.status && peers.status.online) ?
-    <FontIcon className={styles.network} value={iconMap[peers.options.code]} /> :
+    <FontIcon className={`${styles.network} online`} value={iconMap[peers.options.code]} /> :
     <FontIcon className='offline' value='error' />;
 
   return ((peers.data &&

--- a/src/components/account/account.js
+++ b/src/components/account/account.js
@@ -10,19 +10,26 @@ import styles from './account.css';
  */
 
 const Account = ({ peers, t }) => {
+  const iconMap = ['mainnet', 'testnet', 'devnet'];
+  const translations = iconMap.map(code => t(code));
+
+  
   const status = (peers.status && peers.status.online) ?
-    <FontIcon className='online' value='checkmark' /> :
+    <FontIcon className={styles.network} value={iconMap[peers.options.code]} /> :
     <FontIcon className='offline' value='error' />;
 
   return ((peers.data &&
       peers.options.code !== networks.mainnet.code) ?
     <section className={styles.peer}>
-      <div className={`${styles.title} inner primary peer-network`}>{t(peers.options.name)} <span id="accountStatus" className={`${styles.status} status`}>{status}</span>
+      <div className={`${styles.title} inner primary peer-network`}>
+        <span id="accountStatus" className={`${styles.status} status`}>
+          {status}
+          {t('Connected to ')}{translations[peers.options.code]}
+        </span>
+        <span className={`${styles.current} inner secondary peer`}>
+          {peers.data.currentNode}
+        </span>
       </div>
-
-      <span className={`${styles.current} inner secondary peer`}>
-        {peers.data.currentNode}
-      </span>
     </section> :
     null
   );

--- a/src/components/account/account.js
+++ b/src/components/account/account.js
@@ -17,9 +17,9 @@ const Account = ({ peers, t, showNetworkIndicator }) => {
 
   let iconCode = peers.options.code;
   if (iconCode === 2) {
-    iconCode = (peers.options.nethash === Lisk.APIClient.constants.MAINNET_NETHASH) ?
+    iconCode = (peers.options.nethash === Lisk.constants.MAINNET_NETHASH) ?
       networks.mainnet.code : iconCode;
-    iconCode = (peers.options.nethash === Lisk.APIClient.constants.TESTNET_NETHASH) ?
+    iconCode = (peers.options.nethash === Lisk.constants.TESTNET_NETHASH) ?
       networks.testnet.code : iconCode;
   }
 
@@ -30,10 +30,10 @@ const Account = ({ peers, t, showNetworkIndicator }) => {
   return ((showNetworkIndicator && peers.data &&
       peers.options.code !== networks.mainnet.code) ?
     <section className={styles.peer}>
-      <div className={`${styles.title} ${`${styles[iconMap[iconCode]]}Title`} inner primary peer-network`}>
+      <div className={`${styles.title} ${`${styles[`${iconMap[iconCode]}Title`]}`} inner primary peer-network`}>
         <span id="accountStatus" className={`${styles.status} status`}>
           {status}
-          {t('Connected to ')}{translations[peers.options.code]}
+          {t('Connected to ')}{translations[iconCode]}
         </span>
         <span className={`${styles.current} inner secondary peer`}>
           {peers.data.currentNode}

--- a/src/components/account/account.test.js
+++ b/src/components/account/account.test.js
@@ -1,7 +1,9 @@
 import React from 'react';
+import Lisk from 'lisk-elements';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
+import networks from '../../constants/networks';
 import Account from './account';
 
 describe('Account', () => {
@@ -13,6 +15,7 @@ describe('Account', () => {
       i18n: {},
       store: {},
       onActivePeerUpdated: sinon.spy(),
+      showNetworkIndicator: true,
       peers: {
         status: {
           online: false,
@@ -41,9 +44,28 @@ describe('Account', () => {
     expect(wrapper.find('Address')).to.have.lengthOf(1);
   });
 
-  it('depicts being online when peers.status.online is true', () => {
+  it('shows network indicator online', () => {
     props.peers.status.online = true;
     const wrapper = shallow(<Account {...props} />);
-    expect(wrapper.find('.status FontIcon')).to.have.className('online');
+    wrapper.update();
+    expect(wrapper).to.have.exactly(1).descendants('.online');
+  });
+
+  it('shows network indicator offline', () => {
+    props.peers.status.online = false;
+    const wrapper = shallow(<Account {...props} />);
+    wrapper.update();
+    expect(wrapper).to.have.exactly(1).descendants('.offline');
+  });
+
+  it('shows testnet icon when online and nethash matches', () => {
+    props.peers.status.online = true;
+    props.peers.options.nethash = Lisk.constants.TESTNET_NETHASH;
+    props.peers.options.code = networks.customNode.code;
+    props.peers.data.currentNode = 'http://localhost:4000';
+    const wrapper = shallow(<Account {...props} />);
+    wrapper.update();
+    expect(wrapper).to.have.exactly(1).descendants('.online');
+    expect(wrapper).to.have.exactly(1).descendants('.testnet-title');
   });
 });

--- a/src/components/app/global.css
+++ b/src/components/app/global.css
@@ -39,12 +39,6 @@ order to be available application wide
   padding: 0px 30px;
 }
 
-:global .appLoaded {
-  & .searchBar {
-    display: inline-block;
-  }
-}
-
 @media (--medium-viewport) {
   :global body.contentFocused {
     margin-top: 0;

--- a/src/components/autoSuggest/autoSuggest.css
+++ b/src/components/autoSuggest/autoSuggest.css
@@ -45,7 +45,7 @@
   pointer-events: none;
   opacity: 0.5;
   padding: 0;
-  width: calc(30vw - 74px);
+  width: calc(30vw - 74px); /* stylelint-disable-line */
 
   text-overflow: ellipsis;
 }

--- a/src/components/autoSuggest/autoSuggest.css
+++ b/src/components/autoSuggest/autoSuggest.css
@@ -46,7 +46,6 @@
   opacity: 0.5;
   padding: 0;
   width: calc(30vw - 74px); /* stylelint-disable-line */
-
   text-overflow: ellipsis;
 }
 

--- a/src/components/autoSuggest/autoSuggest.css
+++ b/src/components/autoSuggest/autoSuggest.css
@@ -45,7 +45,9 @@
   pointer-events: none;
   opacity: 0.5;
   padding: 0;
-  width: 100%;
+  width: calc(30vw - 74px);
+
+  text-overflow: ellipsis;
 }
 
 .input {

--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -15,7 +15,9 @@
 }
 
 .wrapper {
-  text-align: right;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
 
   & .noPadding {
     padding: 0px;

--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -27,6 +27,7 @@
     display: inline-block;
     float: left;
     margin-bottom: 30px;
+    margin-right: 32px;
   }
 }
 
@@ -216,6 +217,12 @@
   .loginInfo {
     width: 100%;
     float: none;
+
+    & > div {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+    }
   }
 
   .wrapper {
@@ -231,6 +238,7 @@
     & .searchBar {
       width: 100%;
       margin-bottom: 0;
+      display: none;
     }
   }
 

--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -56,12 +56,15 @@ class Header extends React.Component {
   render() {
     return (
       <header className={`${styles.wrapper} mainHeader`}>
-        <div className={`${styles.searchBar}`}>
-          {this.shouldShowSearchBar() && <SearchBar/>}
+        <div>
+          <div className={`${styles.searchBar}`}>
+            {this.shouldShowSearchBar() && <SearchBar/>}
+          </div>
+          {this.props.account.loading
+                ? null
+                : <Account peers={this.props.peers} t={this.props.t}/>}
         </div>
-        {this.props.account.loading
-            ? null
-            : <Account peers={this.props.peers} t={this.props.t}/>}
+
         <div className={`${styles.loginInfo}`}>
           <div>
             <div style={{ display: 'inline-block', float: 'left' }}>

--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -54,6 +54,7 @@ class Header extends React.Component {
   }
 
   render() {
+    const { peers, t, showNetworkIndicator } = this.props;
     return (
       <header className={`${styles.wrapper} mainHeader`}>
         <div>
@@ -62,7 +63,7 @@ class Header extends React.Component {
           </div>
           {this.props.account.loading
                 ? null
-                : <Account peers={this.props.peers} t={this.props.t}/>}
+                : <Account {...{ peers, t, showNetworkIndicator }} />}
         </div>
 
         <div className={`${styles.loginInfo}`}>

--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -56,6 +56,12 @@ class Header extends React.Component {
   render() {
     return (
       <header className={`${styles.wrapper} mainHeader`}>
+        <div className={`${styles.searchBar}`}>
+          {this.shouldShowSearchBar() && <SearchBar/>}
+        </div>
+        {this.props.account.loading
+            ? null
+            : <Account peers={this.props.peers} t={this.props.t}/>}
         <div className={`${styles.loginInfo}`}>
           <div>
             <div style={{ display: 'inline-block', float: 'left' }}>
@@ -129,12 +135,6 @@ class Header extends React.Component {
               }
             </div>
           </div>
-        </div>
-        <div className={`${styles.searchBar}`}>
-          {this.shouldShowSearchBar() && <SearchBar/>}
-          {this.props.account.loading
-            ? null
-            : <Account peers={this.props.peers} t={this.props.t}/>}
         </div>
       </header>
     );

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -14,6 +14,7 @@ const mapStateToProps = state => ({
   autoLog: state.settings.autoLog,
   isAuthenticated: !!state.account.publicKey,
   peers: state.peers,
+  showNetworkIndicator: state.settings.showNetwork,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/searchBar/searchBar.css
+++ b/src/components/searchBar/searchBar.css
@@ -1,7 +1,7 @@
 @import './../app/variables.css';
 
 :root {
-  --search-box-width-l: 30vw; /* stylelint-disable-line */
+  --search-box-width-l: calc(30vw - 32px); /* stylelint-disable-line */
   --search-box-width-xl: 558px;
   --search-box-font-size: 16px;
   --search-box-line-height: 56px;
@@ -10,11 +10,10 @@
 }
 
 .searchBar {
-  display: none;
   vertical-align: top;
   position: relative;
   width: var(--search-box-width-l);
-  margin-right: 50px;
+  margin-right: 32px;
 
   & .icon {
     position: absolute;

--- a/test/e2e/login.feature
+++ b/test/e2e/login.feature
@@ -25,7 +25,7 @@ Feature: Login
     And I select option no. 3 from "network" select
     And I click "login button"
     Then I should be logged in as "genesis" account
-    And I should see text "testnet" in "peer network" element
+    And I should see text "Connected to testnet" in "peer network" element
     And I click "joyride-tooltip__button--skip"
     And I click "joyride-tooltip__button--skip"
     When I click "transactions" menu
@@ -40,7 +40,7 @@ Feature: Login
     When I fill in "https://testnet.lisk.io" to "address" field
     And I click "login button"
     Then I should be logged in as "genesis" account
-    And I should see text "custom node" in "peer network" element
+    And I should see text "Connected to devnet" in "peer network" element
     And I click "joyride-tooltip__button--skip"
     And I click "joyride-tooltip__button--skip"
     When I click "transactions" menu

--- a/test/e2e/login.feature
+++ b/test/e2e/login.feature
@@ -27,7 +27,7 @@ Feature: Login
     And I select option no. 3 from "network" select
     And I click "login button"
     Then I should be logged in as "genesis" account
-    And I should see text "Connected to testnet" in "status" element
+    And I should see text "Connected to testnet" in "network-status" element
     And I click "joyride-tooltip__button--skip"
     And I click "joyride-tooltip__button--skip"
     When I click "transactions" menu
@@ -44,7 +44,7 @@ Feature: Login
     When I fill in "https://testnet.lisk.io" to "address" field
     And I click "login button"
     Then I should be logged in as "genesis" account
-    And I should see text "Connected to testnet" in "status" element
+    And I should see text "Connected to testnet" in "network-status" element
     And I click "joyride-tooltip__button--skip"
     And I click "joyride-tooltip__button--skip"
     When I click "transactions" menu

--- a/test/e2e/login.feature
+++ b/test/e2e/login.feature
@@ -20,6 +20,8 @@ Feature: Login
   Scenario: should allow to login to Testnet through network options launch protocol
     Given I go to "/"
     Then I should see no "network"
+    When I go to "/setting"
+    And I click "showNetwork"
     When I'm on login page
     Then I fill in passphrase of "genesis" to "passphrase" field
     And I select option no. 3 from "network" select
@@ -34,13 +36,15 @@ Feature: Login
   Scenario: should allow to login to Custom node through network options launch protocol
     Given I go to "/"
     Then I should see no "network"
+    When I go to "/setting"
+    And I click "showNetwork"
     When I'm on login page
     Then I fill in passphrase of "genesis" to "passphrase" field
     And I select option no. 4 from "network" select
     When I fill in "https://testnet.lisk.io" to "address" field
     And I click "login button"
     Then I should be logged in as "genesis" account
-    And I should see text "Connected to devnet" in "peer network" element
+    And I should see text "Connected to testnet" in "peer network" element
     And I click "joyride-tooltip__button--skip"
     And I click "joyride-tooltip__button--skip"
     When I click "transactions" menu

--- a/test/e2e/login.feature
+++ b/test/e2e/login.feature
@@ -27,7 +27,7 @@ Feature: Login
     And I select option no. 3 from "network" select
     And I click "login button"
     Then I should be logged in as "genesis" account
-    And I should see text "Connected to testnet" in "peer network" element
+    And I should see text "Connected to testnet" in "status" element
     And I click "joyride-tooltip__button--skip"
     And I click "joyride-tooltip__button--skip"
     When I click "transactions" menu
@@ -44,7 +44,7 @@ Feature: Login
     When I fill in "https://testnet.lisk.io" to "address" field
     And I click "login button"
     Then I should be logged in as "genesis" account
-    And I should see text "Connected to testnet" in "peer network" element
+    And I should see text "Connected to testnet" in "status" element
     And I click "joyride-tooltip__button--skip"
     And I click "joyride-tooltip__button--skip"
     When I click "transactions" menu


### PR DESCRIPTION
### What was the problem?
- #1103 
### How did I fix it?
- refactor styles for header and use flex instead of floating, change order of render html to be more according to document flow.
### How to test it?

- login with mainnet url by customNode dropdown (should show bright, and say connected to mainnet)
- login with testnet url by customNode dropdown (should show with opacity, and say connected to testnet)
- login to devnet url by customNode dropdown (should show with opacity, and say connected to devnet)

- in all cases URL of peer must be shown
- should show only if enabled in settings

### Review checklist
- The PR solves #1103
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
