### PR TITLE
Fix searchbar placeholder overflow - Closes #1241

### DIFF
--- a/src/components/autoSuggest/autoSuggest.css
+++ b/src/components/autoSuggest/autoSuggest.css
@@ -45,7 +45,7 @@
   pointer-events: none;
   opacity: 0.5;
   padding: 0;
-  width: calc(30vw - 74px); /* stylelint-disable-line */
+  width: calc(100% - 44px);
   text-overflow: ellipsis;
 }
 


### PR DESCRIPTION
### What was the problem?
- #1241 search bar placeholder was overflowing on medium breakpoint
### How did I fix it?
- adapt width to it's container
### How to test it?
- open hub in a viewport of ~1030px
### Review checklist
- The PR solves #1241
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
