### PR TITLE
Fix API delegate - Closes #1359

### DIFF
--- a/src/actions/transactions.js
+++ b/src/actions/transactions.js
@@ -132,7 +132,7 @@ export const loadTransaction = ({ id }) =>
           deleted = response.data[0].asset.votes.filter(item => item.startsWith('-')).map(item => item.replace('-', ''));
         }
 
-        const localStorageDelegates = loadDelegateCache(getState().peers.options.code);
+        const localStorageDelegates = loadDelegateCache(getState().peers);
         deleted.forEach((publicKey) => {
           const address = extractAddress(publicKey);
           const storedDelegate = localStorageDelegates[address];

--- a/src/actions/transactions.js
+++ b/src/actions/transactions.js
@@ -132,7 +132,7 @@ export const loadTransaction = ({ id }) =>
           deleted = response.data[0].asset.votes.filter(item => item.startsWith('-')).map(item => item.replace('-', ''));
         }
 
-        const localStorageDelegates = loadDelegateCache(activePeer);
+        const localStorageDelegates = loadDelegateCache(getState().peers.options.code);
         deleted.forEach((publicKey) => {
           const address = extractAddress(publicKey);
           const storedDelegate = localStorageDelegates[address];

--- a/src/actions/voting.js
+++ b/src/actions/voting.js
@@ -156,7 +156,7 @@ export const delegatesFetched = ({
     };
     params = q ? { ...params, search: q } : params;
     listDelegates(activePeer, params).then((response) => {
-      updateDelegateCache(response.data, getState().peers.options.code);
+      updateDelegateCache(response.data, getState().peers);
       dispatch(delegatesAdded({
         list: response.data,
         totalDelegates: response.data.length,

--- a/src/actions/voting.js
+++ b/src/actions/voting.js
@@ -156,7 +156,7 @@ export const delegatesFetched = ({
     };
     params = q ? { ...params, search: q } : params;
     listDelegates(activePeer, params).then((response) => {
-      updateDelegateCache(response.data, activePeer);
+      updateDelegateCache(response.data, getState().peers.options.code);
       dispatch(delegatesAdded({
         list: response.data,
         totalDelegates: response.data.length,

--- a/src/actions/voting.test.js
+++ b/src/actions/voting.test.js
@@ -229,10 +229,9 @@ describe('actions: voting', () => {
       const dispatch = sinon.spy();
       getState = () => ({
         peers: {
-          data: {
-            options: {
-              name: networks.mainnet.name,
-            },
+          options: {
+            name: networks.mainnet.name,
+            code: networks.mainnet.code,
           },
         },
       });

--- a/src/store/middlewares/voting.js
+++ b/src/store/middlewares/voting.js
@@ -13,7 +13,8 @@ const lookupDelegate = (store, username) => {
   const state = store.getState();
   const activePeer = state.peers.data;
   const localStorageDelegates = loadDelegateCache(state.peers.options.code);
-  const delegate = localStorageDelegates[username];
+  const delegate = localStorageDelegates[username] ||
+    state.voting.delegates.find(d => d.username === username);
   if (delegate) {
     return new Promise((resolve) => {
       resolve({ data: [delegate] });

--- a/src/store/middlewares/voting.js
+++ b/src/store/middlewares/voting.js
@@ -1,6 +1,7 @@
 import { getDelegate } from '../../utils/api/delegate';
 import { voteLookupStatusUpdated, voteToggled, votesFetched } from '../../actions/voting';
 import actionTypes from '../../constants/actions';
+import { loadDelegateCache } from '../../utils/delegates';
 
 const updateLookupStatus = (store, list, username) => {
   store.dispatch(voteLookupStatusUpdated({
@@ -11,10 +12,11 @@ const updateLookupStatus = (store, list, username) => {
 const lookupDelegate = (store, username) => {
   const state = store.getState();
   const activePeer = state.peers.data;
-  const delegate = state.voting.delegates.filter(d => d.username === username)[0];
+  const localStorageDelegates = loadDelegateCache(state.peers.options.code);
+  const delegate = localStorageDelegates[username];
   if (delegate) {
     return new Promise((resolve) => {
-      resolve({ delegate });
+      resolve({ data: [delegate] });
     });
   }
   return getDelegate(activePeer, { username });

--- a/src/store/middlewares/voting.js
+++ b/src/store/middlewares/voting.js
@@ -12,7 +12,7 @@ const updateLookupStatus = (store, list, username) => {
 const lookupDelegate = (store, username) => {
   const state = store.getState();
   const activePeer = state.peers.data;
-  const localStorageDelegates = loadDelegateCache(state.peers.options.code);
+  const localStorageDelegates = loadDelegateCache(state.peers);
   const delegate = localStorageDelegates[username] ||
     state.voting.delegates.find(d => d.username === username);
   if (delegate) {

--- a/src/store/middlewares/voting.test.js
+++ b/src/store/middlewares/voting.test.js
@@ -6,6 +6,7 @@ import * as delegateApi from '../../utils/api/delegate';
 import actionTypes from '../../constants/actions';
 import middleware from './voting';
 import votingConst from '../../constants/voting';
+import networks from '../../constants/networks';
 
 describe('voting middleware', () => {
   let store;
@@ -76,6 +77,9 @@ describe('voting middleware', () => {
       },
       peers: {
         data: {},
+        options: {
+          code: networks.mainnet.code,
+        },
       },
     };
     let getDelegateMock;

--- a/src/utils/delegates.js
+++ b/src/utils/delegates.js
@@ -1,22 +1,17 @@
 
 import localJSONStorage from './localJSONStorage';
 
-export const updateDelegateCache = (delegates, activePeer) => {
-  const network = activePeer.currentNode;
-  const savedDelegates = localJSONStorage.get(`delegateCache-${network}`, {});
+export const updateDelegateCache = (delegates, networkCode) => {
+  const savedDelegates = localJSONStorage.get(`delegateCache-${networkCode}`, {});
   const formatedDelegates = delegates
-    .reduce((newDelegates, { account, publicKey, username }) => {
-      const delegate = { [account.address]: { publicKey, username } };
-      return Object.assign(newDelegates, delegate);
+    .reduce((newDelegates, delegate) => {
+      const delegateObj = { [delegate.username]: delegate.account };
+      return Object.assign(newDelegates, delegateObj);
     }, {});
   const updatedDelegates = { ...formatedDelegates, ...savedDelegates };
 
-  localJSONStorage.set(`delegateCache-${network}`, updatedDelegates);
+  localJSONStorage.set(`delegateCache-${networkCode}`, updatedDelegates);
 };
 
-export const loadDelegateCache = (activePeer) => {
-  // TODO network just based on currentNode will not work well on Mainnet
-  // because there are multiplercurrentNode options for Mainnet
-  const network = activePeer.currentNode;
-  return localJSONStorage.get(`delegateCache-${network}`, {});
-};
+export const loadDelegateCache = networkCode =>
+  localJSONStorage.get(`delegateCache-${networkCode}`, {});

--- a/src/utils/delegates.js
+++ b/src/utils/delegates.js
@@ -5,7 +5,7 @@ export const updateDelegateCache = (delegates, networkCode) => {
   const savedDelegates = localJSONStorage.get(`delegateCache-${networkCode}`, {});
   const formatedDelegates = delegates
     .reduce((newDelegates, delegate) => {
-      const delegateObj = { [delegate.username]: delegate.account };
+      const delegateObj = { [delegate.username]: delegate };
       return Object.assign(newDelegates, delegateObj);
     }, {});
   const updatedDelegates = { ...formatedDelegates, ...savedDelegates };

--- a/src/utils/delegates.js
+++ b/src/utils/delegates.js
@@ -4,10 +4,11 @@ import localJSONStorage from './localJSONStorage';
 export const updateDelegateCache = (delegates, activePeer) => {
   const network = activePeer.currentNode;
   const savedDelegates = localJSONStorage.get(`delegateCache-${network}`, {});
-  const formatedDelegates = delegates.reduce((delegate, { address, publicKey, username }) => {
-    delegate[address] = { publicKey, username };
-    return delegate;
-  }, {});
+  const formatedDelegates = delegates
+    .reduce((newDelegates, { account, publicKey, username }) => {
+      const delegate = { [account.address]: { publicKey, username } };
+      return Object.assign(newDelegates, delegate);
+    }, {});
   const updatedDelegates = { ...formatedDelegates, ...savedDelegates };
 
   localJSONStorage.set(`delegateCache-${network}`, updatedDelegates);

--- a/src/utils/delegates.js
+++ b/src/utils/delegates.js
@@ -1,8 +1,17 @@
 
 import localJSONStorage from './localJSONStorage';
+import networks from '../constants/networks';
 
-export const updateDelegateCache = (delegates, networkCode) => {
-  const savedDelegates = localJSONStorage.get(`delegateCache-${networkCode}`, {});
+const getNetworkKey = activePeer => (
+  `delegateCache-${
+    activePeer.options.code === networks.customNode.code ?
+      activePeer.currentNode :
+      activePeer.options.code
+  }`
+);
+
+export const updateDelegateCache = (delegates, activePeer) => {
+  const savedDelegates = localJSONStorage.get(getNetworkKey(activePeer), {});
   const formatedDelegates = delegates
     .reduce((newDelegates, delegate) => {
       const delegateObj = { [delegate.username]: delegate };
@@ -10,8 +19,8 @@ export const updateDelegateCache = (delegates, networkCode) => {
     }, {});
   const updatedDelegates = { ...formatedDelegates, ...savedDelegates };
 
-  localJSONStorage.set(`delegateCache-${networkCode}`, updatedDelegates);
+  localJSONStorage.set(getNetworkKey(activePeer), updatedDelegates);
 };
 
-export const loadDelegateCache = networkCode =>
-  localJSONStorage.get(`delegateCache-${networkCode}`, {});
+export const loadDelegateCache = activePeer =>
+  localJSONStorage.get(getNetworkKey(activePeer), {});

--- a/src/utils/delegates.test.js
+++ b/src/utils/delegates.test.js
@@ -14,7 +14,8 @@ describe('Delegates Utils', () => {
   const item = [{ account: { ...accounts.genesis }, username: 'test' }];
   const itemExpected = {
     test: {
-      ...accounts.genesis,
+      account: { ...accounts.genesis },
+      username: 'test',
     },
   };
 

--- a/src/utils/delegates.test.js
+++ b/src/utils/delegates.test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { updateDelegateCache, loadDelegateCache } from './delegates';
 import accounts from '../../test/constants/accounts';
+import networks from '../constants/networks';
 
 describe('Delegates Utils', () => {
   const storage = {};
@@ -10,17 +11,15 @@ describe('Delegates Utils', () => {
     window.localStorage.setItem = (key, item) => { storage[key] = item; };
   });
 
-  const item = [{ ...accounts.genesis, username: 'test' }];
+  const item = [{ account: { ...accounts.genesis }, username: 'test' }];
   const itemExpected = {
-    [accounts.genesis.address]: {
-      publicKey: accounts.genesis.publicKey,
-      username: 'test',
+    test: {
+      ...accounts.genesis,
     },
   };
 
   it('sets and gets the item', () => {
-    const activePeer = { options: { address: 'item' } };
-    updateDelegateCache(item, activePeer);
-    expect(loadDelegateCache(activePeer)).to.eql(itemExpected);
+    updateDelegateCache(item, networks.mainnet.code);
+    expect(loadDelegateCache(networks.mainnet.code)).to.eql(itemExpected);
   });
 });

--- a/src/utils/delegates.test.js
+++ b/src/utils/delegates.test.js
@@ -11,7 +11,7 @@ describe('Delegates Utils', () => {
     window.localStorage.setItem = (key, item) => { storage[key] = item; };
   });
 
-  const item = [{ account: { ...accounts.genesis }, username: 'test' }];
+  const delegateItem = [{ account: { ...accounts.genesis }, username: 'test' }];
   const itemExpected = {
     test: {
       account: { ...accounts.genesis },
@@ -19,8 +19,18 @@ describe('Delegates Utils', () => {
     },
   };
 
-  it('sets and gets the item', () => {
-    updateDelegateCache(item, networks.mainnet.code);
-    expect(loadDelegateCache(networks.mainnet.code)).to.eql(itemExpected);
+  it('sets and gets the delegate item with mainnet', () => {
+    const activePeer = { options: networks.mainnet };
+    updateDelegateCache(delegateItem, activePeer);
+    expect(loadDelegateCache(activePeer)).to.eql(itemExpected);
+  });
+
+  it('sets and gets the delegate item with customNode', () => {
+    const activePeer = {
+      options: networks.customNode,
+      currentNode: 'http://localhost:4000',
+    };
+    updateDelegateCache(delegateItem, activePeer);
+    expect(loadDelegateCache(activePeer)).to.eql(itemExpected);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #1359

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Fixed localStorage cache for delegates

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Described here #1359
Go to https://jenkins.lisk.io/test/lisk-hub/PR-1451/#/delegates
Check if localStorage Cache was set then

Go to https://jenkins.lisk.io/test/lisk-hub/PR-1451//#/delegates?&votes=dakk,liskit,anamix,corsaro,splatters,redsn0w,gregorst,ondin,vekexasia,fulig,hirish

Check API requests and see if there is fewer requests than number of delegates.
Cache should save 100 first delegates so there is no need to make additional call fo them
### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
