### PR TITLE
Send process inputs labels have wrong styles - Closes #1598 

### DIFF
--- a/src/components/bookmark/bookmark.css
+++ b/src/components/bookmark/bookmark.css
@@ -13,8 +13,6 @@
   & > div > div {
     & > label {
       font-size: 14px;
-      font-weight: 600;
-      color: var(--color-primary-standard);
     }
 
     & > input {

--- a/src/components/send/steps/form/form.css
+++ b/src/components/send/steps/form/form.css
@@ -20,11 +20,6 @@
       font-size: 16px;
       font-weight: 600;
     }
-
-    & > label {
-      font-size: 14px;
-      font-weight: 600px !important;
-    }
   }
 
   & input {
@@ -32,12 +27,6 @@
   }
 
   & > div:first-child {
-    & > label {
-      font-size: 14px;
-      font-weight: 600;
-      color: var(--color-primary-standard);
-    }
-
     & > input {
       font-size: 16px;
       font-weight: 600;
@@ -48,8 +37,6 @@
   & > div:nth-child(2) {
     & > label {
       font-size: 14px;
-      font-weight: 600;
-      color: var(--color-primary-standard);
     }
 
     & > input {
@@ -63,8 +50,6 @@
     & > div:first-child {
       & > label {
         font-size: 14px;
-        font-weight: 600;
-        color: var(--color-primary-standard);
       }
 
       & > input {


### PR DESCRIPTION
In the send components the input labels have a different design with the rest of form in the app.
So this PR is for change the the style of those inputs and match the rest of forms.

### What issue have I solved?

-- #1598

### How have I implemented/fixed it?

Update the form css file for the send component removing the label styles for those 3 inputs and then let the labels use the same default style as the rest of other inputs.


### How has this been tested?

1. Login to the app.
2. Go to wallet page.
3. do a click in the send button.
4. check the default style for the input labels
5. focus and unfocus the input to see the default style.


### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
