### PR TITLE
Add protocol if needed before Lisk client init - Closes #1159

### DIFF
--- a/src/components/login/login.js
+++ b/src/components/login/login.js
@@ -15,7 +15,7 @@ import { parseSearchParams } from './../../utils/searchParams';
 import Box from '../box';
 // eslint-disable-next-line import/no-unresolved
 import SignUp from './signUp';
-import { validateUrl } from '../../utils/login';
+import { validateUrl, addHttp } from '../../utils/login';
 
 /**
  * The container component containing login
@@ -83,7 +83,7 @@ class Login extends React.Component {
   getNetwork() {
     const network = Object.assign({}, getNetwork(this.state.network));
     if (this.state.network === networks.customNode.code) {
-      network.address = this.state.address;
+      network.address = addHttp(this.state.address);
     }
     return network;
   }

--- a/src/utils/login.js
+++ b/src/utils/login.js
@@ -1,9 +1,5 @@
 import i18next from 'i18next';
 
-const addHttp = (url) => {
-  const reg = /^(?:f|ht)tps?:\/\//i;
-  return reg.test(url) ? url : `http://${url}`;
-};
 // https://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url
 // eslint-disable-next-line no-useless-escape
 const pattern = new RegExp(/[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9@:%_\+.~#?&//=]*)?/gi);
@@ -14,15 +10,20 @@ const isValidLocalhost = url => url.hostname === 'localhost' && url.port.length 
 const isValidRemote = url => /(([a-z\d]([a-z\d-]*[a-z\d])*)\.)+[a-z]{2,}|((\d{1,3}\.){3})/.test(url.hostname);
 
 const isValidIp = url => (isValidLocalhost(url) ||
-  isValidRemote(url) ||
-  isValidUrlRegEx(url.toString()));
+isValidRemote(url) ||
+isValidUrlRegEx(url.toString()));
 
+export const addHttp = (url) => {
+  const reg = /^(?:f|ht)tps?:\/\//i;
+  return reg.test(url) ? url : `http://${url}`;
+};
 // eslint-disable-next-line import/prefer-default-export
 export const validateUrl = (value) => {
-  const errorMessage = i18next.t('URL is invalid');
+  let url;
   let addressValidity = '';
+  const errorMessage = i18next.t('URL is invalid');
   try {
-    const url = new URL(addHttp(value));
+    url = new URL(addHttp(value));
     addressValidity = url && value.indexOf(' ') === -1 && isValidIp(url) ? '' : errorMessage;
   } catch (e) {
     addressValidity = errorMessage;


### PR DESCRIPTION
### What was the problem?
- address validator will validate non protocol addresses as valid, but Lisk client does not accept urls with no protocol.
### How did I fix it?
- use utils method to add protocol
### How to test it?

### Review checklist
- The PR solves #1159 
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
