### PR TITLE
Usage tracking doesn't work due to double slash in the url - Closes #1769

### DIFF
--- a/src/constants/piwik.js
+++ b/src/constants/piwik.js
@@ -1,6 +1,6 @@
 
 export default {
-  URL: 'https://matomo.lisk.io/',
+  URL: 'https://matomo.lisk.io',
   SITE_ID: 1,
   DELETE_CUSTOM_VARIABLE: 'deleteCustomVariable',
   ENABLE_HEART_BEAT_TIMER: 'enableHeartBeatTimer',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
-- #1769 

### How have I implemented/fixed it?
In the piwik constants file ('src/constants/piwik.js') I update the piwik URL from URL: **'https://matomo.lisk.io/'** to this URL: **'https://matomo.lisk.io'**

With this now the URL is properly formatted and then the track works fine.


### How has this been tested?

Run the app and enable the tracking in Settings page, after that start doing clicks and navigate on the application and in the browser development tools there is no error message under console any more.

Track should be working fine.


### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)