### PR TITLE
Clear all filters button too big - Closes #1922

### DIFF
--- a/src/components/transactionsV2/filters/filterBar.css
+++ b/src/components/transactionsV2/filters/filterBar.css
@@ -11,12 +11,9 @@
 }
 
 .labelsHolder {
+  align-items: center;
   display: flex;
   flex-wrap: wrap;
-
-  & > button {
-    margin: 4px 0;
-  }
 }
 
 .filter {
@@ -64,8 +61,10 @@
 
   & > .label {
     color: inherit;
+    display: block;
+    height: auto;
     margin: 0;
-    max-width: 245px;
+    max-width: 225px;
     overflow: hidden;
     text-overflow: ellipsis;
   }

--- a/src/components/transactionsV2/filters/filterBar.js
+++ b/src/components/transactionsV2/filters/filterBar.js
@@ -8,43 +8,43 @@ const FilterBar = props => (
     <span className={styles.label}>
       {props.t('Filtered results: {{results}}', { results: props.results })}
     </span>
-    {Object.keys(props.customFilters).map((filter, index) => {
-      let label = props.customFilters[filter];
-      if (label === '') return null;
+    <div className={`${styles.labelsHolder}`}>
+      {Object.keys(props.customFilters).map((filter, index) => {
+        let label = props.customFilters[filter];
+        if (label === '') return null;
 
-      switch (filter) {
-        case 'dateFrom':
-        case 'dateTo': {
-          const prefix = filter === 'dateFrom' ? props.t('from') : props.t('to');
-          label = `${prefix} ${moment(label, 'DD.MM.YY').format('DD MMM YYYY')}`;
-          break;
+        switch (filter) {
+          case 'dateFrom':
+          case 'dateTo': {
+            const prefix = filter === 'dateFrom' ? props.t('from') : props.t('to');
+            label = `${prefix} ${moment(label, 'DD.MM.YY').format('DD MMM YYYY')}`;
+            break;
+          }
+          case 'amountFrom':
+          case 'amountTo': {
+            const prefix = filter === 'amountFrom' ? '>' : '<';
+            label = `${prefix} ${label} ${props.t('LSK')}`;
+            break;
+          }
+          default:
+            break;
         }
-        case 'amountFrom':
-        case 'amountTo': {
-          const prefix = filter === 'amountFrom' ? '>' : '<';
-          label = `${prefix}${label} ${props.t('LSK')}`;
-          break;
-        }
-        default:
-          break;
+
+        return (
+          <div
+            className={`${styles.filter} filter`}
+            key={filter + index}>
+              <p className={styles.label}>{label}</p>
+              <span
+                className={`${styles.clearBtn} clear-filter`}
+                onClick={() => props.clearFilter(filter)} />
+          </div>);
+        })
       }
-
-      return (
-        <div
-          className={`${styles.filter} filter`}
-          key={filter + index}>
-            <p className={styles.label}>{label}</p>
-            <span
-              className={`${styles.clearBtn} clear-filter`}
-              onClick={() => props.clearFilter(filter)} />
-        </div>);
-      })
-    }
-    <div className={`${styles.clearAll}`}>
       <SecondaryButtonV2
-        className={`${styles.clearAllButton} clear-all-filters`}
+        className={'clear-all-filters extra-small'}
         onClick={props.clearAllFilters}>{props.t('Clear All filters')}
-        </SecondaryButtonV2>
+      </SecondaryButtonV2>
     </div>
   </div>);
 

--- a/src/components/transactionsV2/filters/filterBar.test.js
+++ b/src/components/transactionsV2/filters/filterBar.test.js
@@ -23,7 +23,7 @@ describe('FilterBar', () => {
 
   it('Shows 5 filters and clearAll', () => {
     expect(wrapper).toContainMatchingElements(5, '.filter');
-    expect(wrapper).toContainMatchingElement('.clearAllButton');
+    expect(wrapper).toContainMatchingElement('.clear-all-filters');
   });
 
   it('Call clearFilter on clearFilter click', () => {
@@ -32,7 +32,7 @@ describe('FilterBar', () => {
   });
 
   it('Call clearAllFilters on clearAll click', () => {
-    wrapper.find('.clearAllButton').simulate('click');
+    wrapper.find('.clear-all-filters').simulate('click');
     expect(props.clearAllFilters).toBeCalled();
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#1922

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Added extra-small class variant to the clear all button, and fixed some spacing and alignment issues.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Go to wallet, and add some filters, the clear all button should have the same height as the filters labels.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
