### PR TITLE
Session reset button difficult to see - Closes #1567

### DIFF
--- a/src/components/header/customCountDown.css
+++ b/src/components/header/customCountDown.css
@@ -1,13 +1,12 @@
 @import '../app/variables.css';
 
 .reset {
-  margin-right: 18px;
+  margin-right: 15px;
   padding-left: 3px;
   padding-right: 3px;
   padding-bottom: 3px;
   cursor: pointer;
-  color: var(--color-white);
-  border-bottom: solid 2px var(--color-white);
+  color: var(--color-primary-standard);
   display: inline;
   font-family: 'Open Sans';
   font-weight: 600;

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -22,7 +22,7 @@ const mapDispatchToProps = {
   closeDialog: dialogHidden,
   logOut: accountLoggedOut,
   removePassphrase,
-  resetTimer: accountUpdated({ expireTime: Date.now() + lockDuration }),
+  resetTimer: () => accountUpdated({ expireTime: Date.now() + lockDuration }),
 };
 
 export default withRouter(connect(

--- a/src/components/votingListView/index.js
+++ b/src/components/votingListView/index.js
@@ -18,7 +18,7 @@ const mapDispatchToProps = {
   voteToggled,
   votesFetched,
   delegatesFetched,
-  delegatesCleared: delegatesAdded({
+  delegatesCleared: () => delegatesAdded({
     list: [], totalDelegates: 0, refresh: true,
   }),
 };


### PR DESCRIPTION
The reset button is display white when the time is almost gone, so this color should be different.
Base on the new design mockups this button should be blue.

### What issue have I solved?

-- #1567 

### How have I implemented/fixed it?

I just update the css file of the customCountDown component to display the reset button as the mock ups.

Now is easy to see when is enabled it.


### How has this been tested?

1. Log in to the app.
2. Go to settings and disable the auto-logout option
3. Wait for the time to be less than 5 minutes
4. The button should be enabled it and with blue color.


### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
