### PR TITLE
Remove crucial parts of saved accounts - Closes #1247

### DIFF
--- a/src/components/app/index.js
+++ b/src/components/app/index.js
@@ -9,7 +9,6 @@ import OfflineWrapper from '../offlineWrapper';
 import CustomRoute from '../customRoute';
 import Header from '../header';
 import Dialog from '../dialog';
-import SavedAccounts from '../savedAccounts';
 import NotFound from '../notFound';
 
 import routes from '../../constants/routes';
@@ -53,7 +52,6 @@ class App extends React.Component {
         <Dialog />
         <main className={`${styles.bodyWrapper}`} ref={(el) => { this.main = el; }}>
           <MainMenu />
-          <Route path={routes.accounts.path} component={SavedAccounts} />
           <section>
             <div className={styles.mainBox}>
               <Header />

--- a/src/store/middlewares/index.js
+++ b/src/store/middlewares/index.js
@@ -7,7 +7,6 @@ import offlineMiddleware from './offline';
 // ToDo : enable this one when you solve the problem with multi account management
 // import notificationMiddleware from './notification';
 import votingMiddleware from './voting';
-import savedAccountsMiddleware from './savedAccounts';
 import followedAccountsMiddleware from './followedAccounts';
 import socketMiddleware from './socket';
 import savedSettingsMiddleware from './savedSettings';
@@ -22,7 +21,6 @@ export default [
   offlineMiddleware,
   // notificationMiddleware,
   votingMiddleware,
-  savedAccountsMiddleware,
   followedAccountsMiddleware,
   savedSettingsMiddleware,
 ];

--- a/src/store/reducers/index.js
+++ b/src/store/reducers/index.js
@@ -6,7 +6,6 @@ export { default as loading } from './loading';
 export { default as toaster } from './toaster';
 export { default as transactions } from './transactions';
 export { default as transaction } from './transaction';
-export { default as savedAccounts } from './savedAccounts';
 export { default as followedAccounts } from './followedAccounts';
 export { default as search } from './search';
 export { default as settings } from './settings';


### PR DESCRIPTION
### What was the problem?
See #1247

### How did I fix it?
Removed redux of savedAccounts so that accounts are not stored, and router so that /accounts path is now 404

There already is another ticket to do the full cleanup of saved accounts: https://github.com/LiskHQ/lisk-hub/issues/1141

### How to test it?
Follow steps in #1247

### Review checklist
- The PR solves #1247
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
