### PR TITLE
Update terms of use page, fix typo

### DIFF
--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -237,7 +237,7 @@
   "Lisk Hub": "Lisk Hub",
   "Lisk Hub {{newVersion}} is available. You have {{oldVersion}}. Would you like to download it now?": "Lisk Hub {{newVersion}} is available. You have {{oldVersion}}. Would you like to download it now?",
   "Lisk ID": "Lisk ID",
-  "Lisk Terms if Use": "Lisk Terms if Use",
+  "Lisk Terms of Use": "Lisk Terms of Use",
   "Lisk Website": "Lisk Website",
   "Lisk passphrase backup": "Lisk passphrase backup",
   "Lisk.Chat": "Lisk.Chat",

--- a/src/components/termsOfUse/termsOfUse.js
+++ b/src/components/termsOfUse/termsOfUse.js
@@ -44,7 +44,7 @@ class TermsOfUse extends React.Component {
           <img src={logo} />
         </header>
         <div className={styles.content}>
-          <h1>{this.props.t('Lisk Terms if Use')}</h1>
+          <h1>{this.props.t('Lisk Terms of Use')}</h1>
           <p>
             {this.props.t('Before you continue using Lisk Hub, please read and accept the')}
             <a


### PR DESCRIPTION
This PR is just for fix the typo in the terms of use page in the title, from **Terms if Use** to **Terms of Use**


### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
