### PR TITLE
Remove old assets from previous builds - Closes #1480

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,10 @@ pipeline {
 			agent { node { label 'master-01' } }
 			steps {
 					unstash 'build'
-					sh 'rsync -axl --delete $WORKSPACE/app/build/ /var/www/test/${JOB_NAME%/*}/$BRANCH_NAME/'
+					sh '''
+					rsync -axl --delete $WORKSPACE/app/build/ /var/www/test/${JOB_NAME%/*}/$BRANCH_NAME/
+					rm -rf $WORKSPACE/app/build
+					'''
 					githubNotify context: 'Jenkins test deployment',
 					             description: 'Commit was deployed to test',
 						     status: 'SUCCESS',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Deletes build directory in the workspace on Jenkins master
### What issue have I solved?
<!--- Complementary description if needed -->
-- #1480 

### How has this been tested?
Tested on Jenkins. While this version is slightly different from my test, this should get tested by virtue of making this PR when Jenkins runs this

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
