### PR TITLE
Fix Add to bookmarks label don't fitting on button - Closes #1605

### DIFF
--- a/src/components/sendTo/followAccount.css
+++ b/src/components/sendTo/followAccount.css
@@ -42,13 +42,9 @@
 
   & > footer {
     display: flex;
+    flex-direction: column;
     justify-content: space-evenly;
     margin-bottom: 8px;
-
-    & > button {
-      width: calc(100% / 2 - 20px) !important;
-      margin-top: 0 !important;
-    }
   }
 }
 

--- a/src/components/sendTo/followAccount.js
+++ b/src/components/sendTo/followAccount.js
@@ -41,10 +41,6 @@ class FollowAccount extends React.Component {
         onChange={this.handleChange.bind(this)}
       />
       <footer>
-        <Button onClick={() => prevStep()} className={`${styles.button} ${styles.follow} cancel`} >
-          <span className={styles.label}>{t('Cancel')}</span>
-        </Button>
-
         <TertiaryButton className={`${styles.button} follow-account-button`}
           disabled={!this.state.title.value || !!this.state.title.error}
           onClick={() => {
@@ -64,6 +60,10 @@ class FollowAccount extends React.Component {
           }}>
           {t('Add to bookmarks')}
         </TertiaryButton>
+
+        <Button onClick={() => prevStep()} className={`${styles.button} ${styles.follow} cancel`} >
+          <span className={styles.label}>{t('Cancel')}</span>
+        </Button>
       </footer>
     </Box>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #1605

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Since the text was changed from `follow` to `Add to bookmarks`, it had problems with smaller resolutions, so I have used the same standard that we have in other pages and stacking the buttons, and keeping the main action above the cancel button.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Checked on the page described that the error wasn't happening anymore.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
