### PR TITLE
Reenable actions/transactions tests - Close #1750

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,6 @@ module.exports = {
   ],
   testPathIgnorePatterns: [
     '<rootDir>/test/integration/wallet.test.js',
-    'src/actions/transactions.test.js',
     'src/components/dashboard/currencyGraph.test.js', // This should be unskipped in issue #1499
     'src/components/errorBoundary/index.test.js',
     'src/components/feedbackForm/*.test.js',

--- a/src/actions/transactions.test.js
+++ b/src/actions/transactions.test.js
@@ -93,7 +93,9 @@ describe('actions: transactions', () => {
     getState = () => ({
       peers: {
         liskAPIClient: {
+          current: 0,
           options: {
+            code: 0,
             name: networks.mainnet.name,
           },
         },
@@ -116,6 +118,9 @@ describe('actions: transactions', () => {
       dispatch = sinon.spy();
       getState = () => ({
         peers: {
+          options: {
+            code: 0,
+          },
           liskAPIClient: {
             options: {
               name: 'Mainnet',
@@ -133,18 +138,18 @@ describe('actions: transactions', () => {
     it('should create an action function', () => {
       expect(typeof actionFunction).to.be.deep.equal('function');
     });
-    // TODO: enable this when voting functionalities is fixed
-    it.skip('should dispatch one transactionAddDelegateName action when transaction contains one vote added', () => {
-      const delegateResponse = { delegate: { username: 'peterpan' } };
+
+    it('should dispatch one transactionAddDelegateName action when transaction contains one vote added', () => {
+      const delegateResponse = { username: 'peterpan' };
       const transactionResponse = {
         asset: {
           votes: [`+${accounts.delegate.publicKey}`],
         },
       };
       transactionApiMock.returnsPromise().resolves({ data: [transactionResponse] });
-      delegateApiMock.returnsPromise().resolves({ data: delegateResponse });
+      delegateApiMock.returnsPromise().resolves({ data: [delegateResponse] });
       const expectedActionPayload = {
-        ...delegateResponse,
+        delegate: delegateResponse,
         voteArrayName: 'added',
       };
 
@@ -154,14 +159,18 @@ describe('actions: transactions', () => {
       expect(dispatch).to.have.been
         .calledWith({ data: expectedActionPayload, type: actionTypes.transactionAddDelegateName });
     });
-    // TODO: enable this when voting functionalities is fixed
-    it.skip('should dispatch one transactionAddDelegateName action when transaction contains one vote deleted', () => {
-      const delegateResponse = { delegate: { username: 'peterpan' } };
-      const transactionResponse = { transaction: { votes: { deleted: [accounts.delegate.publicKey] }, count: '0' } };
-      transactionApiMock.returnsPromise().resolves(transactionResponse);
-      delegateApiMock.returnsPromise().resolves(delegateResponse);
+
+    it('should dispatch one transactionAddDelegateName action when transaction contains one vote deleted', () => {
+      const delegateResponse = { username: 'peterpan' };
+      const transactionResponse = {
+        asset: {
+          votes: [`-${accounts.delegate.publicKey}`],
+        },
+      };
+      transactionApiMock.returnsPromise().resolves({ data: [transactionResponse] });
+      delegateApiMock.returnsPromise().resolves({ data: [delegateResponse] });
       const expectedActionPayload = {
-        ...delegateResponse,
+        delegate: delegateResponse,
         voteArrayName: 'deleted',
       };
 
@@ -217,6 +226,8 @@ describe('actions: transactions', () => {
         recipientId: data.recipientId,
         amount: toRawLsk(data.amount),
         fee: Fees.send,
+        asset: { data: undefined },
+        type: 0,
       };
 
       await actionFunction(dispatch, getState);

--- a/src/actions/transactions.test.js
+++ b/src/actions/transactions.test.js
@@ -93,9 +93,7 @@ describe('actions: transactions', () => {
     getState = () => ({
       peers: {
         liskAPIClient: {
-          current: 0,
           options: {
-            code: 0,
             name: networks.mainnet.name,
           },
         },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#1750 

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Removed path from the `testPathIgnorePatterns` of `jest.config.js`.
And adjusted were needed, because of the apis now returning a different format as was expected, and also added some options that were needed on the `state.peers`.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Running tests should also run the tests for `actions/transactions` and don't break any.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
