### PR TITLE
Transactions to 'yourself' are all seen as "account initialization" - Closes #1281

### DIFF
--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -7,6 +7,7 @@
   "Academy": "Academy",
   "Access extra features": "Access extra features",
   "Account Info": "Account Info",
+  "Account initialization": "Account initialization",
   "Active": "Active",
   "Activity": "Activity",
   "Add a Lisk ID": "Add a Lisk ID",

--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -7,7 +7,6 @@
   "Academy": "Academy",
   "Access extra features": "Access extra features",
   "Account Info": "Account Info",
-  "Account initialization": "Account initialization",
   "Active": "Active",
   "Activity": "Activity",
   "Add a Lisk ID": "Add a Lisk ID",

--- a/src/components/sendReadable/send.js
+++ b/src/components/sendReadable/send.js
@@ -79,13 +79,14 @@ class SendReadable extends React.Component {
   send(event) {
     event.preventDefault();
     this.setState({ loading: true });
+    const isAccountInit = this.props.accountInit && (this.props.account.address === this.state.recipient.value);
     this.props.sent({
       account: this.props.account,
       recipientId: this.state.recipient.value,
       amount: this.state.amount.value,
       passphrase: this.props.passphrase.value,
       secondPassphrase: this.props.secondPassphrase.value,
-      data: this.props.reference,
+      data: isAccountInit ? this.props.t('Account initialization') : this.props.reference,
     });
   }
 

--- a/src/components/sendReadable/send.js
+++ b/src/components/sendReadable/send.js
@@ -79,7 +79,8 @@ class SendReadable extends React.Component {
   send(event) {
     event.preventDefault();
     this.setState({ loading: true });
-    const isAccountInit = this.props.accountInit && (this.props.account.address === this.state.recipient.value);
+    const isAccountInit = this.props.accountInit &&
+      (this.props.account.address === this.state.recipient.value);
     this.props.sent({
       account: this.props.account,
       recipientId: this.state.recipient.value,

--- a/src/components/sendReadable/send.js
+++ b/src/components/sendReadable/send.js
@@ -79,15 +79,13 @@ class SendReadable extends React.Component {
   send(event) {
     event.preventDefault();
     this.setState({ loading: true });
-    const isAccountInit = this.props.accountInit &&
-      (this.props.account.address === this.state.recipient.value);
     this.props.sent({
       account: this.props.account,
       recipientId: this.state.recipient.value,
       amount: this.state.amount.value,
       passphrase: this.props.passphrase.value,
       secondPassphrase: this.props.secondPassphrase.value,
-      data: isAccountInit ? this.props.t('Account initialization') : this.props.reference,
+      data: this.props.accountInit ? this.props.t('Account initialization') : this.props.reference,
     });
   }
 

--- a/src/components/transactions/transactionType.js
+++ b/src/components/transactions/transactionType.js
@@ -7,7 +7,7 @@ const TransactionType = (props) => {
   let type;
   switch (props.type) {
     case 0:
-      type = props.senderId === props.recipientId ? t('Account initialization') : false;
+      type = false;
       break;
     case 1:
       type = t('Second passphrase registration');

--- a/src/components/transactions/transactionType.js
+++ b/src/components/transactions/transactionType.js
@@ -6,9 +6,6 @@ const TransactionType = (props) => {
   const { t } = props;
   let type;
   switch (props.type) {
-    case 0:
-      type = false;
-      break;
     case 1:
       type = t('Second passphrase registration');
       break;

--- a/test/cypress/e2e/transfer.spec.js
+++ b/test/cypress/e2e/transfer.spec.js
@@ -136,7 +136,7 @@ describe('Transfer', () => {
     cy.get(ss.amountInput).click().type(randomAmount);
     cy.get(ss.nextButton).click();
     cy.get(ss.sendButton).click();
-    cy.get(ss.transactionRow).eq(0).find(ss.transactionAddress).should('have.text', msg.accountInitializatoinAddress);
+    cy.get(ss.transactionRow).eq(0).find(ss.transactionReference).should('have.text', msg.accountInitializatoinAddress);
   });
 
   it('Launch protocol link prefills recipient, amount and reference', () => {

--- a/test/cypress/e2e/transfer.spec.js
+++ b/test/cypress/e2e/transfer.spec.js
@@ -129,16 +129,6 @@ describe('Transfer', () => {
     cy.get('@tx').find(ss.transactionAddress).should('have.text', randomAddress);
   });
 
-  it('Transfer to myself appears as account initialization', () => {
-    cy.autologin(accounts.genesis.passphrase, networks.devnet.node);
-    cy.visit(urls.wallet);
-    cy.get(ss.recipientInput).type(accounts.genesis.address);
-    cy.get(ss.amountInput).click().type(randomAmount);
-    cy.get(ss.nextButton).click();
-    cy.get(ss.sendButton).click();
-    cy.get(ss.transactionRow).eq(0).find(ss.transactionAddress).should('have.text', accounts.genesis.address);
-  });
-
   it('Launch protocol link prefills recipient, amount and reference', () => {
     cy.autologin(accounts.genesis.passphrase, networks.devnet.node);
     cy.visit('/wallet?recipient=4995063339468361088L&amount=5&reference=test');
@@ -172,5 +162,8 @@ describe('Transfer', () => {
     cy.wait(txConfirmationTimeout);
     cy.reload();
     cy.get(ss.accountInitializationMsg).should('not.exist');
+    cy.get(ss.transactionRow).eq(0).as('tx');
+    cy.get('@tx').find(ss.transactionAddress).should('have.text', accounts['without initialization'].address);
+    cy.get('@tx').find(ss.transactionReference).should('have.text', 'Account initialization');
   });
 });

--- a/test/cypress/e2e/transfer.spec.js
+++ b/test/cypress/e2e/transfer.spec.js
@@ -136,7 +136,7 @@ describe('Transfer', () => {
     cy.get(ss.amountInput).click().type(randomAmount);
     cy.get(ss.nextButton).click();
     cy.get(ss.sendButton).click();
-    cy.get(ss.transactionRow).eq(0).find(ss.transactionReference).should('have.text', msg.accountInitializatoinAddress);
+    cy.get(ss.transactionRow).eq(0).find(ss.transactionAddress).should('have.text', accounts.genesis.address);
   });
 
   it('Launch protocol link prefills recipient, amount and reference', () => {

--- a/test/integration/wallet.test.js
+++ b/test/integration/wallet.test.js
@@ -200,7 +200,7 @@ describe('@integration: Wallet', () => {
         match.defined,
         match.defined,
         null,
-        undefined,
+        'Account initialization',
       ).returnsPromise().resolves({ data: [] });
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #1281

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
1. Type 0 transactions to yourself (same sender & receiver) show address instead of "Account initialization"
2. When initializing account the reference message for the transaction is set to "Account initialization"

### How has this been tested?
<!--- Please describe how you tested your changes. -->
1. Transfer some amount of LSK to yourself
2. Go to wallet outgoing transactions check for the transaction you made to yourself you should see  recipient (self) address instead of "Account initialization"

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
