### PR TITLE
Create a function that check if the port use for electron is being in use - Closes #1611

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -1,3 +1,5 @@
+// const findAvailablePort = require('./src/modules/portAssign');
+
 const server = {
   // eslint-disable-next-line max-statements
   init: () => {
@@ -6,7 +8,7 @@ const server = {
     const bodyParser = require('body-parser');
 
     const app = express();
-    const port = process.env.PORT || 8080;
+    const port = process.env.PORT || 8081;
 
     app.use(bodyParser.json());
     app.use(bodyParser.urlencoded({ extended: true }));

--- a/app/src/modules/portAssign.js
+++ b/app/src/modules/portAssign.js
@@ -1,0 +1,14 @@
+const fp = require('find-free-port');
+
+const getPort = fp(3000)
+  .then(([freep]) => freep)
+  .catch((err) => {
+    throw err;
+  });
+
+async function findAvailablePort() {
+  const port = await getPort();
+  return port;
+}
+
+module.exports = findAvailablePort;

--- a/jest.config.js
+++ b/jest.config.js
@@ -39,6 +39,7 @@ module.exports = {
     '/node_modules/',
     'app/src/ipc.js',
     'app/src/ledger.js',
+    'app/src/modules/portAssign.js',
     'src/actions/liskService.js',
     'src/actions/transactions.js',
     'src/components/account/stories.js',
@@ -55,12 +56,12 @@ module.exports = {
     'src/components/passphrase/create/create.js',
     'src/components/passphraseCreation/index.js',
     'src/components/passphraseSteps/index.js', // FollowUp #1515
-    'src/components/register/register.js',
-    'src/components/request/specifyRequest.js',
     'src/components/receive/index.js',
-    'src/components/request/index.js',
+    'src/components/register/register.js',
     'src/components/register/register.js',
     'src/components/request/index.js',
+    'src/components/request/index.js',
+    'src/components/request/specifyRequest.js',
     'src/components/resultBox/index.js',
     'src/components/searchBar/index.js', // Passing in mocha but not in Jest
     'src/components/send/steps/form/stories.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10425,6 +10425,11 @@
         "pkg-dir": "^3.0.0"
       }
     },
+    "find-free-port": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-free-port/-/find-free-port-2.0.0.tgz",
+      "integrity": "sha1-SyLl9leesaOMQaxryz7+0bbamxs="
+    },
     "find-index": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "dpos-ledger-api": "1.1.0",
     "electron-localshortcut": "3.1.0",
     "express": "4.16.4",
+    "find-free-port": "2.0.0",
     "flexboxgrid": "=6.3.1",
     "hard-source-webpack-plugin": "0.13.1",
     "history": "=4.7.2",


### PR DESCRIPTION
This PR is to address the static port set on express application that runs in electron.
So to avoid that electron can show the absolute file path, what we are trying to do is run the app in express and then pass the URL to electron to be able to open the project from express.

So the request is to create a function/module that provide a specific port for run the express server however if this port is being used then the app can reassign the port to any that is available.
At this point there is one file called **portAssign.js** under **app/src/modules**, is using promises to address this request, however at the time to start the app by electron this fails.

This PR will be open and we need to rethink in a different way to address this problem.

<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
-- #1611 

### How have I implemented/fixed it?


### How has this been tested?


### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
