### PR TITLE
Update process file to support process.argv - Closes #1531

### DIFF
--- a/app/src/modules/process.js
+++ b/app/src/modules/process.js
@@ -1,4 +1,9 @@
 
+/* this file is ignored by coverage because it's just a simple wrapper
+  created to allow mocking `process` in unit tests.
+*/
+
+/* istanbul ignore file */
 export default {
   isPlatform: os => process.platform === os,
   getArgv: () => process.argv,

--- a/app/src/modules/process.js
+++ b/app/src/modules/process.js
@@ -1,4 +1,5 @@
 
 export default {
   isPlatform: os => process.platform === os,
+  getArgv: () => process.argv,
 };

--- a/app/src/modules/win.js
+++ b/app/src/modules/win.js
@@ -44,7 +44,7 @@ const win = {
     win.browser.on('focus', () => win.browser.webContents.send('focus'));
 
     if (!process.isPlatform('darwin')) {
-      win.send({ event: 'openUrl', value: process.argv[1] || '/' });
+      win.send({ event: 'openUrl', value: process.getArgv()[1] || '/' });
     }
 
     Menu.setApplicationMenu(menu.build(electron, checkForUpdates));

--- a/app/src/modules/win.test.js
+++ b/app/src/modules/win.test.js
@@ -45,7 +45,6 @@ describe('Electron Browser Window Wrapper', () => {
   let processMock;
 
   beforeEach(() => {
-    process.argv = [];
     processMock = mock(process);
   });
 
@@ -155,6 +154,7 @@ describe('Electron Browser Window Wrapper', () => {
     it('Creates the window with menu when platform is not "darwin"', () => {
       processMock.expects('isPlatform').atLeast(2).withArgs('darwin').returns(false);
       processMock.expects('isPlatform').atLeast(2).withArgs('linux').returns(true);
+      processMock.expects('getArgv').atLeast(2).withArgs().returns([]);
 
       expect(win.browser).to.equal(null);
       win.create({

--- a/jest.config.js
+++ b/jest.config.js
@@ -39,7 +39,6 @@ module.exports = {
     '/node_modules/',
     'app/src/ipc.js',
     'app/src/ledger.js',
-    'app/src/modules/process.js',
     'src/components/receive/index.js',
     'src/actions/liskService.js',
     'src/actions/peers.js', // FollowUp #1515

--- a/jest.config.js
+++ b/jest.config.js
@@ -39,6 +39,7 @@ module.exports = {
     '/node_modules/',
     'app/src/ipc.js',
     'app/src/ledger.js',
+    'app/src/modules/process.js',
     'src/components/receive/index.js',
     'src/actions/liskService.js',
     'src/actions/peers.js', // FollowUp #1515


### PR DESCRIPTION
### What issue have I solved?

-- #1531 

### How have I implemented/fixed it?

In the **process.j**s file under **app/src/modules** add a new function that returns the process.argv value and then in the **win.js** file this can be call as a function.

With this now the **win.test.js** file the mock that function and run properly.


### How has this been tested?



### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
