### PR TITLE
Delegate registration should not allow upper case letters - Closes #1211

### DIFF
--- a/src/components/registerDelegate/steps/choose/choose.js
+++ b/src/components/registerDelegate/steps/choose/choose.js
@@ -19,7 +19,7 @@ class Choose extends React.Component {
         error: '',
       },
     };
-    this.delegateNameRegEx = new RegExp(/[a-zA-Z0-9!@$&_.]+/g); // !@$&_.
+    this.delegateNameRegEx = new RegExp(/[a-z0-9!@$&_.]+/g); // !@$&_.
     this.delegateNameMaxChars = 20;
   }
 


### PR DESCRIPTION
### What was the problem?
- #1211
### How did I fix it?
- remove [A-Z] from regex, to not allow capital letters
### How to test it?

### Review checklist
- The PR solves #1211 
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
