### PR TITLE
Fetch 101 votes - Closes #1325

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -1,7 +1,7 @@
 import i18next from 'i18next';
 import actionTypes from '../constants/actions';
 import { setSecondPassphrase, getAccount } from '../utils/api/account';
-import { registerDelegate, getDelegate, getVotes, getVoters } from '../utils/api/delegate';
+import { registerDelegate, getDelegate, getAlllVotes, getVoters } from '../utils/api/delegate';
 import { loadTransactionsFinish, transactionsUpdated } from './transactions';
 import { delegateRegisteredFailure } from './delegate';
 import { errorAlertDialogDisplayed } from './dialog';
@@ -70,10 +70,10 @@ export const passphraseUsed = data => ({
 export const accountVotesFetched = ({ address }) =>
   (dispatch, getState) => {
     const activePeer = getState().peers.data;
-    return getVotes(activePeer, address).then(({ data }) => {
+    return getAlllVotes(activePeer, address).then((votes) => {
       dispatch({
         type: actionTypes.accountAddVotes,
-        votes: data.votes,
+        votes,
       });
     });
   };

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -1,7 +1,7 @@
 import i18next from 'i18next';
 import actionTypes from '../constants/actions';
 import { setSecondPassphrase, getAccount } from '../utils/api/account';
-import { registerDelegate, getDelegate, getAlllVotes, getVoters } from '../utils/api/delegate';
+import { registerDelegate, getDelegate, getVotes, getVoters } from '../utils/api/delegate';
 import { loadTransactionsFinish, transactionsUpdated } from './transactions';
 import { delegateRegisteredFailure } from './delegate';
 import { errorAlertDialogDisplayed } from './dialog';
@@ -70,14 +70,24 @@ export const passphraseUsed = data => ({
 export const accountVotesFetched = ({ address }) =>
   (dispatch, getState) => {
     const activePeer = getState().peers.data;
-    return getAlllVotes(activePeer, address).then((votes) => {
+    return getVotes(activePeer, { address }).then(({ data }) => {
       dispatch({
         type: actionTypes.accountAddVotes,
-        votes,
+        votes: data.votes,
       });
     });
   };
 
+  // export const accountVotesFetched = ({ address }) =>
+  // (dispatch, getState) => {
+  //   const activePeer = getState().peers.data;
+  //   return getAlllVotes(activePeer, address).then((votes) => {
+  //     dispatch({
+  //       type: actionTypes.accountAddVotes,
+  //       votes,
+  //     });
+  //   });
+  // };
 /**
  * Gets list of all voters
  */

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -78,16 +78,6 @@ export const accountVotesFetched = ({ address }) =>
     });
   };
 
-  // export const accountVotesFetched = ({ address }) =>
-  // (dispatch, getState) => {
-  //   const activePeer = getState().peers.data;
-  //   return getAlllVotes(activePeer, address).then((votes) => {
-  //     dispatch({
-  //       type: actionTypes.accountAddVotes,
-  //       votes,
-  //     });
-  //   });
-  // };
 /**
  * Gets list of all voters
  */

--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -2,7 +2,7 @@ import actionTypes from '../constants/actions';
 import { loadingStarted, loadingFinished } from '../actions/loading';
 import { getAccount } from '../utils/api/account';
 import { getTransactions } from '../utils/api/transactions';
-import { getDelegate, getVoters, getVotes } from '../utils/api/delegate';
+import { getDelegate, getVoters, getAlllVotes } from '../utils/api/delegate';
 import searchAll from '../utils/api/search';
 
 const searchDelegate = ({ publicKey, address }) =>
@@ -22,13 +22,11 @@ const searchDelegate = ({ publicKey, address }) =>
 const searchVotes = ({ address }) =>
   (dispatch, getState) => {
     const activePeer = getState().peers.data;
-    const votesEarlyBatch = getVotes(activePeer, address, 0, 100);
-    const votesLasteBatch = getVotes(activePeer, address, 101, 1);
-    Promise.all([votesEarlyBatch, votesLasteBatch]).then(([a, b]) =>
+    getAlllVotes(activePeer, address).then(votes =>
       dispatch({
         type: actionTypes.searchVotes,
         data: {
-          votes: [...a.data.votes, ...b.data.votes],
+          votes,
           address,
         },
       }));

--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -22,11 +22,13 @@ const searchDelegate = ({ publicKey, address }) =>
 const searchVotes = ({ address }) =>
   (dispatch, getState) => {
     const activePeer = getState().peers.data;
-    getVotes(activePeer, address).then(response =>
+    const votesEarlyBatch = getVotes(activePeer, address, 0, 100);
+    const votesLasteBatch = getVotes(activePeer, address, 101, 1);
+    Promise.all([votesEarlyBatch, votesLasteBatch]).then(([a, b]) =>
       dispatch({
         type: actionTypes.searchVotes,
         data: {
-          votes: response.data.votes,
+          votes: [...a.data.votes, ...b.data.votes],
           address,
         },
       }));

--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -22,11 +22,11 @@ const searchDelegate = ({ publicKey, address }) =>
 const searchVotes = ({ address }) =>
   (dispatch, getState) => {
     const activePeer = getState().peers.data;
-    getAlllVotes(activePeer, address).then(votes =>
+    getAlllVotes(activePeer, address).then(response =>
       dispatch({
         type: actionTypes.searchVotes,
         data: {
-          votes,
+          votes: response.data.votes,
           address,
         },
       }));

--- a/src/utils/api/delegate.js
+++ b/src/utils/api/delegate.js
@@ -35,8 +35,19 @@ export const vote = (
   });
 };
 
-export const getVotes = (activePeer, address, offset, limit) =>
+export const getVotes = (activePeer, { address, offset, limit }) =>
   activePeer.votes.get({ address, limit, offset });
+
+export const getAlllVotes = (activePeer, address) =>
+  new Promise((resolve, reject) => {
+    getVotes(activePeer, { address, offset: 0, limit: 100 }).then((votesEarlyBatch) => {
+      if (votesEarlyBatch.data.votes && votesEarlyBatch.data.votes.length < 50) {
+        return resolve(votesEarlyBatch.data.votes);
+      }
+      return getVotes(activePeer, { address, offset: 101, limit: 1 }).then(votesLasteBatch =>
+        resolve([...votesEarlyBatch.data.votes, ...votesLasteBatch.data.votes])).catch(reject);
+    }).catch(reject);
+  });
 
 export const getVoters = (activePeer, publicKey) =>
   activePeer.voters.get({ publicKey });

--- a/src/utils/api/delegate.js
+++ b/src/utils/api/delegate.js
@@ -41,10 +41,10 @@ export const getVotes = (activePeer, { address, offset, limit }) =>
 export const getAlllVotes = (activePeer, address) =>
   new Promise((resolve, reject) => {
     getVotes(activePeer, { address, offset: 0, limit: 100 }).then((votesEarlyBatch) => {
-      if (votesEarlyBatch.data.votes && votesEarlyBatch.data.votes.length < 50) {
+      if (votesEarlyBatch.data.votes && votesEarlyBatch.data.votesUsed < 101) {
         return resolve(votesEarlyBatch.data.votes);
       }
-      return getVotes(activePeer, { address, offset: 101, limit: 1 }).then(votesLasteBatch =>
+      return getVotes(activePeer, { address, offset: 100, limit: 1 }).then(votesLasteBatch =>
         resolve([...votesEarlyBatch.data.votes, ...votesLasteBatch.data.votes])).catch(reject);
     }).catch(reject);
   });

--- a/src/utils/api/delegate.js
+++ b/src/utils/api/delegate.js
@@ -35,8 +35,8 @@ export const vote = (
   });
 };
 
-export const getVotes = (activePeer, address) =>
-  activePeer.votes.get({ address });
+export const getVotes = (activePeer, address, offset, limit) =>
+  activePeer.votes.get({ address, limit, offset });
 
 export const getVoters = (activePeer, publicKey) =>
   activePeer.voters.get({ publicKey });

--- a/src/utils/api/delegate.js
+++ b/src/utils/api/delegate.js
@@ -42,10 +42,12 @@ export const getAlllVotes = (activePeer, address) =>
   new Promise((resolve, reject) => {
     getVotes(activePeer, { address, offset: 0, limit: 100 }).then((votesEarlyBatch) => {
       if (votesEarlyBatch.data.votes && votesEarlyBatch.data.votesUsed < 101) {
-        return resolve(votesEarlyBatch.data.votes);
+        return resolve(votesEarlyBatch);
       }
-      return getVotes(activePeer, { address, offset: 100, limit: 1 }).then(votesLasteBatch =>
-        resolve([...votesEarlyBatch.data.votes, ...votesLasteBatch.data.votes])).catch(reject);
+      return getVotes(activePeer, { address, offset: 100, limit: 1 }).then((votesLasteBatch) => {
+        votesEarlyBatch.data.votes = [...votesEarlyBatch.data.votes, ...votesLasteBatch.data.votes];
+        return resolve(votesEarlyBatch);
+      }).catch(reject);
     }).catch(reject);
   });
 

--- a/src/utils/api/delegate.test.js
+++ b/src/utils/api/delegate.test.js
@@ -137,7 +137,7 @@ describe('Utils: Delegate', () => {
       const address = '123L';
       const offset = 0;
       const limit = 100;
-      getVotes(activePeer, address, offset, limit);
+      getVotes(activePeer, { address, offset, limit });
       expect(activePeer.votes.get).to.have.been.calledWith({ address, offset, limit });
     });
   });

--- a/src/utils/api/delegate.test.js
+++ b/src/utils/api/delegate.test.js
@@ -135,8 +135,10 @@ describe('Utils: Delegate', () => {
   describe('getVotes', () => {
     it('should get votes for an address with no parameters', () => {
       const address = '123L';
-      getVotes(activePeer, address);
-      expect(activePeer.votes.get).to.have.been.calledWith({ address });
+      const offset = 0;
+      const limit = 100;
+      getVotes(activePeer, address, offset, limit);
+      expect(activePeer.votes.get).to.have.been.calledWith({ address, offset, limit });
     });
   });
 

--- a/src/utils/api/delegate.test.js
+++ b/src/utils/api/delegate.test.js
@@ -8,6 +8,7 @@ import {
   vote,
   getVotes,
   getVoters,
+  getAlllVotes,
   registerDelegate } from './delegate';
 import accounts from '../../../test/constants/accounts';
 
@@ -25,7 +26,7 @@ describe('Utils: Delegate', () => {
       get: () => { },
     },
     votes: {
-      get: sinon.spy(),
+      get: () => { },
     },
     voters: {
       get: () => { },
@@ -63,8 +64,8 @@ describe('Utils: Delegate', () => {
   describe('listAccountDelegates', () => {
     it('should get votes for an address with 101 limit', () => {
       const address = '123L';
+      activePeerMockVotes.expects('get').withArgs({ address, limit: '101' }).once();
       listAccountDelegates(activePeer, address);
-      expect(activePeer.votes.get).to.have.been.calledWith({ address, limit: '101' });
     });
   });
 
@@ -137,8 +138,28 @@ describe('Utils: Delegate', () => {
       const address = '123L';
       const offset = 0;
       const limit = 100;
+      activePeerMockVotes.expects('get').withArgs({ address, offset, limit }).once();
       getVotes(activePeer, { address, offset, limit });
-      expect(activePeer.votes.get).to.have.been.calledWith({ address, offset, limit });
+    });
+  });
+
+  describe('getAlllVotes', () => {
+    it('should get all votes for an address with no parameters > 100', () => {
+      const address = '123L';
+      activePeerMockVotes.expects('get').withArgs({ address, offset: 0, limit: 100 })
+        .returnsPromise().resolves({ data: { votes: [1, 2, 3], votesUsed: 101 } });
+      activePeerMockVotes.expects('get').withArgs({ address, offset: 100, limit: 1 })
+        .returnsPromise().resolves({ data: { votes: [4], votesUsed: 101 } });
+      const returnedPromise = getAlllVotes(activePeer, address);
+      expect(returnedPromise).to.eventually.equal([1, 2, 3, 4]);
+    });
+
+    it('should get all votes for an address with no parameters < 100', () => {
+      const address = '123L';
+      activePeerMockVotes.expects('get').withArgs({ address, offset: 0, limit: 100 })
+        .returnsPromise().resolves({ data: { votes: [1], votesUsed: 1 } });
+      const returnedPromise = getAlllVotes(activePeer, address);
+      expect(returnedPromise).to.eventually.equal([1]);
     });
   });
 

--- a/test/cypress/e2e/ex-protractor-cucumber/explorer.spec.js
+++ b/test/cypress/e2e/ex-protractor-cucumber/explorer.spec.js
@@ -38,6 +38,6 @@ describe('Explorer page', () => {
     cy.get('.addresses-result').click();
     cy.wait(3000);
     cy.get('.delegate-statistics').click();
-    cy.get('.votesFilterQuery-row').should('have.length', 10);
+    cy.get('.votesFilterQuery-row').should('have.length', 35);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #1325 
Will fix issue with votes but voters still to-do will implement infinite scroll on another ticket: https://github.com/LiskHQ/lisk-hub/issues/1344

### How have I implemented/fixed it?
Run two api calls in parallel one with an offset of 101 items


### How has this been tested?
Manually:
1) On MainNet go to https://jenkins.lisk.io/test/lisk-hub/PR-1333/#/
2) Search for `1010556662314252067L`
2) Click on Delegate statistics
3) Look for votes = 101


### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
