### PR TITLE
Make load delegates event trigger every time - Closes #1614

### DIFF
--- a/src/components/votingListView/votingListView.js
+++ b/src/components/votingListView/votingListView.js
@@ -44,11 +44,9 @@ class VotingListView extends React.Component {
     }
 
     if (this.props.delegates.length < nextProps.delegates.length) {
-      setTimeout(() => {
-        this.freezeLoading = false;
-        this.offset = nextProps.delegates.length;
-        this.isInitial = false;
-      }, 5);
+      this.freezeLoading = false;
+      this.offset = nextProps.delegates.length;
+      this.isInitial = false;
     }
   }
 

--- a/test/cypress/e2e/delegates.spec.js
+++ b/test/cypress/e2e/delegates.spec.js
@@ -65,10 +65,9 @@ describe('Delegates', () => {
   it('Displays 100 delegates and loads more as I scroll to bottom', () => {
     cy.autologin(accounts.genesis.passphrase, networks.testnet.node);
     cy.visit(urls.delegates);
-    cy.get(ss.delegateRow).should('have.length', 100);
-    // TODO Unskip after 1614 fix
-    // cy.get(ss.delegateList).scrollTo('bottom');
-    // cy.get(ss.delegateRow).should('have.length', 200);
+    cy.get(ss.delegateName);
+    cy.get(ss.delegateList).scrollTo('bottom');
+    cy.get(ss.delegateRow).should('have.length', 200);
   });
 
   /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#1614

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
The race condition is the result of 5 ms delay made after fetching delegates and preceding unfreezing next possible loading.
The solution is to remove the delay as unforeseeable behavior

### How has this been tested?
<!--- Please describe how you tested your changes. -->
It works just the same, the number of requests for /api/delegates is the same

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
