### PR TITLE
Fix balance graph being rendered with 0 height in electron - Closes #1918

### DIFF
--- a/src/components/wallet/balanceChart.css
+++ b/src/components/wallet/balanceChart.css
@@ -9,15 +9,15 @@
 }
 
 .content {
+  display: flex;
   flex-grow: 1;
   position: relative;
 }
 
 .graphHolder {
-  height: 100%;
+  flex-grow: 1;
   overflow: hidden;
   position: relative;
-  width: 100%;
 
   & > * {
     height: 100%;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#1918 

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Changed from `height: 100%;` to `flex-grow: 1;` to make sure that the graph uses all the available space when running in electron and in the browser.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
1. Run app in electron;
2. My wallet;
3. Check Balance Details;
4. Balance Graph should be showing.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
