### PR TITLE
Prevent setProgressBar error in autoUpdater - Closes #1207

### DIFF
--- a/app/src/modules/autoUpdater.js
+++ b/app/src/modules/autoUpdater.js
@@ -36,7 +36,9 @@ export default ({
     logMessage = `${logMessage} (${progressObj.transferred}/${progressObj.total})`;
     // eslint-disable-next-line no-console
     console.log(logMessage);
-    win.browser.setProgressBar(progressObj.transferred / progressObj.total);
+    if (win && win.browser) {
+      win.browser.setProgressBar(progressObj.transferred / progressObj.total);
+    }
   });
 
   autoUpdater.on('update-available', ({ releaseNotes, version }) => {

--- a/app/src/modules/autoUpdater.test.js
+++ b/app/src/modules/autoUpdater.test.js
@@ -182,6 +182,21 @@ describe('autoUpdater', () => {
     expect(params.win.browser.setProgressBar).to.have.been.calledWith(50 / 100);
   });
 
+  it('should not fail if browser is not defined when being in download progress', () => {
+    let error;
+    try {
+      autoUpdater({
+        ...params,
+        win: {},
+      });
+      callbacks['download-progress']({ transferred: 50, total: 100 });
+      error = false;
+    } catch (e) {
+      error = e;
+    }
+    expect(error).to.equal(false);
+  });
+
   it('should log any update error', () => {
     const error = new Error('Error: Can not find Squirrel');
     const consoleSpy = spy(console, 'error');

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
 
     // '<rootDir>/app/src/menu.test.js',
     // '<rootDir>/app/src/modules/updateModal.test.js',
-    // '<rootDir>/app/src/modules/autoUpdater.test.js',
+    '<rootDir>/app/src/modules/autoUpdater.test.js',
     // '<rootDir>/app/src/modules/win.test.js',
     // '<rootDir>/app/src/modules/localeHandler.test.js',
 


### PR DESCRIPTION
### What was the problem?
For some reason, the browser object is sometimes not available, so 
### How did I fix it?
I added a condition to check for that. The result for user is that he
won't get the progress bar on the OS Dock icon updated.
### How to test it?
That's the hard part. I don't have a good way to test it, because you need to build the whole app with signature and have a higher version published on Github which triggers the auto update. IMO it's sufficient to look at the error in #1207 and search code that I took care of the only place that calls `setProgressBar` to understand that this error can no longer happen.

### Review checklist
- The PR solves #1207
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
