### PR TITLE
Dont show user data before fetched - Closes #1693

### DIFF
--- a/src/components/topBar/topBar.js
+++ b/src/components/topBar/topBar.js
@@ -81,6 +81,8 @@ class TopBar extends React.Component {
 
     const isUserLogout = Object.keys(account).length === 0 || account.afterLogout;
 
+    const isUserDataFetched = (account.balance) || account.balance === 0;
+
     return (
       <div className={styles.wrapper}>
         <div className={styles.elements}>
@@ -94,7 +96,7 @@ class TopBar extends React.Component {
           <SearchBar />
 
           {
-            !isUserLogout ?
+            isUserDataFetched ?
               <UserAccount
                 account={this.props.account}
                 isDropdownEnable={this.state.isDropdownEnable}

--- a/src/components/topBar/userAccount.css
+++ b/src/components/topBar/userAccount.css
@@ -21,6 +21,7 @@
   font-size: 12px;
   font-weight: var(--font-weight-semi-bold);
   color: var(--color-dark-gray);
+  white-space: nowrap;
 }
 
 .balance {

--- a/test/cypress/e2e/bookmarks.spec.js
+++ b/test/cypress/e2e/bookmarks.spec.js
@@ -86,7 +86,6 @@ describe('Bookmarks', () => {
       ]`);
       cy.autologin(accounts.genesis.passphrase, networks.devnet.node);
       cy.visit(urls.dashboard);
-      cy.wait(500); // To let app fetch and update the actual balance
       cy.get(ss.followedAccountBalance).invoke('text').as('balanceBefore');
       cy.visit(urls.send);
       cy.get(ss.recipientInput).type(accounts.genesis.address);

--- a/test/cypress/e2e/bookmarks.spec.js
+++ b/test/cypress/e2e/bookmarks.spec.js
@@ -86,6 +86,7 @@ describe('Bookmarks', () => {
       ]`);
       cy.autologin(accounts.genesis.passphrase, networks.devnet.node);
       cy.visit(urls.dashboard);
+      cy.wait(1000); // To let app fetch and update the actual balance
       cy.get(ss.followedAccountBalance).invoke('text').as('balanceBefore');
       cy.visit(urls.send);
       cy.get(ss.recipientInput).type(accounts.genesis.address);

--- a/test/cypress/e2e/delegateReg.spec.js
+++ b/test/cypress/e2e/delegateReg.spec.js
@@ -39,7 +39,6 @@ describe('Delegate Registration', () => {
     cy.autologin(accounts['delegate candidate'].passphrase, networks.devnet.node);
     cy.visit(urls.registerDelegate);
     // Memorize the balance before test
-    cy.wait(500);
     cy.get(ss.headerBalance).invoke('text').as('balanceBefore');
     // Choose delegate name
     cy.get(ss.chooseDelegateName).click();

--- a/test/cypress/e2e/secondPassphraseReg.spec.js
+++ b/test/cypress/e2e/secondPassphraseReg.spec.js
@@ -33,7 +33,6 @@ describe('Second Passphrase Registration', () => {
   it('Setup second passphrase + Header balance is affected', function () {
     cy.autologin(accounts['second passphrase candidate'].passphrase, networks.devnet.node);
     cy.visit(urls.secondPassphrase);
-    cy.wait(500);
     cy.get(ss.headerBalance).invoke('text').as('balanceBefore');
     cy.get(ss.nextBtn).click();
     moveMouseRandomly();

--- a/test/cypress/e2e/send.spec.js
+++ b/test/cypress/e2e/send.spec.js
@@ -56,7 +56,6 @@ describe('Send', () => {
     'Header balance is affected', () => {
     cy.autologin(accounts.genesis.passphrase, networks.devnet.node);
     cy.visit(urls.send);
-    cy.wait(500);
     cy.get(ss.headerBalance).invoke('text').as('balanceBefore');
     cy.get(ss.recipientInput).type(randomAddress);
     cy.get(ss.amountInput).click().type(randomAmount);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#1693

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Add a condition to check if the data is already there, then to show whole userAccount component.
Otherwise, nothing to show cause there is no meaningful data yet.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Login. Logout. Login with 0 balance.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
