### PR TITLE
Set active peer on app start - Closes #1242

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,7 +1,8 @@
 import { createStore, combineReducers, applyMiddleware, compose } from 'redux';
 import throttle from 'lodash.throttle';
 
-// import actionTypes from '../constants/actions';
+import actionTypes from '../constants/actions';
+import env from '../constants/env';
 import * as reducers from './reducers';
 import middleWares from './middlewares';
 import savedAccountsSubscriber from './subscribers/savedAccounts';
@@ -12,6 +13,12 @@ const App = combineReducers(reducers);
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
 const store = createStore(App, composeEnhancers(applyMiddleware(...middleWares)));
+
+// ignore this in coverage because it is not run in tests, because it causes mock issues
+/* istanbul ignore if */
+if (!env.test) {
+  store.dispatch({ type: actionTypes.storeCreated });
+}
 
 store.subscribe(throttle(savedAccountsSubscriber.bind(null, store), 1000));
 store.subscribe(throttle(followedAccountsSubscriber.bind(null, store), 1000));

--- a/src/store/middlewares/login.js
+++ b/src/store/middlewares/login.js
@@ -8,7 +8,8 @@ import { errorToastDisplayed } from '../../actions/toaster';
 
 const { lockDuration } = accountConfig;
 const loginMiddleware = store => next => (action) => {
-  if (action.type !== actionTypes.activePeerSet || action.data.noSavedAccounts) {
+  if (action.type !== actionTypes.activePeerSet ||
+      (!action.data.publicKey && !action.data.passphrase)) {
     return next(action);
   }
   next(action);

--- a/src/store/middlewares/peers.js
+++ b/src/store/middlewares/peers.js
@@ -2,21 +2,16 @@ import { activePeerSet, activePeerUpdate } from '../../actions/peers';
 import actionTypes from '../../constants/actions';
 import networks from './../../constants/networks';
 import getNetwork from './../../utils/getNetwork';
-import localJSONStorage from './../../utils/localJSONStorage';
 
 const peersMiddleware = store => next => (action) => {
   next(action);
 
-  const network = Object.assign({}, getNetwork(networks.default.code));
-  const hasNoSavedAccounts = !localJSONStorage.get('accounts', []).length;
+  const network = Object.assign({}, getNetwork(networks.mainnet.code));
 
   switch (action.type) {
     case actionTypes.storeCreated:
-      /* istanbul ignore else  */
-      if (hasNoSavedAccounts) {
-        store.dispatch(activePeerSet({ network, noSavedAccounts: true }));
-        store.dispatch(activePeerUpdate({ online: true }));
-      }
+      store.dispatch(activePeerSet({ network }));
+      store.dispatch(activePeerUpdate({ online: true }));
       break;
     default: break;
   }

--- a/src/utils/account.test.js
+++ b/src/utils/account.test.js
@@ -22,5 +22,9 @@ describe('Utils: Account', () => {
       const derivedAddress = '440670704090200331L';
       expect(extractAddress(publicKey)).to.be.equal(derivedAddress);
     });
+
+    it('should return false if no param passed to it', () => {
+      expect(extractAddress()).to.be.equal(false);
+    });
   });
 });


### PR DESCRIPTION
### What was the problem?
We were not setting active peer on app start, so a user couldn't search or browse accounts without login.

### How did I fix it?
I set active peer on app start

### How to test it?
- Open the app
- try to search for a delegate or something else
### Review checklist
- The PR solves #1242
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
