### PR TITLE
Enable autoupdater on Linux

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,6 +43,7 @@ pipeline {
 						archiveArtifacts artifacts: 'app/build/'
 						archiveArtifacts artifacts: 'app/build-testnet/'
 						archiveArtifacts allowEmptyArchive: true, artifacts: 'dist/lisk-hub*'
+						archiveArtifacts allowEmptyArchive: true, artifacts: 'dist/latest-linux.yml'
 						stash includes: 'app/build/', name: 'build'
 					}
 				)

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lisk-hub",
-  "version": "1.10.0",
+  "version": "1.1.0-beta.1",
   "description": "Lisk Hub",
   "main": "./build/main.js",
   "author": {

--- a/app/src/menu.js
+++ b/app/src/menu.js
@@ -34,19 +34,9 @@ const addAboutMenuForNonMac = ({ template, electron }) => {
   });
 };
 
-const addCheckForUpdates = ({ template, checkForUpdates }) => {
-  template[template.length - 1].submenu.push({
-    label: i18n.t('Check for updates...'),
-    click: checkForUpdates,
-  });
-};
-
 const menu = {
   build: (electron, checkForUpdates) => {
-    const template = menu.buildTemplate(electron);
-    if (!process.isPlatform('linux')) {
-      addCheckForUpdates({ template, checkForUpdates });
-    }
+    const template = menu.buildTemplate(electron, checkForUpdates);
     if (process.isPlatform('darwin')) {
       addAboutMenuForMac({ template, name: electron.app.getName() });
     } else {
@@ -57,7 +47,7 @@ const menu = {
   onClickLink: (electron, url) => {
     electron.shell.openExternal(url);
   },
-  buildTemplate: electron =>
+  buildTemplate: (electron, checkForUpdates) =>
     ([
       {
         label: i18n.t('Edit'),
@@ -142,6 +132,10 @@ const menu = {
           {
             label: i18n.t('What\'s New...'),
             click: menu.onClickLink.bind(null, electron, 'https://github.com/LiskHQ/lisk-hub/releases'),
+          },
+          {
+            label: i18n.t('Check for updates...'),
+            click: checkForUpdates,
           },
         ],
       },

--- a/app/src/modules/autoUpdater.js
+++ b/app/src/modules/autoUpdater.js
@@ -2,19 +2,17 @@ import i18n from './../i18n';
 import updateModal from './updateModal';
 
 export default ({ // eslint-disable-line max-statements
-  autoUpdater, dialog, win, process, electron,
+  autoUpdater, dialog, win, electron,
 }) => {
   const updater = {
     menuItem: { enabled: true },
   };
   autoUpdater.autoDownload = false;
 
-  if (process.platform !== 'linux') {
+  autoUpdater.checkForUpdates();
+  setInterval(() => {
     autoUpdater.checkForUpdates();
-    setInterval(() => {
-      autoUpdater.checkForUpdates();
-    }, 24 * 60 * 60 * 1000);
-  }
+  }, 24 * 60 * 60 * 1000);
 
   autoUpdater.on('error', (error) => {
     // eslint-disable-next-line no-console

--- a/app/src/modules/autoUpdater.test.js
+++ b/app/src/modules/autoUpdater.test.js
@@ -50,9 +50,6 @@ describe('autoUpdater', () => {
   beforeEach(() => {
     callbacks = {};
     params = {
-      process: {
-        platform: 'darwin',
-      },
       autoUpdater: {
         checkForUpdates: spy(),
         on: (name, callback) => {
@@ -88,18 +85,13 @@ describe('autoUpdater', () => {
     expect(params.autoUpdater.checkForUpdates).to.have.been.calledWithExactly();
   });
 
-  it('should check for updates every 24 hours if platform is not linux', () => {
+  it('should check for updates every 24 hours', () => {
     autoUpdater(params);
     expect(params.autoUpdater.checkForUpdates).to.have.callCount(1);
     clock.tick(24 * 60 * 60 * 1000);
     expect(params.autoUpdater.checkForUpdates).to.have.callCount(2);
     clock.tick(24 * 60 * 60 * 1000);
     expect(params.autoUpdater.checkForUpdates).to.have.callCount(3);
-
-    params.autoUpdater.checkForUpdates.reset();
-    params.process.platform = 'linux';
-    autoUpdater(params);
-    expect(params.autoUpdater.checkForUpdates).to.have.callCount(0);
   });
 
   it('should show error box when there was an error', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lisk-hub",
-  "version": "1.10.0",
+  "version": "1.1.0-beta.1",
   "description": "Lisk Hub",
   "homepage": "https://github.com/LiskHQ/lisk-hub",
   "bugs": "https://github.com/LiskHQ/lisk-hub/issues",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
The auto-updater that works on MacOs and Windows was not enabled for Linux, because back when it was first introduced into the project, Linux was not yet supported.

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
I removed conditions for "linux" when checking for a new version automatically or from menu item.

I also updated Jenkinsfile to archive `latest-linux.yml` build artifact which is needed similarly to `latest-mac.yml` for MacOs and `latest.yml` for Windows.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
I added an additional commit for testing purposes https://github.com/LiskHQ/lisk-hub/commit/913bd27352e81d6ea2aa179dcb597978fb2cfb98 that decreases version number so that the auto-updater triggers. Without this commit, there is no new version to update to.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
