### PR TITLE
Open direct link with autologin - Closes #1339

### DIFF
--- a/src/store/middlewares/peers.js
+++ b/src/store/middlewares/peers.js
@@ -2,6 +2,7 @@ import { activePeerSet, activePeerUpdate } from '../../actions/peers';
 import actionTypes from '../../constants/actions';
 import networks from './../../constants/networks';
 import getNetwork from './../../utils/getNetwork';
+import { shouldAutoLogIn } from './../../utils/login';
 
 const peersMiddleware = store => next => (action) => {
   next(action);
@@ -10,7 +11,10 @@ const peersMiddleware = store => next => (action) => {
 
   switch (action.type) {
     case actionTypes.storeCreated:
-      store.dispatch(activePeerSet({ network }));
+      // It changes network back to mainnet when we want to autologin for explorer account
+      if (!shouldAutoLogIn) {
+        store.dispatch(activePeerSet({ network }));
+      }
       store.dispatch(activePeerUpdate({ online: true }));
       break;
     default: break;

--- a/src/store/middlewares/peers.js
+++ b/src/store/middlewares/peers.js
@@ -2,17 +2,20 @@ import { activePeerSet, activePeerUpdate } from '../../actions/peers';
 import actionTypes from '../../constants/actions';
 import networks from './../../constants/networks';
 import getNetwork from './../../utils/getNetwork';
-import { shouldAutoLogIn } from './../../utils/login';
+import { shouldAutoLogIn, getAutoLogInData } from './../../utils/login';
 
 const peersMiddleware = store => next => (action) => {
   next(action);
 
   const network = Object.assign({}, getNetwork(networks.mainnet.code));
+  const autologinData = getAutoLogInData();
 
   switch (action.type) {
     case actionTypes.storeCreated:
-      // It changes network back to mainnet when we want to autologin for explorer account
-      if (!shouldAutoLogIn) {
+      // It stops activePeer to be overridden to mainnet
+      // when we want to autologin for explorer account
+      // https://github.com/LiskHQ/lisk-hub/issues/1339
+      if (!shouldAutoLogIn(autologinData)) {
         store.dispatch(activePeerSet({ network }));
       }
       store.dispatch(activePeerUpdate({ online: true }));

--- a/src/store/middlewares/peers.js
+++ b/src/store/middlewares/peers.js
@@ -15,6 +15,7 @@ const peersMiddleware = store => next => (action) => {
       // It stops activePeer to be overridden to mainnet
       // when we want to autologin for explorer account
       // https://github.com/LiskHQ/lisk-hub/issues/1339
+      /* istanbul ignore else */
       if (!shouldAutoLogIn(autologinData)) {
         store.dispatch(activePeerSet({ network }));
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #1339

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Stopped overwriting activePeer when We are in autologin mode

### How has this been tested?
<!--- Please describe how you tested your changes. -->
set up autologin and try to access e`explorer/transactions`

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
