### PR TITLE
Balance chart reflecting changes on transactions table - Closes #1913

### DIFF
--- a/src/components/wallet/balanceChart.js
+++ b/src/components/wallet/balanceChart.js
@@ -4,8 +4,22 @@ import { Line as LineChart } from 'react-chartjs-2';
 import BoxV2 from '../boxV2';
 import styles from './balanceChart.css';
 import * as ChartUtils from '../../utils/balanceChart';
+import transactionFilters from '../../constants/transactionFilters';
 
 class BalanceGraph extends React.Component {
+  shouldComponentUpdate(nextProps) {
+    const { customFilters } = nextProps;
+    const hasCustomFilters = Object.keys(customFilters).filter(field => !!customFilters[field]);
+    if (
+      nextProps.filter === transactionFilters.all
+      && !hasCustomFilters.length
+      && nextProps.balance !== this.props.balance
+    ) {
+      return true;
+    }
+    return false;
+  }
+
   render() {
     const {
       t, transactions, balance, address,

--- a/src/components/wallet/balanceChart.js
+++ b/src/components/wallet/balanceChart.js
@@ -6,7 +6,6 @@ import styles from './balanceChart.css';
 import * as ChartUtils from '../../utils/balanceChart';
 
 class BalanceGraph extends React.Component {
-  // eslint-disable-next-line class-methods-use-this
   shouldComponentUpdate(nextProps) {
     if (this.props.transactions.length !== nextProps.transactions.length) {
       return true;

--- a/src/components/wallet/balanceChart.js
+++ b/src/components/wallet/balanceChart.js
@@ -4,17 +4,11 @@ import { Line as LineChart } from 'react-chartjs-2';
 import BoxV2 from '../boxV2';
 import styles from './balanceChart.css';
 import * as ChartUtils from '../../utils/balanceChart';
-import transactionFilters from '../../constants/transactionFilters';
 
 class BalanceGraph extends React.Component {
+  // eslint-disable-next-line class-methods-use-this
   shouldComponentUpdate(nextProps) {
-    const { customFilters } = nextProps;
-    const hasCustomFilters = Object.keys(customFilters).filter(field => !!customFilters[field]);
-    if (
-      nextProps.filter === transactionFilters.all
-      && !hasCustomFilters.length
-      && nextProps.balance !== this.props.balance
-    ) {
+    if (this.props.transactions.length !== nextProps.transactions.length) {
       return true;
     }
     return false;

--- a/src/components/wallet/balanceChart.js
+++ b/src/components/wallet/balanceChart.js
@@ -7,7 +7,7 @@ import * as ChartUtils from '../../utils/balanceChart';
 
 class BalanceGraph extends React.Component {
   shouldComponentUpdate(nextProps) {
-    if (this.props.transactions.length !== nextProps.transactions.length) {
+    if (this.props.balance !== nextProps.balance || this.props.address !== nextProps.address) {
       return true;
     }
     return false;

--- a/src/components/wallet/walletTab.js
+++ b/src/components/wallet/walletTab.js
@@ -20,10 +20,8 @@ const WalletTab = ({ ...props }) => (
         </div>
         <div className={`${grid['col-sm-8']} ${grid['col-lg-9']}`}>
         { // istanbul ignore next
-          !props.hideChart ?
+          !props.hideChart || props.transactions.length ?
           <BalanceChart
-            filter={props.activeFilter}
-            customFilters={props.activeCustomFilters}
             balance={props.balance}
             address={props.address}
             transactions={props.transactions} />

--- a/src/components/wallet/walletTab.js
+++ b/src/components/wallet/walletTab.js
@@ -22,6 +22,8 @@ const WalletTab = ({ ...props }) => (
         { // istanbul ignore next
           !props.hideChart ?
           <BalanceChart
+            filter={props.activeFilter}
+            customFilters={props.activeCustomFilters}
             balance={props.balance}
             address={props.address}
             transactions={props.transactions} />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#1913

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Added condition to only update the balance chart when first getting transactions data. Afterwards the balance chart shouldn't update, only if leaving and revisiting the page.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
1. Go to My wallet
2. Do some tx list filtering
3. Balance chart shouldn't update.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
