### PR TITLE
Show delegate statistics on a delegate account - Closes #1336

### DIFF
--- a/src/components/transactions/walletTransactions/index.js
+++ b/src/components/transactions/walletTransactions/index.js
@@ -16,6 +16,7 @@ const mapStateToProps = state => ({
   votes: state.account.votes,
   voters: state.account.voters,
   count: state.transactions.count,
+  // Pick delegate from source
   delegate: (state.account && state.account.delegate) ?
     state.account && (state.account.delegate || null) :
     state.search.delegates[state.account.address],

--- a/src/components/transactions/walletTransactions/index.js
+++ b/src/components/transactions/walletTransactions/index.js
@@ -9,17 +9,22 @@ import actionTypes from '../../../constants/actions';
 import txFilters from './../../../constants/transactionFilters';
 
 /* istanbul ignore next */
-const mapStateToProps = state => ({
-  account: state.account,
-  transaction: state.transaction,
-  transactions: [...state.transactions.pending, ...state.transactions.confirmed],
-  votes: state.account.votes,
-  voters: state.account.voters,
-  count: state.transactions.count,
-  delegate: state.account && (state.account.delegate || null),
-  activeFilter: state.filters.wallet || txFilters.all,
-  loading: state.loading,
-});
+const mapStateToProps = (state) => {
+  const address = state.account.address;
+  const delegate = (state.search && state.search.delegates) ?
+    state.search.delegates[address] : state.account && (state.account.delegate || null);
+  return {
+    account: state.account,
+    transaction: state.transaction,
+    transactions: [...state.transactions.pending, ...state.transactions.confirmed],
+    votes: state.account.votes,
+    voters: state.account.voters,
+    count: state.transactions.count,
+    delegate,
+    activeFilter: state.filters.wallet || txFilters.all,
+    loading: state.loading,
+  };
+};
 
 const mapDispatchToProps = dispatch => ({
   searchAccount: data => dispatch(searchAccount(data)),

--- a/src/components/transactions/walletTransactions/index.js
+++ b/src/components/transactions/walletTransactions/index.js
@@ -9,22 +9,19 @@ import actionTypes from '../../../constants/actions';
 import txFilters from './../../../constants/transactionFilters';
 
 /* istanbul ignore next */
-const mapStateToProps = (state) => {
-  const address = state.account.address;
-  const delegate = (state.search && state.search.delegates) ?
-    state.search.delegates[address] : state.account && (state.account.delegate || null);
-  return {
-    account: state.account,
-    transaction: state.transaction,
-    transactions: [...state.transactions.pending, ...state.transactions.confirmed],
-    votes: state.account.votes,
-    voters: state.account.voters,
-    count: state.transactions.count,
-    delegate,
-    activeFilter: state.filters.wallet || txFilters.all,
-    loading: state.loading,
-  };
-};
+const mapStateToProps = state => ({
+  account: state.account,
+  transaction: state.transaction,
+  transactions: [...state.transactions.pending, ...state.transactions.confirmed],
+  votes: state.account.votes,
+  voters: state.account.voters,
+  count: state.transactions.count,
+  delegate: (state.account && state.account.delegate) ?
+    state.account && (state.account.delegate || null) :
+    state.search.delegates[state.account.address],
+  activeFilter: state.filters.wallet || txFilters.all,
+  loading: state.loading,
+});
 
 const mapDispatchToProps = dispatch => ({
   searchAccount: data => dispatch(searchAccount(data)),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #1336

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Call action searchAccount on WalletTransactions with addess

### How has this been tested?
<!--- Please describe how you tested your changes. -->
1. Login as delegate
2. Go to your Wallet
3. Open Account info tab should see delegate statistics instead of account info

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
