### PR TITLE
Use cache function from library

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,18 +16,12 @@ node('lisk-hub') {
 
     stage ('Install npm dependencies') {
       try {
+        cache_file = restoreCache("package.json")
         sh '''
-        cache_file="$HOME/cache/$( sha1sum package.json |awk '{ print $1 }' ).tar.gz"
-        if [ -f "$cache_file" ]; then
-            tar xf "$cache_file"
-        fi
         npm install
         ./node_modules/protractor/bin/webdriver-manager update
-        if [ ! -f "$cache_file" ]; then
-            GZIP=-4 tar czf "$cache_file" node_modules/
-            find $HOME/cache/ -name '*.tar.gz' -ctime +7 -delete
-        fi
         '''
+        saveCache(cache_file, './node_modules', 10)
       } catch (err) {
         echo "Error: ${err}"
         fail('Stopping build: npm install failed')


### PR DESCRIPTION
### What was the problem?

We need to use the cache function provided by the shared library

### How did I fix it?

Changing the inline bash core for the groovy function from lisk-jenkins

### How to test it?

https://jenkins.lisk.io/job/lisk-hub/job/use_library_cache/ (failed but passed the cache part)