### PR TITLE
Show delegate statistics on a delegate account - Closes #1336

### DIFF
--- a/src/components/transactions/walletTransactions/index.js
+++ b/src/components/transactions/walletTransactions/index.js
@@ -3,6 +3,7 @@ import { translate } from 'react-i18next';
 import { withRouter } from 'react-router-dom';
 import { transactionsRequested, transactionsFilterSet } from '../../../actions/transactions';
 import { accountVotersFetched, accountVotesFetched } from '../../../actions/account';
+import { searchAccount } from '../../../actions/search';
 import WalletTransactions from './walletTransactions';
 import actionTypes from '../../../constants/actions';
 import txFilters from './../../../constants/transactionFilters';
@@ -21,6 +22,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
+  searchAccount: data => dispatch(searchAccount(data)),
   transactionsRequested: data => dispatch(transactionsRequested(data)),
   transactionsFilterSet: data => dispatch(transactionsFilterSet(data)),
   accountVotersFetched: data => dispatch(accountVotersFetched(data)),

--- a/src/components/transactions/walletTransactions/walletTransactions.js
+++ b/src/components/transactions/walletTransactions/walletTransactions.js
@@ -23,6 +23,11 @@ class WalletTransactions extends React.Component {
         publicKey: this.props.account.delegate.publicKey,
       });
     }
+
+    this.props.searchAccount({
+      address: this.props.address,
+    });
+
     this.props.accountVotesFetched({
       address: this.props.address,
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #1336

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Call action searchAccount on WalletTransactions with addess

### How has this been tested?
<!--- Please describe how you tested your changes. -->
1. Login as delegate
2. Go to your Wallet
3. Open Account info tab should see delegate statistics instead of account info

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
