### PR TITLE
E2E: Change send tx page to wallet, substitute refreshing - Closes 1219

### DIFF
--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -24,7 +24,7 @@ exports.config = {
   params: {
     screenshotFolder: 'e2e-test-screenshots',
     baseURL: 'http://localhost:8080',
-    liskCoreURL: 'http://localhost:4000/',
+    liskCoreURL: 'http://localhost:4000',
     testnetPassphrase: process.env.TESTNET_PASSPHRASE,
     useTestnetPassphrase: false,
     network: 'customNode',

--- a/test/e2e/send.feature
+++ b/test/e2e/send.feature
@@ -33,6 +33,7 @@ Feature: Send dialog
   @advanced
   Scenario: should be able to init account if needed
     Given I'm logged in as "genesis"
+    Then I go to "/wallet"
     And I fill in "1" to "amount" field
     And I fill in "94495548317450502L" to "recipient" field
     And I click "send next button"
@@ -40,6 +41,7 @@ Feature: Send dialog
     Then I go to "/"
     Then I wait 15 seconds
     And I'm logged in as "without initialization"
+    Then I go to "/wallet"
     Then I should see "account initialization" element
     When I click "account init button"
     And I click "send button"
@@ -47,7 +49,8 @@ Feature: Send dialog
     Then I should see text "Transaction is being processed and will be confirmed. It may take up to 15 minutes to be secured in the blockchain." in "result box message" element
     When I click "okay button"
     Then I should see no "account initialization"
-    When I refresh the page
+    Then I go to "/dashboard"
+    Then I go to "/wallet"
     Then I wait 15 seconds
     Then I should see no "account initialization"
     Then I should see 2 rows


### PR DESCRIPTION
### What was the problem?
Init account e2e test fails cause
1. There is no more send module on dashboard
1. Refreshing doesn't preserve logged in status
1. custome node address should not end with /
### How did I fix it?
Send tx on wallet page
Go to another page and back instead of refreshing
custom node address

### How to test it?
Jenkins build have to pass

### Review checklist
- The PR solves #1219 
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
