### PR TITLE
Fix send LSK navigation data form - Closes #1906 #1905

### DIFF
--- a/src/components/bookmarkV2/index.js
+++ b/src/components/bookmarkV2/index.js
@@ -178,7 +178,7 @@ class Bookmark extends React.Component {
         </span>
 
         <Feedback
-          show={recipient.error}
+          show={recipient.error || false}
           status={'error'}
           className={styles.feedbackMessage}
           showIcon={false}>

--- a/src/components/sendV2/form/form.js
+++ b/src/components/sendV2/form/form.js
@@ -67,18 +67,16 @@ class Form extends React.Component {
   }
 
   componentDidMount() {
-    this.ifDataFromPrevState();
-    this.ifDataFromUrl();
+    if (!Object.entries(this.props.prevState).length) this.ifDataFromUrl();
+    if (Object.entries(this.props.prevState).length) this.ifDataFromPrevState();
     this.checkIfBoormakedAccount();
   }
 
   ifDataFromPrevState() {
     const { prevState } = this.props;
-
-    if (prevState.fields && Object.entries(prevState.fields).length > 0) {
+    if (prevState.fields && Object.entries(prevState.fields).length) {
       this.setState({
         fields: {
-          ...this.state.fields,
           ...prevState.fields,
         },
       });
@@ -89,24 +87,24 @@ class Form extends React.Component {
     const { fields = {} } = this.props;
 
     if (fields.recipient.address !== '' || fields.amount.value !== '' || fields.reference.value !== '') {
-      this.setState({
+      this.setState(prevState => ({
         fields: {
-          ...this.state.fields,
+          ...prevState.fields,
           recipient: {
-            ...this.state.fields.recipient,
-            address: fields.recipient.address,
-            value: fields.recipient.address,
+            ...prevState.fields.recipient,
+            address: prevState.fields.recipient.address,
+            value: prevState.fields.recipient.address,
           },
           amount: {
-            ...this.state.fields.amount,
-            value: fields.amount.value,
+            ...prevState.fields.amount,
+            value: prevState.fields.amount.value,
           },
           reference: {
-            ...this.state.fields.reference,
-            value: fields.reference.value,
+            ...prevState.fields.reference,
+            value: prevState.fields.reference.value,
           },
         },
-      });
+      }));
     }
   }
 
@@ -215,9 +213,9 @@ class Form extends React.Component {
   }
 
   onSelectedAccount(account) {
-    this.setState({
+    this.setState(prevState => ({
       fields: {
-        ...this.state.fields,
+        ...prevState.fields,
         recipient: {
           ...this.state.fields.recipient,
           ...account,
@@ -229,7 +227,7 @@ class Form extends React.Component {
           following: true,
         },
       },
-    });
+    }));
   }
 
   getMaxAmount() {
@@ -238,7 +236,7 @@ class Form extends React.Component {
 
   validateAmountField(value) {
     if (/([^\d.])/g.test(value)) return this.props.t('Provide a correct amount of LSK');
-    if (/(\.)(.*\1){1}/g.test(value) || /\.$/.test(value)) return this.props.t('Invalid amount');
+    if ((/(\.)(.*\1){1}/g.test(value) || /\.$/.test(value)) || value === '0') return this.props.t('Invalid amount');
     if (parseFloat(this.getMaxAmount()) < value) return this.props.t('Provided amount is higher than your current balance.');
     return false;
   }

--- a/src/components/sendV2/summary/summary.css
+++ b/src/components/sendV2/summary/summary.css
@@ -130,6 +130,6 @@
   }
 
   & > .editBtn {
-    width: 100px !important;
+    width: auto !important;
   }
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #1906 
-- #1905 

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
This PR include the fix for the send LSK form so know works properly.

From the Wallet table select any address (click)
Once the send LSK form page show up, type any amount and message, (the message it is option but is better for testing purposes).
Do click in the "Go to Confirmation" button
Then from the confirmation button go back to the previous page
Then the amount and message fields are populated with the provided information.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Like this.
From the Wallet table select any address (click)
Once the send LSK form page show up, type any amount and message, (the message it is option but is better for testing purposes).
Do click in the "Go to Confirmation" button
Then from the confirmation button go back to the previous page
Then the amount and message fields are populated with the provided information.


### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
