### PR TITLE
Implement animation of pending transaction on wallet - Closes #1744

### DIFF
--- a/src/components/spinnerV2/spinnerV2.css
+++ b/src/components/spinnerV2/spinnerV2.css
@@ -2,7 +2,29 @@
 
 @keyframes rotate {
   0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+  100% { transform: rotate(-360deg); }
+}
+
+@keyframes checkmark {
+  0% {
+    height: 0;
+    width: 0;
+  }
+
+  20% {
+    height: 50%;
+    width: 0;
+  }
+
+  40% {
+    height: 50%;
+    width: 100%;
+  }
+
+  100% {
+    height: 50%;
+    width: 100%;
+  }
 }
 
 .wrapper {
@@ -21,16 +43,43 @@
 }
 
 .spinner {
-  animation-name: rotate;
-  animation-duration: var(--animation-speed-standard);
-  animation-iteration-count: infinite;
-  animation-timing-function: linear;
-  border: 2px solid currentColor;
-  border-bottom-color: transparent;
-  border-radius: 50%;
   box-sizing: border-box;
   color: inherit;
   display: block;
   height: 14px;
   width: 14px;
+
+  &::after {
+    animation-name: rotate;
+    animation-duration: var(--animation-speed-standard);
+    animation-iteration-count: infinite;
+    animation-timing-function: linear;
+    border: 2px solid currentColor;
+    border-bottom-color: transparent;
+    border-radius: 50%;
+    box-sizing: border-box;
+    content: '';
+    display: block;
+    height: 100%;
+    width: 100%;
+  }
+
+  &.completed {
+    position: relative;
+    transform: rotate(-45deg);
+
+    &::after {
+      animation-name: checkmark;
+      animation-duration: var(--animation-speed-slow);
+      animation-fill-mode: forwards;
+      animation-iteration-count: 1;
+      animation-timing-function: linear;
+      border: 0 solid transparent;
+      border-bottom: 2px solid currentColor;
+      border-left: 2px solid currentColor;
+      border-radius: 0;
+      height: 50%;
+      width: 100%;
+    }
+  }
 }

--- a/src/components/spinnerV2/spinnerV2.js
+++ b/src/components/spinnerV2/spinnerV2.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import styles from './spinnerV2.css';
 
