### PR TITLE
Show transaction reference in list - Closes #1146

### DIFF
--- a/src/actions/transactions.js
+++ b/src/actions/transactions.js
@@ -226,6 +226,9 @@ export const sent = ({
             amount: toRawLsk(amount),
             fee: Fees.send,
             type: transactionTypes.send,
+            asset: {
+              data,
+            },
           },
           type: actionTypes.transactionAdded,
         });

--- a/src/actions/transactions.test.js
+++ b/src/actions/transactions.test.js
@@ -213,6 +213,7 @@ describe('actions: transactions', () => {
         senderPublicKey: 'test_public-key',
         senderId: 'test_address',
         recipientId: data.recipientId,
+        asset: { data: undefined },
         amount: toRawLsk(data.amount),
         fee: Fees.send,
         type: transactionTypes.send,

--- a/src/components/transactions/transactionRow.css
+++ b/src/components/transactions/transactionRow.css
@@ -9,19 +9,34 @@
   --result-address-font-weight: var(--font-weight-semi-bold);
   --grid-header-line-height: 60px;
   --main-row-line-height: 70px;
+
+  --box-padding-right-M: 0;
+  --box-padding-right-L: 0;
+  --box-padding-right-XL: 0;
 }
 
 .header {
   color: var(--grid-header-color);
   line-height: var(--grid-header-line-height);
   font-weight: var(--font-weight-very-bold);
+
+  &:nth-child(2) {
+    text-align: left;
+  }
 }
 
 .reference {
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
-  max-width: 110px;
+  text-align: left;
+}
+
+.arrowRow {
+
+  & span {
+    margin-right: 8px;
+  }
 }
 
 .rows {
@@ -65,7 +80,7 @@
   }
 
   .rows {
-    padding: 0px var(--box-padding-left-XL);
+    padding: 0 var(--box-padding-right-XL) 0 var(--box-padding-left-XL);
   }
 }
 
@@ -75,7 +90,7 @@
   }
 
   .rows {
-    padding: 0px var(--box-padding-left-L);
+    padding: 0 var(--box-padding-right-L) 0 var(--box-padding-left-L);
   }
 }
 
@@ -85,7 +100,7 @@
   }
 
   .rows {
-    padding: 0px var(--box-padding-left-M);
+    padding: 0 var(--box-padding-right-M) 0 var(--box-padding-left-M);
 
     &:nth-of-type(even) {
       background: var(--gradient-greyscale-mobile);
@@ -95,10 +110,22 @@
       background: var(--color-grayscale-mobile-background);
     }
   }
+
+  .arrowRow {
+    text-align: right;
+
+    & span {
+      margin-right: 8px;
+    }
+  }
 }
 
 @media (--small-viewport) {
   .hiddenXs {
     display: none;
+  }
+
+  .arrowRow {
+    text-align: right;
   }
 }

--- a/src/components/transactions/transactionRow.css
+++ b/src/components/transactions/transactionRow.css
@@ -17,6 +17,13 @@
   font-weight: var(--font-weight-very-bold);
 }
 
