### PR TITLE
Do not show balance if undefined - Closes #1391

### DIFF
--- a/src/components/liskAmount/index.js
+++ b/src/components/liskAmount/index.js
@@ -10,8 +10,12 @@ const roundTo = (value, places) => {
   return Math.round(value * x) / x;
 };
 
-const LiskAmount = props => (<FormattedNumber val={
-  roundTo(parseFloat(fromRawLsk(props.val)), props.roundTo)} />);
+const LiskAmount = props => (
+  props.val !== undefined ?
+    <FormattedNumber val={roundTo(parseFloat(fromRawLsk(props.val)), props.roundTo)} /> :
+    <span />
+);
+
 
 export default LiskAmount;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #1391

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Return empty from LiskAmount component span if balance value passed was undefined

### How has this been tested?
<!--- Please describe how you tested your changes. -->


### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
