### PR TITLE
Change chart font color - Closes #1347

### DIFF
--- a/src/components/dashboard/currencyGraph.js
+++ b/src/components/dashboard/currencyGraph.js
@@ -25,7 +25,7 @@ const chartOptions = step => ({
       time: step.timeFormat,
       distribution: 'linear',
       ticks: {
-        fontColor: '#FFFFFF',
+        fontColor: '#2C4062',
         fontSize: 14,
         fontFamily: '\'Open Sans\', sans-serif',
       },

--- a/src/components/dashboard/currencyGraph.js
+++ b/src/components/dashboard/currencyGraph.js
@@ -25,7 +25,7 @@ const chartOptions = step => ({
       time: step.timeFormat,
       distribution: 'linear',
       ticks: {
-        fontColor: '#204F9F',
+        fontColor: '#FFFFFF',
         fontSize: 14,
         fontFamily: '\'Open Sans\', sans-serif',
       },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #1347

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Change color to #2C4062 in chart options: /Users/benjaminmaggi/LiskHQ/lisk-hub/src/components/dashboard/currencyGraph.js

### How has this been tested?
<!--- Please describe how you tested your changes. -->
1) Go to home page (dashboard)
2) Chart should look like this:
![image](https://user-images.githubusercontent.com/43953571/47286553-6ef12e80-d5ef-11e8-8407-b2caba3bf5d4.png)



### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
