### PR TITLE
Removed clean-build and copy-files from ESLint step - Closes #1685

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,11 +23,7 @@ pipeline {
 					"ESLint": {
 						ansiColor('xterm') {
 							nvm(getNodejsVersion()) {
-								sh '''
-								npm run --silent clean-build
-								npm run --silent copy-files
-								npm run --silent eslint
-								'''
+								sh 'npm run --silent eslint'
 							}
 						}
 					},


### PR DESCRIPTION
This PR removes the `clean-build` and `copy-files` commands from ESLint step in Jenkinsfile, as they were reduntand with the build step. This avoid the situation descibed on #1685. 