### PR TITLE
Adjust width for search input large screen breakpoint - Closes #1353

### DIFF
--- a/src/components/searchBar/searchBar.css
+++ b/src/components/searchBar/searchBar.css
@@ -1,7 +1,7 @@
 @import './../app/variables.css';
 
 :root {
-  --search-box-width-l: 100%; /* stylelint-disable-line */
+  --search-box-width-l: 25vw; /* stylelint-disable-line */
   --search-box-width-xl: 558px;
   --search-box-font-size: 16px;
   --search-box-line-height: 56px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #1353

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
On large size screen, input search width is set to 25vw

### How has this been tested?
<!--- Please describe how you tested your changes. -->
1. Go to home page,
2. Reduce the width of the app window to less or equal 1400
3. Look at the search field

![image](https://user-images.githubusercontent.com/43953571/47288881-70732480-d5f8-11e8-930d-b60842635f35.png)

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
