### PR TITLE
Delegate account shows account before delegate name - Closes #1899

### DIFF
--- a/src/components/transactionsV2/explorerTransactionsV2/explorerTransactionsV2.js
+++ b/src/components/transactionsV2/explorerTransactionsV2/explorerTransactionsV2.js
@@ -131,7 +131,7 @@ class ExplorerTransactionsV2 extends React.Component {
     const delegate = detailAccount && detailAccount.delegate ? {
       ...detailAccount.delegate,
       ...(this.props.delegate || {}),
-    } : {};
+    } : { ...(this.props.delegate || {}) };
 
     return (
       <React.Fragment>

--- a/src/components/transactionsV2/explorerTransactionsV2/explorerTransactionsV2.js
+++ b/src/components/transactionsV2/explorerTransactionsV2/explorerTransactionsV2.js
@@ -126,14 +126,17 @@ class ExplorerTransactionsV2 extends React.Component {
       customFilters: this.state.customFilters,
       updateCustomFilters: this.updateCustomFilters,
     };
+    const { detailAccount } = this.props;
 
-    const isDelegate = (this.props.delegate
-      && this.props.delegate.account && this.props.delegate.account.address === this.props.address);
+    const delegate = detailAccount && detailAccount.delegate ? {
+      ...detailAccount.delegate,
+      ...(this.props.delegate || {}),
+    } : {};
 
     return (
       <React.Fragment>
         <TransactionsOverviewHeader
-          delegate={this.props.delegate}
+          delegate={delegate}
           followedAccounts={this.props.followedAccounts}
           balance={this.props.balance}
           address={this.props.address}
@@ -152,7 +155,7 @@ class ExplorerTransactionsV2 extends React.Component {
             votes={this.props.votes}
             tabClassName={'account-info'}
             tabName={this.props.t('Votes')} />
-          {isDelegate
+          {delegate.username
             ? (<DelegateTab
               tabClassName={'delegate-statistics'}
               tabName={this.props.t('Delegate')}

--- a/src/components/transactionsV2/explorerTransactionsV2/explorerTransactionsV2.test.js
+++ b/src/components/transactionsV2/explorerTransactionsV2/explorerTransactionsV2.test.js
@@ -119,7 +119,12 @@ describe('ExplorerTransactions V2 Component', () => {
       account: accounts.genesis,
       match: { params: { address: accounts.delegate.address } },
       balance: accounts.delegate.balance,
-      detailAccount: accounts.delegate,
+      detailAccount: {
+        ...accounts.delegate,
+        delegate: {
+          username: accounts.genesis.username,
+        },
+      },
       delegate: {
         account: accounts.delegate,
         approval: 98.63,

--- a/test/cypress/e2e/wallet.spec.js
+++ b/test/cypress/e2e/wallet.spec.js
@@ -71,9 +71,12 @@ describe('Wallet', () => {
     it('Delegate -> Address, Name & Label are correct', () => {
       cy.autologin(accounts.genesis.passphrase, networks.devnet.node);
       cy.visit(`${urls.accounts}/${topDelegate.address}`);
+      cy.server();
+      cy.route(`/api/accounts?address=${topDelegate.address}`).as('getAccount');
+      cy.wait('@getAccount');
       cy.url().should('contain', topDelegate.address);
       cy.get(ss.accountAddress).contains(topDelegate.address);
-      // cy.get(ss.accountName).contains(topDelegate.username); TODO: unskip after 1899 fix
+      cy.get(ss.accountName).contains(topDelegate.username);
       cy.get(ss.accountLabel).contains('Delegate #1');
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#1899

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Since we have the username when the request for the account info is finished, already display, without waiting for other delegate data.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Go to a delegate account page, and the name should show up faster than before.
It's not possible to show directly the delegate username since we need to wait for the request for account data to finish.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