-const SpinnerV2 = ({ label, className = '' }) => (
+const SpinnerV2 = ({ label, className = '', completed = false }) => (
   <span className={`${styles.wrapper} ${className}`}>
-    <span className={`${styles.spinner} spinner`}/>
+    <span className={`${styles.spinner} ${completed ? styles.completed : ''} spinner`}/>
     {label
       ? <span className={`${styles.label} spinner-label`}>{label}</span>
       : null

--- a/src/components/spinnerV2/spinnerV2.test.js
+++ b/src/components/spinnerV2/spinnerV2.test.js
@@ -8,6 +8,12 @@ describe('Spinner V2', () => {
     const wrapper = mount(<SpinnerV2 className={'test'} />);
     expect(wrapper).to.have.className('test');
     expect(wrapper).to.have.descendants('.spinner');
+    expect(wrapper).to.not.have.descendants('.completed');
+  });
+
+  it('should render with completed state', () => {
+    const wrapper = mount(<SpinnerV2 completed={true} />);
+    expect(wrapper).to.have.exactly(1).descendants('.completed');
   });
 
   it('should render the spinner with given label', () => {

--- a/src/components/transactionsV2/transactionRowV2.css
+++ b/src/components/transactionsV2/transactionRowV2.css
@@ -1,5 +1,40 @@
 @import '../app/variablesV2.css';
 
+@keyframes appear {
+  0% {
+    height: 0;
+    opacity: 0;
+  }
+
+  40% {
+    height: 85px;
+    opacity: 0;
+  }
+  70% { height: 80px; }
+
+  100% {
+    height: 80px;
+    opacity: 1;
+  }
+}
+
+@keyframes showIcons {
+  0% {
+    opacity: 0;
+    transform: scale(1.6);
+  }
+
+  70% {
+    opacity: 1;
+    transform: scale(0.8);
+  }
+
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
 .row {
   align-items: center;
   cursor: pointer;
@@ -24,6 +59,25 @@
       text-align: right;
     }
   }
+
+  &.pending {
+    animation-delay: var(--animation-speed-slowest);
+    animation-duration: var(--animation-speed-slow);
+    animation-fill-mode: both;
+    animation-iteration-count: 1;
+    animation-name: appear;
+    animation-timing-function: linear;
+
+    & :global(.tx-avatar),
+    & :global(.tx-icon) {
+      animation-delay: calc(var(--animation-speed-slowest) + calc(var(--animation-speed-slow) / 1.5));
+      animation-duration: var(--animation-speed-standard);
+      animation-fill-mode: both;
+      animation-iteration-count: 1;
+      animation-name: showIcons;
+      animation-timing-function: linear;
+    }
+  }
 }
 
 .header {
@@ -36,6 +90,30 @@
     letter-spacing: 0.2px;
     line-height: 1;
     padding: 14px 16px;
+  }
+}
+
+.status {
+  display: flex;
+  height: 16px;
+  position: relative;
+
+  & > span {
+    opacity: 0;
+    position: absolute;
+    transition: opacity var(--animation-speed-standard);
+  }
+
+  &.showSpinner {
+    & > span:first-child {
+      opacity: 1;
+    }
+  }
+
+  &.showTime {
+    & > span:last-child {
+      opacity: 1;
+    }
   }
 }
 

--- a/src/components/transactionsV2/transactionRowV2.css
+++ b/src/components/transactionsV2/transactionRowV2.css
@@ -95,24 +95,30 @@
 
 .status {
   display: flex;
-  height: 16px;
   position: relative;
 
   & > span {
     opacity: 0;
-    position: absolute;
-    transition: opacity var(--animation-speed-standard);
+    visibility: hidden;
+    transition: opacity var(--animation-speed-fast) linear, visibility var(--animation-speed-fast) linear;
+
+    &:last-child {
+      transition-delay: var(--animation-delay-standard);
+      position: absolute;
+    }
   }
 
   &.showSpinner {
     & > span:first-child {
       opacity: 1;
+      visibility: visible;
     }
   }
 
-  &.showTime {
+  &.showDate {
     & > span:last-child {
       opacity: 1;
+      visibility: visible;
     }
   }
 }

--- a/src/components/transactionsV2/transactionRowV2.js
+++ b/src/components/transactionsV2/transactionRowV2.js
@@ -14,29 +14,32 @@ class TransactionRowV2 extends React.Component {
     super();
 
     this.state = {
-      isUnconfirmed: true,
+      isConfirmed: false,
     };
 
-    this.setUnconfirmed = this.setUnconfirmed.bind(this);
+    this.setIsConfirmed = this.setIsConfirmed.bind(this);
   }
 
-  shouldComponentUpdate(nextProps) {
-    if (this.state.isUnconfirmed && nextProps.value.confirmations) {
+  shouldComponentUpdate(nextProps, nextState) {
+    if (!this.state.isConfirmed && nextProps.value.confirmations) {
       clearTimeout(this.timeout);
-      this.timeout = setTimeout(this.setUnconfirmed, 2000);
+      this.timeout = setTimeout(this.setIsConfirmed, 2000);
     }
-    return nextProps.value.id !== this.props.value.id || nextProps.value.confirmations <= 1000;
+
+    return (!this.state.isConfirmed && nextState.isConfirmed)
+      || nextProps.value.id !== this.props.value.id
+      || nextProps.value.confirmations <= 1000;
   }
 
   componentDidMount() {
     if (this.props.value.confirmations && this.props.value.confirmations > 0) {
-      this.setUnconfirmed();
+      this.setIsConfirmed();
     }
   }
 
-  setUnconfirmed() {
+  setIsConfirmed() {
     this.setState({
-      isUnconfirmed: false,
+      isConfirmed: true,
     });
   }
 
@@ -48,7 +51,7 @@ class TransactionRowV2 extends React.Component {
     const { props } = this;
     const onClick = props.onClick || (() => {});
     const hasConfirmations = props.value.confirmations && props.value.confirmations > 0;
-    const { isUnconfirmed } = this.state;
+    const { isConfirmed } = this.state;
     return (
       <div className={`${grid.row} ${styles.row} ${!hasConfirmations ? styles.pending : ''} transactions-row`} onClick={() => onClick(props)}>
         <div className={`${grid['col-xs-6']} ${grid['col-sm-4']} ${grid['col-lg-3']} transactions-cell`}>
@@ -62,7 +65,7 @@ class TransactionRowV2 extends React.Component {
               transaction={props.value} />
           </div>
         <div className={`${styles.hiddenXs} ${grid['col-sm-2']} ${grid['col-lg-2']} transactions-cell`}>
-          <div className={`${styles.status} ${isUnconfirmed ? styles.showSpinner : styles.showDate}`}>
+          <div className={`${styles.status} ${!isConfirmed ? styles.showSpinner : styles.showDate}`}>
             <SpinnerV2 completed={hasConfirmations} label={props.t('Pending...')} />
             <DateTimeFromTimestamp time={props.value.timestamp} />
           </div>

--- a/src/components/transactionsV2/transactionRowV2.js
+++ b/src/components/transactionsV2/transactionRowV2.js
@@ -10,7 +10,6 @@ import LiskAmount from '../liskAmount';
 import { DateTimeFromTimestamp } from './../timestamp/index';
 
 class TransactionRowV2 extends React.Component {
-  // eslint-disable-next-line class-methods-use-this
   shouldComponentUpdate(nextProps) {
     return nextProps.value.id !== this.props.value.id || nextProps.value.confirmations <= 1000;
   }
@@ -18,8 +17,9 @@ class TransactionRowV2 extends React.Component {
   render() {
     const { props } = this;
     const onClick = props.onClick || (() => {});
+    const isPending = !props.value.confirmations;
     return (
-      <div className={`${grid.row} ${styles.row} transactions-row`} onClick={() => onClick(props)}>
+      <div className={`${grid.row} ${styles.row} ${isPending ? styles.pending : ''} transactions-row`} onClick={() => onClick(props)}>
         <div className={`${grid['col-xs-6']} ${grid['col-sm-4']} ${grid['col-lg-3']} transactions-cell`}>
           <TransactionTypeV2 {...props.value}
             followedAccounts={props.followedAccounts}
@@ -31,8 +31,10 @@ class TransactionRowV2 extends React.Component {
               transaction={props.value} />
           </div>
         <div className={`${styles.hiddenXs} ${grid['col-sm-2']} ${grid['col-lg-2']} transactions-cell`}>
-          {props.value.confirmations ? <DateTimeFromTimestamp time={props.value.timestamp} />
-            : <SpinnerV2 label={props.t('Pending...')} />}
+          <div className={`${styles.status}`}>
+            {isPending ? <SpinnerV2 label={props.t('Pending...')} />
+              : <DateTimeFromTimestamp time={props.value.timestamp} />}
+          </div>
         </div>
         <div className={`${styles.hiddenXs} ${grid['col-sm-1']} ${grid['col-lg-2']} transactions-cell`}>
           <LiskAmount val={props.value.fee}/> {props.t('LSK')}

--- a/src/components/transactionsV2/transactionTypeV2.js
+++ b/src/components/transactionsV2/transactionTypeV2.js
@@ -55,7 +55,7 @@ const TransactionTypeV2 = (props) => { // eslint-disable-line complexity
 
   return (
     <div className={`${styles.transactionType} transaction-address`}>
-      <img src={icon} className={styles.icon} />
+      <img src={icon} className={`${styles.icon} tx-icon`} />
       <div className={styles.info}>
       { type || props.showTransaction
         ? (
@@ -63,7 +63,7 @@ const TransactionTypeV2 = (props) => { // eslint-disable-line complexity
         ) : (
           <React.Fragment>
             <AccountVisual
-              className={styles.avatar}
+              className={`${styles.avatar} tx-avatar`}
               address={address}
               size={36} />
             <div className={styles.accountInfo}>

--- a/test/cypress/e2e/send.spec.js
+++ b/test/cypress/e2e/send.spec.js
@@ -64,11 +64,11 @@ describe('Send', () => {
     cy.get(ss.resultMessage).should('have.text', msg.transferTxSuccess);
     cy.get(ss.okayBtn).click();
     cy.get(ss.transactionRow).eq(0).as('tx');
-    cy.get('@tx').find('.spinner');
+    cy.get('@tx').find(ss.spinner).should('be.visible');
     cy.get('@tx').find(ss.transactionAddress).should('have.text', randomAddress);
     cy.get('@tx').find(ss.transactionAmount).should('have.text', randomAmount.toString());
     cy.wait(txConfirmationTimeout);
-    cy.get('@tx').find(ss.spinner).should('not.exist');
+    cy.get('@tx').find(ss.spinner).should('be.not.visible');
     cy.get(ss.headerBalance).invoke('text').as('balanceAfter').then(function () {
       compareBalances(this.balanceBefore, this.balanceAfter, randomAmount + transactionFee);
     });
@@ -95,11 +95,11 @@ describe('Send', () => {
     cy.get(ss.resultMessage).should('have.text', msg.transferTxSuccess);
     cy.visit(urls.dashboard);
     cy.get(ss.transactionRow).eq(0).as('tx');
-    cy.get('@tx').find(ss.spinner);
+    cy.get('@tx').find(ss.spinner).should('be.visible');
     cy.get('@tx').find(ss.transactionAddress).should('have.text', randomAddress);
     cy.get('@tx').find(ss.transactionAmount).should('have.text', randomAmount.toString());
     cy.wait(txConfirmationTimeout);
-    cy.get('@tx').find(ss.spinner).should('not.exist');
+    cy.get('@tx').find(ss.spinner).should('be.not.visible');
   });
 
   /**
@@ -121,7 +121,7 @@ describe('Send', () => {
     cy.get(ss.resultMessage).should('have.text', msg.transferTxSuccess);
     cy.get(ss.okayBtn).click();
     cy.get(ss.transactionRow).eq(0).as('tx');
-    cy.get('@tx').find('.spinner');
+    cy.get('@tx').find(ss.spinner).should('be.visible');
     cy.get('@tx').find(ss.transactionAddress).should('have.text', randomAddress);
   });
 

--- a/test/cypress/e2e/txDetails.spec.js
+++ b/test/cypress/e2e/txDetails.spec.js
@@ -22,7 +22,7 @@ describe('Tx details', () => {
     cy.get(ss.nextTransferBtn).click();
     cy.get(ss.sendBtn).click();
     cy.get(ss.okayBtn).click();
-    cy.get(ss.transactionRow).find(ss.spinner).click();
+    cy.get(ss.transactionRow).first().find(ss.spinner).click();
     // Before confirmation
     cy.get(ss.txHeader).contains('Transaction');
     cy.get(ss.txSenderAddress).should('have.text', accounts.genesis.address)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#1744 

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Added a completed props to the `SpinnerV2` component, that draws the checkmark.
Adjusted `transactionRowV2` component to show with an animation the transactions that are pending, and when they are confirmed, change the completed props to the `SpinnerV2`, and set a timeout to show the date and time.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Go to `/wallet` and send any transaction, and when you get back at the wallet, there should be an animation on the pending transaction, and after being confirmed, the spinner changes to a checkmark and after 2 seconds, changes to the date time.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