+.reference {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  max-width: 110px;
+}
+
 .rows {
   color: var(--amount-negative-color);
   border-bottom: 0;

--- a/src/components/transactions/transactionRow.css
+++ b/src/components/transactions/transactionRow.css
@@ -9,7 +9,6 @@
   --result-address-font-weight: var(--font-weight-semi-bold);
   --grid-header-line-height: 60px;
   --main-row-line-height: 70px;
-
   --box-padding-right-M: 0;
   --box-padding-right-L: 0;
   --box-padding-right-XL: 0;
@@ -33,7 +32,6 @@
 }
 
 .arrowRow {
-
   & span {
     margin-right: 8px;
   }

--- a/src/components/transactions/transactionRow.js
+++ b/src/components/transactions/transactionRow.js
@@ -24,7 +24,7 @@ class TransactionRow extends React.Component {
             <TransactionType {...props.value} address={props.address}></TransactionType>
           </div>
         </div>
-          <div className={`${styles.rightText} ${grid['col-sm-2']} transactions-cell`}>
+          <div className={`${styles.rightText} ${grid['col-sm-3']} transactions-cell`}>
             <div className={`${styles.hiddenXs} ${styles.reference}`}>
                 {props.value.asset && props.value.asset.data ?
                   <span>{props.value.asset.data}</span>
@@ -37,10 +37,10 @@ class TransactionRow extends React.Component {
               : <Spinner />}
           </div>
         </div>
-        <div className={`${styles.rightText} ${grid['col-xs-5']} ${grid['col-sm-3']} transactions-cell`}>
+        <div className={`${styles.rightText} ${grid['col-xs-5']} ${grid['col-sm-2']} transactions-cell`}>
           <Amount {...props}></Amount>
         </div>
-        <div className={`${styles.rightText} ${grid['col-xs-1']} ${grid['col-sm-1']} transactions-cell`}>
+        <div className={`${grid['col-xs-1']} ${grid['col-sm-1']} ${styles.arrowRow} transactions-cell`}>
           <FontIcon value='arrow-right'/>
         </div>
       </div>

--- a/src/components/transactions/transactionRow.js
+++ b/src/components/transactions/transactionRow.js
@@ -24,6 +24,13 @@ class TransactionRow extends React.Component {
             <TransactionType {...props.value} address={props.address}></TransactionType>
           </div>
         </div>
+        {props.value.asset && props.value.asset.data ?
+          <div className={`${styles.rightText} ${grid['col-sm-2']} transactions-cell`}>
+            <div className={`${styles.hiddenXs}`}>
+              <span className={styles.reference}>{props.value.asset.data}</span>
+            </div>
+          </div>
+        : null}
         <div className={`${styles.rightText} ${grid['col-sm-2']} transactions-cell`}>
           <div className={`${styles.hiddenXs}`}>
             {props.value.confirmations ? <DateFromTimestamp time={props.value.timestamp} />

--- a/src/components/transactions/transactionRow.js
+++ b/src/components/transactions/transactionRow.js
@@ -19,18 +19,18 @@ class TransactionRow extends React.Component {
     const onClick = !props.onClick ? (() => {}) : () => props.onClick(this.props);
     return (
       <div className={`${grid.row} ${styles.rows} ${styles.clickable} transactions-row`} onClick={onClick}>
-        <div className={`${styles.leftText} ${grid['col-xs-6']} ${grid['col-sm-6']} transactions-cell`}>
+        <div className={`${styles.leftText} ${grid['col-xs-6']} ${grid['col-sm-4']} transactions-cell`}>
           <div className={`${styles.address}`}>
             <TransactionType {...props.value} address={props.address}></TransactionType>
           </div>
         </div>
-        {props.value.asset && props.value.asset.data ?
           <div className={`${styles.rightText} ${grid['col-sm-2']} transactions-cell`}>
-            <div className={`${styles.hiddenXs}`}>
-              <span className={styles.reference}>{props.value.asset.data}</span>
+            <div className={`${styles.hiddenXs} ${styles.reference}`}>
+                {props.value.asset && props.value.asset.data ?
+                  <span>{props.value.asset.data}</span>
+                : '-'}
             </div>
           </div>
-        : null}
         <div className={`${styles.rightText} ${grid['col-sm-2']} transactions-cell`}>
           <div className={`${styles.hiddenXs}`}>
             {props.value.confirmations ? <DateFromTimestamp time={props.value.timestamp} />

--- a/src/components/transactions/transactionRow.test.js
+++ b/src/components/transactions/transactionRow.test.js
@@ -56,7 +56,7 @@ describe('TransactionRow', () => {
       </Router>
     </Provider>, options);
 
-    expect(wrapper.find('.transactions-cell')).to.have.lengthOf(4);
+    expect(wrapper.find('.transactions-cell')).to.have.lengthOf(5);
   });
 
   it('should not cause any error on click if props.onClick is not defined', () => {

--- a/src/components/transactions/transactionsHeader.js
+++ b/src/components/transactions/transactionsHeader.js
@@ -5,7 +5,8 @@ import styles from './transactionRow.css';
 
 const TransactionsHeader = ({ t }) => (
   <div className={`${grid.row}  ${styles.rows} ${styles.paddingLeft}`} id="transactionsHeader">
-    <div className={`${styles.leftText} ${grid['col-xs-6']} ${grid['col-sm-6']} ${styles.header} transactions-header`}>{t('Address')}</div>
+    <div className={`${styles.leftText} ${grid['col-xs-6']} ${grid['col-sm-4']} ${styles.header} transactions-header`}>{t('Address')}</div>
+    <div className={`${styles.rightText} ${grid['col-xs-0']} ${grid['col-sm-2']} ${styles.header} transactions-header ${styles.hiddenXs}`}>{t('Reference')}</div>
     <div className={`${styles.rightText} ${grid['col-xs-0']} ${grid['col-sm-2']} ${styles.header} transactions-header ${styles.hiddenXs}`}>{t('Date')}</div>
     <div className={`${styles.rightText} ${grid['col-xs-5']} ${grid['col-sm-3']} ${styles.header} transactions-header`}>{t('Amount (LSK)')}</div>
     <div className={`${grid['col-xs-1']} ${grid['col-sm-1']}`}></div>

--- a/src/components/transactions/transactionsHeader.test.js
+++ b/src/components/transactions/transactionsHeader.test.js
@@ -18,6 +18,6 @@ describe('TransactionsHeader', () => {
 },
     );
 
-    expect(wrapper.find('.transactions-header')).to.have.lengthOf(3);
+    expect(wrapper.find('.transactions-header')).to.have.lengthOf(4);
   });
 });


### PR DESCRIPTION
### What was the problem?
- reference should be added to transaction list and be shown in wallet, explorer, dashboard. 
### How did I fix it?
- refactoring styles to allocate new cell
- fixing a bug where pending transactions were not adding asset field
### How to test it?
go to any of the pages wallet, explorer, dashboard
### Review checklist
- The PR solves #1146 
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
