### PR TITLE
Allocate random port numbers for core - Closes #1386

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,8 +83,8 @@ pipeline {
 					"jest": {
 						ansiColor('xterm') {
 							sh 'ON_JENKINS=true npm run --silent test-jest'
-							
-							// TODO: uncomment sending coverage to coveralls when 
+
+							// TODO: uncomment sending coverage to coveralls when
 							// all tests are migrated from mocha to jest
 							// withCredentials([string(credentialsId: 'lisk-hub-coveralls-token', variable: 'COVERALLS_REPO_TOKEN')]) {
 								//	sh 'cat coverage/HeadlessChrome*/lcov.info |coveralls -v'
@@ -108,6 +108,10 @@ pipeline {
 									cp $WORKSPACE/test/blockchain.db.gz $WORKSPACE/$BRANCH_NAME/dev_blockchain.db.gz
 									cd $WORKSPACE/$BRANCH_NAME
 									cp .env.development .env
+
+									# random port assignment
+									yq --yaml-output '.services.lisk.ports[0]="${ENV_LISK_HTTP_PORT}"|.services.lisk.ports[1]="${ENV_LISK_WS_PORT}"' docker-compose.yml |sponge docker-compose.yml
+
 									LISK_VERSION=1.1.0-alpha.8 make coldstart
 									export CYPRESS_baseUrl=http://127.0.0.1:300$N/#/
 									export CYPRESS_coreUrl=http://127.0.0.1:$( docker-compose port lisk 4000 |cut -d ":" -f 2 )

--- a/test/cypress/e2e/delegates.spec.js
+++ b/test/cypress/e2e/delegates.spec.js
@@ -39,6 +39,7 @@ describe('Delegates', () => {
     cy.addLocalStorage('settings', 'advancedMode', true);
     cy.autologin(accounts.genesis.passphrase, networks.devnet.node);
     cy.visit(urls.dashboard);
+    cy.wait(200); // Wait for wallet sidebar button to appear
     cy.get(ss.sidebarMenuDelegatesBtn).click();
     cy.url().should('contain', urls.delegates);
     cy.get(ss.confirmVotesSidebar).find(ss.nextButton);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #1386

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Allocate random http and ws ports instead of 4000 and 5000
to avoid _port already allocated_ error when running several instances on a single machine

### How has this been tested?
<!--- Please describe how you tested your changes. -->


### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
