### PR TITLE
No result screen showing before tx loaded - Closes #1882

### DIFF
--- a/src/components/singleTransactionV2/singleTransactionV2.js
+++ b/src/components/singleTransactionV2/singleTransactionV2.js
@@ -146,7 +146,7 @@ class SingleTransactionV2 extends React.Component {
             </footer>
           </main>
         </BoxV2>
-      ) : (
+      ) : this.props.transaction && this.props.transaction.error && (
         <BoxV2 className={`${grid['col-sm-8']} ${grid['col-md-4']}`}>
           <EmptyState title={this.props.t('No results')}
             message={this.props.t('Search for Lisk ID, Delegate or Transaction ID')} />

--- a/src/components/singleTransactionV2/singleTransactionV2.js
+++ b/src/components/singleTransactionV2/singleTransactionV2.js
@@ -78,7 +78,7 @@ class SingleTransactionV2 extends React.Component {
 
     return (
       <div className={`${grid.row} ${grid['center-xs']}`}>
-      { this.props.transaction.id && !this.props.transaction.error ? (
+      { transaction.id && !transaction.error ? (
         <BoxV2 className={`${grid['col-sm-8']} ${grid['col-md-4']} ${styles.wrapper}`}>
           <header className={`${styles.detailsHeader} tx-header`}>
             <h1>{title}</h1>
@@ -146,7 +146,7 @@ class SingleTransactionV2 extends React.Component {
             </footer>
           </main>
         </BoxV2>
-      ) : this.props.transaction && typeof this.props.transaction === 'string' && (
+      ) : typeof transaction === 'string' && (
         <BoxV2 className={`${grid['col-sm-8']} ${grid['col-md-4']}`}>
           <EmptyState title={this.props.t('No results')}
             message={this.props.t('Search for Lisk ID, Delegate or Transaction ID')} />

--- a/src/components/singleTransactionV2/singleTransactionV2.js
+++ b/src/components/singleTransactionV2/singleTransactionV2.js
@@ -146,7 +146,7 @@ class SingleTransactionV2 extends React.Component {
             </footer>
           </main>
         </BoxV2>
-      ) : this.props.transaction && this.props.transaction.error && (
+      ) : this.props.transaction && typeof this.props.transaction === 'string' && (
         <BoxV2 className={`${grid['col-sm-8']} ${grid['col-md-4']}`}>
           <EmptyState title={this.props.t('No results')}
             message={this.props.t('Search for Lisk ID, Delegate or Transaction ID')} />

--- a/src/components/singleTransactionV2/singleTransactionV2.test.js
+++ b/src/components/singleTransactionV2/singleTransactionV2.test.js
@@ -164,4 +164,33 @@ describe('Single Transaction V2 Component', () => {
       expect(wrapper.find('.detailsHeader h1')).toHaveText('Vote Transaction');
     });
   });
+
+  describe('No results', () => {
+    const transaction = {
+      error: 'No transction found',
+    };
+
+    const store = configureMockStore([thunk])({
+      account: accounts.genesis,
+      transaction,
+      peers,
+      loadTransaction: jest.fn(),
+    });
+
+    const options = {
+      context: { i18n, store },
+      childContextTypes: {
+        store: PropTypes.object.isRequired,
+        i18n: PropTypes.object.isRequired,
+      },
+    };
+
+    beforeEach(() => {
+      wrapper = mount(<Router><SingleTransactionV2 {...props} /></Router>, options);
+    });
+
+    it('Should render no result screen', () => {
+      expect(wrapper).toContainMatchingElement('EmptyState');
+    });
+  });
 });

--- a/src/components/singleTransactionV2/singleTransactionV2.test.js
+++ b/src/components/singleTransactionV2/singleTransactionV2.test.js
@@ -166,9 +166,7 @@ describe('Single Transaction V2 Component', () => {
   });
 
   describe('No results', () => {
-    const transaction = {
-      error: 'No transction found',
-    };
+    const transaction = 'No transction found';
 
     const store = configureMockStore([thunk])({
       account: accounts.genesis,

--- a/src/components/singleTransactionV2/singleTransactionV2.test.js
+++ b/src/components/singleTransactionV2/singleTransactionV2.test.js
@@ -166,7 +166,7 @@ describe('Single Transaction V2 Component', () => {
   });
 
   describe('No results', () => {
-    const transaction = 'No transction found';
+    const transaction = 'No transaction found';
 
     const store = configureMockStore([thunk])({
       account: accounts.genesis,

--- a/test/cypress/e2e/search.spec.js
+++ b/test/cypress/e2e/search.spec.js
@@ -9,8 +9,15 @@ describe('Search', () => {
   const testnetTransaction = '755251579479131174';
   const mainnetTransaction = '881002485778658401';
 
+  beforeEach(() => {
+    cy.server();
+    cy.route('/api/accounts**').as('requestAccount');
+    cy.route('/api/transactions**').as('requestTransaction');
+    cy.route('/api/delegates**').as('requestDelegate');
+  });
+
   function assertAccountPage(accountsAddress) {
-    cy.wait(3000);
+    cy.wait('@requestAccount');
     cy.get(ss.accountAddress).should('have.text', accountsAddress)
       .and(() => {
         expect(getSearchesObjFromLS()[0].id).to.equal(accountsAddress);
@@ -19,7 +26,7 @@ describe('Search', () => {
   }
 
   function assertTransactionPage(transactionId) {
-    cy.wait(3000);
+    cy.wait('@requestTransaction');
     cy.get(ss.transactionId).should('have.text', transactionId)
       .and(() => {
         expect(getSearchesObjFromLS()[0].id).to.equal(transactionId);
@@ -28,7 +35,7 @@ describe('Search', () => {
   }
 
   function assertDelegatePage(delegateName, delegateId) {
-    cy.wait(3000);
+    cy.wait('@requestDelegate');
     cy.get(ss.accountName).should('have.text', delegateName)
       .and(() => {
         expect(getSearchesObjFromLS()[0].id).to.equal(delegateId);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#1882 

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Added condition to only show the no result screen if request returns no result.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
You can throttle the network to delay the loading of the tx.
- Click on some tx in Wallet or use the direct link or use search suggestions to open valid tx.
- No result screen should not flash before the tx loaded.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
