### PR TITLE
Multiple tx table loading states - Closes #1857

### DIFF
--- a/src/components/transactionsV2/transactionsListV2.js
+++ b/src/components/transactionsV2/transactionsListV2.js
@@ -32,7 +32,9 @@ class TransactionsListV2 extends React.Component {
       return !(isFilterIncoming && (isTypeNonSend || isAccountInit));
     };
 
-    const isLoading = loading.length > 0;
+    const isLoading = loading.filter(type =>
+      [actionTypes.transactionsRequested, actionTypes.transactionsFilterSet]
+        .includes(type)).length > 0;
     const spinnerClass = loading.includes(actionTypes.transactionsRequested)
       ? styles.bottom : styles.top;
 

--- a/src/components/votes/votesTab.js
+++ b/src/components/votes/votesTab.js
@@ -10,6 +10,7 @@ import SpinnerV2 from '../spinnerV2/spinnerV2';
 import { InputV2 } from '../toolbox/inputsV2';
 import LiskAmount from '../liskAmount';
 import routes from '../../constants/routes';
+import actionTypes from '../../constants/actions';
 import styles from './votesTab.css';
 
 class VotesTab extends React.Component {
@@ -90,7 +91,8 @@ class VotesTab extends React.Component {
     const { filterValue } = this.state;
     const filteredVotes = votes.filter(vote => RegExp(filterValue, 'i').test(vote.username));
     const canLoadMore = filteredVotes.length > this.state.showing;
-    const isLoading = loading.length > 0 || this.state.isLoading;
+    const isLoading = loading.filter(type => actionTypes.searchVotes === type).length > 0
+      || this.state.isLoading;
 
     return (
       <BoxV2 className={`${styles.wrapper}`}>

--- a/src/components/votes/votesTab.test.js
+++ b/src/components/votes/votesTab.test.js
@@ -5,6 +5,7 @@ import i18n from '../../i18n';
 import accounts from '../../../test/constants/accounts';
 import routes from '../../constants/routes';
 import VotesTab from './votesTab';
+import actionTypes from '../../constants/actions';
 
 describe('Votes Tab Component', () => {
   let wrapper;
@@ -33,7 +34,7 @@ describe('Votes Tab Component', () => {
   });
 
   it('Should show loading state', () => {
-    wrapper = setup({ ...props, loading: ['loading'] });
+    wrapper = setup({ ...props, loading: [actionTypes.searchVotes] });
     expect(wrapper).toContainMatchingElement('.loadingSpinner');
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#1857

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Fix issue with transaction table showing loading state multiple times, by checking what action triggered the loading state.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Go to wallet, and the transaction table should show the loading just one time.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
