### PR TITLE
Fix Ledger login on Windows

### DIFF
--- a/app/src/ledger.js
+++ b/app/src/ledger.js
@@ -49,7 +49,7 @@ const ledgerObserver = {
   next: async ({ device, type }) => {
     if (device) {
       if (type === 'add') {
-        if (process.platform === 'darwin' || await isInsideLedgerApp(device.path)) {
+        if (process.platform !== 'linux' || await isInsideLedgerApp(device.path)) {
           ledgerPath = device.path;
           win.send({ event: 'ledgerConnected', value: null });
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#1449 

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Enabled sending the "connected" event on windows to fix the second point in
https://github.com/LiskHQ/lisk-hub/pull/1522#issuecomment-449396169
The last point from that comment was already fixed in https://github.com/LiskHQ/lisk-hub/pull/1655

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Try on Windows:
- connect/disconnect hw wallet while on login page and while app closed
- to login to a Ledger account.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
