### PR TITLE
Make liskCoreUrl work as default network on start - Closes #1623

### DIFF
--- a/src/store/middlewares/peers.js
+++ b/src/store/middlewares/peers.js
@@ -1,7 +1,6 @@
 import { liskAPIClientSet, liskAPIClientUpdate } from '../../actions/peers';
 import actionTypes from '../../constants/actions';
 import networks from './../../constants/networks';
-import getNetwork from './../../utils/getNetwork';
 import { shouldAutoLogIn, getAutoLogInData, findMatchingLoginNetwork } from './../../utils/login';
 
 const peersMiddleware = store => next => (action) => {
@@ -16,11 +15,11 @@ const peersMiddleware = store => next => (action) => {
   // else default network
   if (loginNetwork) {
     loginNetwork = loginNetwork.slice(-1).shift();
-  } else if (!loginNetwork) {
-    loginNetwork = liskCoreUrl ? networks.customNode : networks.default;
+  } else if (!loginNetwork && liskCoreUrl) {
+    loginNetwork = { ...networks.customNode, address: liskCoreUrl };
+  } else if (!loginNetwork && !liskCoreUrl) {
+    loginNetwork = networks.default;
   }
-
-  const network = Object.assign({}, getNetwork(loginNetwork.code));
 
   switch (action.type) {
     case actionTypes.storeCreated:
@@ -29,7 +28,7 @@ const peersMiddleware = store => next => (action) => {
       // https://github.com/LiskHQ/lisk-hub/issues/1339
       /* istanbul ignore else */
       if (!shouldAutoLogIn(autologinData)) {
-        store.dispatch(liskAPIClientSet({ network }));
+        store.dispatch(liskAPIClientSet({ network: loginNetwork }));
       }
       store.dispatch(liskAPIClientUpdate({ online: true }));
       break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#1623 

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Include liskCoreUrl in the condition in peers middleware

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Try to login and reboot to mainnet, testnet, custom node other than localhost:4000

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
