### PR TITLE
Fix unstable passphrase test - Closes #1402

### DIFF
--- a/src/components/passphraseCreation/index.test.js
+++ b/src/components/passphraseCreation/index.test.js
@@ -55,7 +55,7 @@ describe('Passphrase Creation', () => {
       }
 
       wrapper.update();
-      expect(wrapper.find(CreateFirst)).to.have.prop('percentage').greaterThan(100);
+      expect(wrapper.find(CreateFirst)).to.have.prop('percentage').at.least(100);
       expect(wrapper.find(CreateFirst)).to.have.prop('hintTitle', 'by moving your mouse.');
       expect(wrapper.find(CreateFirst)).to.have.prop('address');
       expect(wrapper.find(CreateFirst)).to.have.prop('step', 'info');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #1402
The problem was that the passphrase generation process is by definition random and implementation was stopping on `percentage >= 100` but tests expected `percentage > 100`

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
I fixed the test to allow 100 percentage.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Run multiple times
`npm run test`

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
