### PR TITLE
Make it impossible to change delegate bookmark name - Closes #1859

### DIFF
--- a/src/components/followAccount/followAccount.js
+++ b/src/components/followAccount/followAccount.js
@@ -82,9 +82,16 @@ class FollowAccount extends React.Component {
   }
 
   handleFollow() {
-    const { address, balance, accounts } = this.props;
+    const {
+      address, balance, accounts, delegate,
+    } = this.props;
     const title = this.state.fields.accountName.value;
-    const account = { address, title, balance };
+    const account = {
+      address,
+      title,
+      balance,
+      isDelegate: !!(delegate && delegate.username),
+    };
     const followIndex = accounts.length;
     this.props.followedAccountAdded(account);
     this.setState({

--- a/src/components/followAccount/followAccount.test.js
+++ b/src/components/followAccount/followAccount.test.js
@@ -55,6 +55,7 @@ describe('Follow Account Component', () => {
         address: props.address,
         balance: props.balance,
         title: evt.target.value,
+        isDelegate: false,
       };
       wrapper.find('input[name="accountName"]').simulate('change', evt);
       expect(wrapper.find('.fieldInput')).toContainMatchingElement('SpinnerV2.show');

--- a/src/components/followedAccounts/addAccountID.js
+++ b/src/components/followedAccounts/addAccountID.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { translate } from 'react-i18next';
+import { searchAccount } from '../../actions/search';
 import { PrimaryButtonV2, SecondaryButtonV2 } from '../toolbox/buttons/button';
 import regex from '../../utils/regex';
 import styles from './followedAccounts.css';
@@ -44,6 +45,7 @@ class AddAccountID extends React.Component {
 
   onNextStep() {
     Piwik.trackingEvent('AddAccountID', 'button', 'Next step');
+    this.props.searchAccount({ address: this.state.address.value });
     this.props.nextStep({ address: this.state.address.value });
   }
 
@@ -87,4 +89,8 @@ const mapStateToProps = state => ({
   accounts: state.followedAccounts.accounts,
 });
 
-export default connect(mapStateToProps)(translate()(AddAccountID));
+const mapDispatchToProps = {
+  searchAccount,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(translate()(AddAccountID));

--- a/src/components/followedAccounts/addAccountID.test.js
+++ b/src/components/followedAccounts/addAccountID.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import thunk from 'redux-thunk';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 import { spy } from 'sinon';
@@ -7,7 +8,7 @@ import PropTypes from 'prop-types';
 import i18n from '../../i18n';
 import AddAccountID from './addAccountID';
 
-const fakeStore = configureStore();
+const fakeStore = configureStore([thunk]);
 
 describe('Add Account ID Component', () => {
   let wrapper;
@@ -16,6 +17,7 @@ describe('Add Account ID Component', () => {
   beforeEach(() => {
     const store = fakeStore({
       followedAccounts: { accounts: [{ address: '16313739661670634666L', balance: 0 }] },
+      peers: { liskAPIClient: {} },
     });
 
     props = {

--- a/src/components/followedAccounts/addAccountTitle.js
+++ b/src/components/followedAccounts/addAccountTitle.js
@@ -99,8 +99,8 @@ const mapStateToProps = (state, ownProps) => ({
   accounts: state.followedAccounts.accounts,
 });
 
-const mapDispatchToProps = {
-  addAccount: followedAccountAdded,
-};
+const mapDispatchToProps = dispatch => ({
+  addAccount: data => dispatch(followedAccountAdded(data)),
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(translate()(AddAccountTitle));

--- a/src/components/followedAccounts/addAccountTitle.js
+++ b/src/components/followedAccounts/addAccountTitle.js
@@ -19,6 +19,7 @@ class AddAccountTitle extends React.Component {
       title: {
         value,
         error: validateInput(value),
+        isDelegate: false,
       },
     });
   }
@@ -33,13 +34,32 @@ class AddAccountTitle extends React.Component {
 
     const { addAccount, address, prevStep } = this.props;
     const title = this.state.title.value;
+    const isDelegate = this.state.title.isDelegate;
 
-    addAccount({ title, address });
+    addAccount({ title, address, isDelegate });
     prevStep({ reset: true });
   }
 
+  shouldComponentUpdate(nextProps) {
+    const { title } = this.state;
+    const { account } = nextProps;
+    const username = account && account.delegate && account.delegate.username;
+    if (username && username !== title.value) {
+      this.setState({
+        title: {
+          value: username,
+          error: false,
+          isDelegate: true,
+        },
+      });
+      return false;
+    }
+    return true;
+  }
+
   render() {
-    const { t } = this.props;
+    const { t, account } = this.props;
+    const isDelegate = !!(account && account.delegate && account.delegate.username);
 
     return (
       <BoxV2 className={styles.addAccount}>
@@ -49,6 +69,7 @@ class AddAccountTitle extends React.Component {
         <div>
           <TitleInput
             title={this.state.title}
+            disabled={isDelegate}
             onChange={this.handleChange.bind(this)} />
         </div>
         <footer>
@@ -73,8 +94,13 @@ class AddAccountTitle extends React.Component {
   }
 }
 
-const mapDispatchToProps = dispatch => ({
-  addAccount: data => dispatch(followedAccountAdded(data)),
+const mapStateToProps = (state, ownProps) => ({
+  account: state.search.accounts[ownProps.address],
+  accounts: state.followedAccounts.accounts,
 });
 
-export default connect(null, mapDispatchToProps)(translate()(AddAccountTitle));
+const mapDispatchToProps = {
+  addAccount: followedAccountAdded,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(translate()(AddAccountTitle));

--- a/src/components/followedAccounts/addAccountTitle.js
+++ b/src/components/followedAccounts/addAccountTitle.js
@@ -44,6 +44,7 @@ class AddAccountTitle extends React.Component {
     const { title } = this.state;
     const { account } = nextProps;
     const username = account && account.delegate && account.delegate.username;
+    /* istanbul ignore next */
     if (username && username !== title.value) {
       this.setState({
         title: {

--- a/src/components/followedAccounts/addAccountTitle.test.js
+++ b/src/components/followedAccounts/addAccountTitle.test.js
@@ -14,10 +14,15 @@ const fakeStore = configureStore();
 describe('Add Account Title Component', () => {
   let wrapper;
   let props;
+  let options;
 
   beforeEach(() => {
     const store = fakeStore({
-      search: { accounts: { [accounts.genesis.address]: {} } },
+      search: {
+        accounts: {
+          [accounts.delegate.address]: { delegate: accounts.delegate.address },
+        },
+      },
       followedAccounts: { acounts: [] },
     });
 
@@ -25,18 +30,19 @@ describe('Add Account Title Component', () => {
 
     props = {
       address: accounts.genesis.address,
-      account: {},
       prevStep: spy(),
       t: key => key,
     };
 
-    wrapper = mount(<AddAccountTitle {...props} />, {
+    options = {
       context: { store, i18n },
       childContextTypes: {
         store: PropTypes.object.isRequired,
         i18n: PropTypes.object.isRequired,
       },
-    });
+    };
+
+    wrapper = mount(<AddAccountTitle {...props} />, options);
   });
 
   afterEach(() => {
@@ -49,6 +55,15 @@ describe('Add Account Title Component', () => {
 
   it('renders two Button component', () => {
     expect(wrapper.find('Button')).to.have.length(2);
+  });
+
+  it('renders Input with delegate name if account is delegate', () => {
+    props = {
+      address: accounts.delegate.address,
+    };
+    wrapper.setProps(props);
+    wrapper.update();
+    expect(wrapper.find('Input.account-title')).to.have.prop('disabled');
   });
 
   it('accepts empty field', () => {

--- a/src/components/followedAccounts/addAccountTitle.test.js
+++ b/src/components/followedAccounts/addAccountTitle.test.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import i18n from '../../i18n';
 import AddAccountTitle from './addAccountTitle';
 import * as followedAccounts from '../../actions/followedAccounts';
+import accounts from '../../../test/constants/accounts';
 
 const fakeStore = configureStore();
 
@@ -15,12 +16,16 @@ describe('Add Account Title Component', () => {
   let props;
 
   beforeEach(() => {
-    const store = fakeStore({});
+    const store = fakeStore({
+      search: { accounts: { [accounts.genesis.address]: {} } },
+      followedAccounts: { acounts: [] },
+    });
 
     spy(followedAccounts, 'followedAccountAdded');
 
     props = {
-      address: '16313739661670634666L',
+      address: accounts.genesis.address,
+      account: {},
       prevStep: spy(),
       t: key => key,
     };
@@ -65,8 +70,9 @@ describe('Add Account Title Component', () => {
     wrapper.find('.account-title input').simulate('change', { target: { value: 'some title' } });
     wrapper.find('.next').first().simulate('click');
     expect(followedAccounts.followedAccountAdded).to.have.been.calledWith({
-      address: '16313739661670634666L',
+      address: accounts.genesis.address,
       title: 'some title',
+      isDelegate: false,
     });
   });
 });

--- a/src/components/followedAccounts/titleInputForList.js
+++ b/src/components/followedAccounts/titleInputForList.js
@@ -38,7 +38,7 @@ class TitleInputForList extends React.Component {
     return <TitleInput
       className={styles.title}
       title={this.state.title}
-      disabled={!this.props.edit}
+      disabled={!this.props.edit || this.props.account.isDelegate}
       hideLabel={true}
       onChange={this.handleChange.bind(this)}
     />;

--- a/src/components/followedAccounts/viewAccounts.js
+++ b/src/components/followedAccounts/viewAccounts.js
@@ -100,7 +100,7 @@ class ViewAccounts extends React.Component {
                     </div>
 
                     <div className={`${styles.accountInformation}`}>
-                      <div className={this.state.edit ? styles.editMode : null}>
+                      <div className={this.state.edit ? styles.editMode : ''}>
                         <div className={`${styles.balance} followed-account-balance`}>
                           <LiskAmount val={account.balance} /> <span>LSK</span>
                         </div>
@@ -111,6 +111,7 @@ class ViewAccounts extends React.Component {
                             title: account.title || account.address,
                             address: account.address,
                             balance: account.balance,
+                            isDelegate: account.isDelegate,
                           }}
                         />
                       </div>

--- a/src/components/followedAccounts/viewAccounts.test.js
+++ b/src/components/followedAccounts/viewAccounts.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import thunk from 'redux-thunk';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 import { spy } from 'sinon';
@@ -9,7 +10,7 @@ import ViewAccounts from './viewAccounts';
 import routes from '../../constants/routes';
 import * as followedAccounts from '../../actions/followedAccounts';
 
-const fakeStore = configureStore();
+const fakeStore = configureStore([thunk]);
 
 describe('Followed accounts list Component', () => {
   let wrapper;
@@ -22,7 +23,9 @@ describe('Followed accounts list Component', () => {
 
   describe('Without followed accounts', () => {
     beforeEach(() => {
-      const store = fakeStore({ followedAccounts: { accounts: [] } });
+      const store = fakeStore({
+        followedAccounts: { accounts: [] },
+      });
 
       wrapper = mount(<ViewAccounts {...props} />, {
         context: { store, i18n },
@@ -53,12 +56,19 @@ describe('Followed accounts list Component', () => {
       const store = fakeStore({
         followedAccounts: {
           accounts: [
-            { address: '123L', balance: 0, title: 'bob' },
-            { address: '567L', balance: 100000, title: '' },
-            { address: '23467L', balance: 30000, title: '' },
-            { address: '23464567L', balance: 3000, title: '' },
-            { address: '2346456347L', balance: 3000, title: '' },
-            { address: '234645634347L', balance: 3000, title: '' },
+            {
+              address: '123L', balance: 0, title: 'bob', isDelegate: false,
+            }, {
+              address: '567L', balance: 100000, title: '', isDelegate: false,
+            }, {
+              address: '23467L', balance: 30000, title: '', isDelegate: false,
+            }, {
+              address: '23464567L', balance: 3000, title: '', isDelegate: false,
+            }, {
+              address: '2346456347L', balance: 3000, title: '', isDelegate: false,
+            }, {
+              address: '234645634347L', balance: 3000, title: '', isDelegate: false,
+            },
           ],
         },
       });
@@ -105,7 +115,7 @@ describe('Followed accounts list Component', () => {
       wrapper.find('.remove-account').at(0).simulate('click');
 
       expect(followedAccounts.followedAccountRemoved).to.have.been.calledWith({
-        address: '123L', balance: 0, title: 'bob',
+        address: '123L', balance: 0, title: 'bob', isDelegate: false,
       });
     });
 
@@ -139,7 +149,7 @@ describe('Followed accounts list Component', () => {
 
       expect(wrapper.find('.account-title input').at(1)).to.have.value('my friend');
       expect(followedAccounts.followedAccountUpdated).to.have.been.calledWith({
-        address: '567L', balance: 100000, title: 'my friend',
+        address: '567L', balance: 100000, title: 'my friend', isDelegate: false,
       });
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#1859

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Updated stored data for followed account with a flag if `isDelegate`, and disable editing for the account name.
Updated followAccount dropdown and follow account on dashboard to set the flag when saving the bookmark.
Updated follow account on dashboard to use the username if the account is a delegate.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
1. Open delegate account
2. Bookmark it
3. Go to dashboard
4. Shouldn't be able to rename it.
5. Delete delegate bookmark
6. Add through dashboard, shouldn't be able to choose a account title.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
