### PR TITLE
Fix delay before loading TXs to latest activity - Closes #1721

### DIFF
--- a/src/components/hwWallet/hwWallet.js
+++ b/src/components/hwWallet/hwWallet.js
@@ -69,6 +69,7 @@ class HwWallet extends React.Component {
       return (
         <Box>
           <LedgerLogin
+            account={this.props.account}
             loginType={loginType.normal}
             network={getNetwork(this.props.network)}
             cancelLedgerLogin={this.cancelLedgerLogin.bind(this)} />

--- a/src/components/hwWallet/index.js
+++ b/src/components/hwWallet/index.js
@@ -10,6 +10,7 @@ import HwWallet from './hwWallet';
 const mapStateToProps = state => ({
   network: state.settings.network || networks.mainnet.code,
   peers: state.peers,
+  account: state.account,
 });
 
 const mapDispatchToProps = {

--- a/src/components/hwWallet/ledgerLogin.js
+++ b/src/components/hwWallet/ledgerLogin.js
@@ -39,7 +39,7 @@ class LedgerLogin extends React.Component {
 
   componentDidUpdate() {
     if (this.props.account && this.props.account.address) {
-      this.props.history.replace(routes.dashboard.path);
+      this.props.history.push(`${routes.dashboard.path}`);
     }
   }
 
@@ -54,8 +54,6 @@ class LedgerLogin extends React.Component {
         derivationIndex: index,
       },
     });
-
-    this.props.history.push(`${routes.dashboard.path}`);
   }
 
   async addAccount() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#1721

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Go to dashboard only after the account was fetched. It allows fetching transactions in dashboard compnent

### How has this been tested?
<!--- Please describe how you tested your changes. -->


### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
