### PR TITLE
Fix Auto-logout timer number format - Closes #1608

### DIFF
--- a/src/components/header/customCountDown.js
+++ b/src/components/header/customCountDown.js
@@ -58,8 +58,8 @@ class CustomCountDown extends React.Component {
     const {
       minutes, autoLog, seconds, resetTimer, t,
     } = this.props;
-    const min = minutes < 10 ? `0${minutes}` : minutes;
-    const sec = seconds < 10 ? `0${seconds}` : seconds;
+    const min = `0${minutes}`.slice(-2);
+    const sec = `0${seconds}`.slice(-2);
 
     const resetCondition = (minutes < 5);
     const timeoutCondition = (minutes === 0 && seconds === 0);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #1608 

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Changed how we handled the verification to include or not the leading 0 on numbers. Now we always add the leading 0, and only get the last two digits.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Checked that all tests pass, and that the UI is correct now.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
