### PR TITLE
Unable to register as a delegate with an account balance of 25 - Closes #1350

### DIFF
--- a/src/components/registerDelegate/steps/choose/choose.js
+++ b/src/components/registerDelegate/steps/choose/choose.js
@@ -25,7 +25,7 @@ class Choose extends React.Component {
 
   hasEnoughLSK() {
     return (fromRawLsk(this.props.account.balance) * 1
-    > fromRawLsk(Fees.registerDelegate) * 1);
+    >= fromRawLsk(Fees.registerDelegate) * 1);
   }
 
   checkSufficientFunds(evt) {


### PR DESCRIPTION
Unable to register as a delegate with an account balance of 25 - Closes #1350
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #1350

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
In src/components/registerDelegate/steps/choose/choose.js make it so the function hasEnoughLSK returns true for values > or = to the required lisk amount to become a delegate

### How has this been tested?
<!--- Please describe how you tested your changes. -->
1. Choose an account with 25LSK
2. Try to become a delegate
3. Screen should allow user to become a delegate with 25LSK in it's wallet

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
