### PR TITLE
Remove duplicated words on help center text - Closes #1559

### DIFF
--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -276,7 +276,7 @@
   "Search": "Search",
   "Search for Lisk ID or Transaction ID": "Search for Lisk ID or Transaction ID",
   "Search for a delegate": "Search for a delegate",
-  "Search for answers in our extensive FAQ": "Search for answers in our extensive FAQ",
+  "Search for answers in our extensive ": "Search for answers in our extensive ",
   "Search for delegate, Lisk ID, transaction ID": "Search for delegate, Lisk ID, transaction ID",
   "Search for delegates, addresses and transactions.": "Search for delegates, addresses and transactions.",
   "Second passphrase (Fee: 5 LSK)": "Second passphrase (Fee: 5 LSK)",

--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -3,7 +3,7 @@
   " FAQ": " FAQ",
   " Make sure that you are using the latest version of Lisk Hub.": " Make sure that you are using the latest version of Lisk Hub.",
   " of": " of",
-  " or get in touch in via chat ": " or get in touch in via chat ",
+  " or get in touch in via ": " or get in touch in via ",
   "About": "About",
   "Academy": "Academy",
   "Access extra features": "Access extra features",

--- a/src/components/help/help.js
+++ b/src/components/help/help.js
@@ -43,7 +43,7 @@ class Help extends React.Component {
             </h2>
             <div className={styles.articleContainer}>
               <div>
-                <p>{this.props.t('Search for answers in our extensive FAQ')}
+                <p>{this.props.t('Search for answers in our extensive ')}
                   {fAQIcon()}
                   {this.props.t(' or get in touch in via chat ')}
                   {chatIcon()}.

--- a/src/components/help/help.js
+++ b/src/components/help/help.js
@@ -45,7 +45,7 @@ class Help extends React.Component {
               <div>
                 <p>{this.props.t('Search for answers in our extensive ')}
                   {fAQIcon()}
-                  {this.props.t(' or get in touch in via chat ')}
+                  {this.props.t(' or get in touch in via ')}
                   {chatIcon()}.
                 </p>
               </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #1559 

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Updated the json file of i18n with the strings to don't contain the duplicated word

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Checked on the help center page that the words weren't duplicated anymore.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
