### PR TITLE
Prevent saved devnet account listed twice - Closes #1049

### DIFF
--- a/src/store/middlewares/savedAccounts.js
+++ b/src/store/middlewares/savedAccounts.js
@@ -96,7 +96,7 @@ const savedAccountsMiddleware = (store) => {
           balance: account.balance,
           publicKey: account.publicKey,
           network: peers.options.code,
-          address: peers.options.address,
+          peerAddress: peers.options.address,
         }));
         break;
       case actionTypes.accountLoggedIn:

--- a/src/store/middlewares/savedAccounts.test.js
+++ b/src/store/middlewares/savedAccounts.test.js
@@ -134,7 +134,7 @@ describe('SavedAccounts middleware', () => {
     };
     middleware(store)(next)(action);
     expect(store.dispatch).to.have.been.calledWith(accountSaved({
-      address: undefined,
+      peerAddress: undefined,
       balance,
       network: networks.mainnet.code,
       publicKey: publicKey2,


### PR DESCRIPTION
### What was the problem?
See #1049 . 
The root cause was that when changing `address` -> `peerAddress` in saved accounts, it was not done in one place in savedAcconts middleware.

### How did I fix it?
I changed `address` -> `peerAddress` in one place in savedAcconts middleware

### How to test it?
Follow steps in #1049

### Review checklist
- The PR solves #1049
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
