### PR TITLE
okay button location is wrong - closes #1824

### DIFF
--- a/src/components/resultBox/resultBox.css
+++ b/src/components/resultBox/resultBox.css
@@ -23,10 +23,6 @@
   width: 100%;
   height: 100%;
 
-  & > div {
-    margin-bottom: 100px;
-  }
-
   & .header {
     position: relative;
   }
@@ -51,8 +47,6 @@
   & footer {
     padding: 0px;
     display: flex;
-    justify-content: space-between;
-    position: absolute;
     bottom: 58px;
 
     & > div > button {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #1824

### How have I implemented/fixed it?
Update the css style of the result box for properly align the buttons in the page.


### How has this been tested?
<!--- Please describe how you tested your changes. -->
Try to send some LSKs to any account and at the end the okay button should be properly align


### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
