### PR TITLE
Autosuggest should show error message when no results - Closes #1193

### DIFF
--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -200,6 +200,7 @@
   "No Updates": "No Updates",
   "No activity yet": "No activity yet",
   "No results": "No results",
+  "No results found": "No results found",
   "Not enough LSK": "Not enough LSK",
   "Not voted": "Not voted",
   "Note: After registration completes,": "Note: After registration completes,",

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -24,7 +24,7 @@ exports.config = {
   params: {
     screenshotFolder: 'e2e-test-screenshots',
     baseURL: 'http://localhost:8080',
-    liskCoreURL: 'http://localhost:4000/',
+    liskCoreURL: 'http://localhost:4000',
     testnetPassphrase: process.env.TESTNET_PASSPHRASE,
     useTestnetPassphrase: false,
     network: 'customNode',

--- a/src/components/autoSuggest/autoSuggest.css
+++ b/src/components/autoSuggest/autoSuggest.css
@@ -49,6 +49,14 @@
   text-overflow: ellipsis;
 }
 
+.noResults {
+  color: var(--color-primary-standard);
+  font-family: var(--content-font);
+  font-size: var(--paragraph-font-size-l);
+  padding: 0 24px;
+  margin: 15px 0 0;
+}
+
 .input {
   padding: 0;
   z-index: var(--searchbar-input-index);

--- a/src/components/autoSuggest/index.js
+++ b/src/components/autoSuggest/index.js
@@ -335,6 +335,26 @@ class AutoSuggest extends React.Component {
             />
             : null
           }
+
+          { this.state.value !== '' && this.state.resultsLength === 0 ?
+            <ResultsList
+              key='no-results'
+              results={[{
+                id: 'no-results',
+                valueLeft: t('No results found'),
+                valueRight: '',
+                isSelected: false,
+                type: 'no-results',
+              }]}
+              header={{
+                titleLeft: '',
+                titleRight: '',
+              }}
+              onMouseDown={() => {}}
+              setSelectedRow={() => {}}
+            />
+            : null
+          }
         </div>
       </div>
     );

--- a/src/components/autoSuggest/index.js
+++ b/src/components/autoSuggest/index.js
@@ -337,22 +337,7 @@ class AutoSuggest extends React.Component {
           }
 
           { this.state.value !== '' && this.state.resultsLength === 0 ?
-            <ResultsList
-              key='no-results'
-              results={[{
-                id: 'no-results',
-                valueLeft: t('No results found'),
-                valueRight: '',
-                isSelected: false,
-                type: 'no-results',
-              }]}
-              header={{
-                titleLeft: '',
-                titleRight: '',
-              }}
-              onMouseDown={() => {}}
-              setSelectedRow={() => {}}
-            />
+            <p className={styles.noResults}>{t('No results found')}</p>
             : null
           }
         </div>

--- a/src/utils/api/account.js
+++ b/src/utils/api/account.js
@@ -3,6 +3,9 @@ import Lisk from 'lisk-elements';
 
 export const getAccount = (activePeer, address) =>
   new Promise((resolve, reject) => {
+    if (!activePeer) {
+      reject();
+    }
     activePeer.accounts.get({ address }).then((res) => {
       if (res.data.length > 0) {
         resolve({

--- a/src/utils/api/delegate.js
+++ b/src/utils/api/delegate.js
@@ -3,8 +3,13 @@ import Lisk from 'lisk-elements';
 export const listAccountDelegates = (activePeer, address) =>
   activePeer.votes.get({ address, limit: '101' });
 
-export const listDelegates = (activePeer, options) =>
-  activePeer.delegates.get(options);
+export const listDelegates = (activePeer, options) => new Promise((resolve, reject) => {
+  if (!activePeer) {
+    reject();
+  } else {
+    activePeer.delegates.get(options).then(response => resolve(response));
+  }
+});
 
 export const getDelegate = (activePeer, options) =>
   activePeer.delegates.get(options);

--- a/src/utils/api/transactions.js
+++ b/src/utils/api/transactions.js
@@ -27,7 +27,13 @@ export const getTransactions = ({
   return activePeer.transactions.get(params);
 };
 
-export const getSingleTransaction = ({ activePeer, id }) => activePeer.transactions.get({ id });
+export const getSingleTransaction = ({ activePeer, id }) => new Promise((resolve, reject) => {
+  if (!activePeer) {
+    reject();
+  } else {
+    activePeer.transactions.get({ id }).then(response => resolve(response));
+  }
+});
 
 export const unconfirmedTransactions = (activePeer, address, limit = 20, offset = 0, sort = 'timestamp:desc') =>
   activePeer.node.getTransactions('unconfirmed', {


### PR DESCRIPTION
### What was the problem?
- see #1193 
### How did I fix it?
- always rejecting promises in case activePeer is not set
- show a i18n result key when no results are found
### How to test it?

- while being connected to a peer, try to find a non existing delegate name
- while not being connected to a peer, try to find any delegate name, tx id, or address id. 

### Review checklist
- The PR solves #1193 
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
