### PR TITLE
Implement redux logic for switching active token - closes #1948

### DIFF
--- a/src/actions/setting.test.js
+++ b/src/actions/setting.test.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import actionTypes from '../constants/actions';
 import {
   settingsReset,
@@ -16,7 +15,7 @@ describe('actions: setting', () => {
         data,
         type: actionTypes.settingsUpdated,
       };
-      expect(settingsUpdated(data)).to.be.deep.equal(expectedAction);
+      expect(settingsUpdated(data)).toEqual(expectedAction);
     });
   });
 
@@ -25,7 +24,7 @@ describe('actions: setting', () => {
       const expectedAction = {
         type: actionTypes.settingsReset,
       };
-      expect(settingsReset()).to.be.deep.equal(expectedAction);
+      expect(settingsReset()).toEqual(expectedAction);
     });
   });
 
@@ -45,7 +44,7 @@ describe('actions: setting', () => {
         type: actionTypes.settingsUpdateToken,
         data,
       };
-      expect(settingsUpdateToken(data)).to.be.deep.equal(expectedAction);
+      expect(settingsUpdateToken(data)).toEqual(expectedAction);
     });
   });
 });

--- a/src/actions/setting.test.js
+++ b/src/actions/setting.test.js
@@ -1,8 +1,9 @@
 import { expect } from 'chai';
 import actionTypes from '../constants/actions';
 import {
-  settingsUpdated,
   settingsReset,
+  settingsUpdateToken,
+  settingsUpdated,
 } from './settings';
 
 
@@ -25,6 +26,26 @@ describe('actions: setting', () => {
         type: actionTypes.settingsReset,
       };
       expect(settingsReset()).to.be.deep.equal(expectedAction);
+    });
+  });
+
+  describe('settingsTokenUpdate', () => {
+    it('should create an action to update settings token', () => {
+      const data = {
+        token: {
+          active: 'LSK',
+          list: {
+            LSK: true,
+            BTC: true,
+          },
+        },
+      };
+
+      const expectedAction = {
+        type: actionTypes.settingsUpdateToken,
+        data,
+      };
+      expect(settingsUpdateToken(data)).to.be.deep.equal(expectedAction);
     });
   });
 });

--- a/src/actions/settings.js
+++ b/src/actions/settings.js
@@ -16,3 +16,12 @@ export const settingsUpdated = data => ({
 export const settingsReset = () => ({
   type: actionTypes.settingsReset,
 });
+
+/**
+ * An action to dispatch settingsTokenUpdate
+ *
+ */
+export const settingsUpdateToken = data => ({
+  type: actionTypes.settingsUpdateToken,
+  data,
+});

--- a/src/constants/actions.js
+++ b/src/constants/actions.js
@@ -80,6 +80,7 @@ const actionTypes = {
   cleanTransactions: 'CLEAN_TRANSACTIONS',
   moduleAdded: 'MODULE_ADDED',
   walletUpdated: 'WALLET_UPDATED',
+  settingsUpdateToken: 'SETTINGS_UPDATE_TOKEN',
 };
 
 export default actionTypes;

--- a/src/store/reducers/settings.js
+++ b/src/store/reducers/settings.js
@@ -1,4 +1,24 @@
 import actionTypes from '../../constants/actions';
+import { tokenKeys } from '../../constants/tokens';
+
+
+/**
+ * Defines the active token. Reverts to LSK if the active token is disabled.
+ *
+ * @param {Object} actionToken - action.data.token value
+ * @param {Object} stateToken - state.token value
+ *
+ * @returns {String} active token key
+ */
+const defineActiveToken = (actionToken, stateToken) => {
+  if (!actionToken) return stateToken.active;
+  if (actionToken.active && !actionToken.list) {
+    return stateToken.list[actionToken.active] === true ? actionToken.active : stateToken.active;
+  }
+
+  const lastActiveToken = actionToken.active || stateToken.active;
+  return actionToken.list[lastActiveToken] === false ? tokenKeys[0] : lastActiveToken;
+};
 
 export const channels = {
   academy: false,
@@ -19,6 +39,10 @@ const initialState = JSON.parse(localStorage.getItem('settings')) || {
   isRequestHowItWorksDisable: false,
   statistics: false,
   areTermsOfUseAccepted: false,
+  token: {
+    active: tokenKeys[0],
+    list: tokenKeys.reduce((acc, key) => { acc[key] = true; return acc; }, {}),
+  },
 };
 
 /**
@@ -43,6 +67,13 @@ const settings = (state = initialState, action) => {
           [action.data.name]: action.data.value,
         },
       };
+    case actionTypes.settingsUpdateToken:
+      return Object.assign({}, state, action.data, {
+        token: {
+          active: defineActiveToken(action.data.token, state.token),
+          list: action.data.token ? action.data.token.list : state.token.list,
+        },
+      });
     default:
       return state;
   }

--- a/src/store/reducers/settings.test.js
+++ b/src/store/reducers/settings.test.js
@@ -6,6 +6,38 @@ import actionTypes from '../../constants/actions';
 describe('Reducer: settings(state, action)', () => {
   let initializeState;
 
+  const defaultTokens = {
+    active: 'LSK',
+    list: {
+      LSK: true,
+      BTC: true,
+    },
+  };
+
+  const disabledBTC = {
+    active: 'LSK',
+    list: {
+      LSK: true,
+      BTC: false,
+    },
+  };
+
+  const enabledBTC = {
+    active: 'BTC',
+    list: {
+      LSK: true,
+      BTC: true,
+    },
+  };
+
+  const invalidBTCActivationAttempt = {
+    active: 'BTC',
+    list: {
+      LSK: true,
+      BTC: false,
+    },
+  };
+
   beforeEach(() => {
     initializeState = { autoLog: true, advancedMode: false };
   });
@@ -37,6 +69,104 @@ describe('Reducer: settings(state, action)', () => {
     };
     const changedState = settings(initializeState, action);
     expect(changedState.channels).to.deep.equal({ twitter: true });
+  });
+
+  it('should return updated state', () => {
+    const state = {
+      token: defaultTokens,
+    };
+    const action = {
+      type: actionTypes.settingsUpdateToken,
+      data: {
+        token: null,
+      },
+    };
+    const changedState = settings(state, action);
+    expect(changedState).to.deep.equal({
+      token: defaultTokens,
+    });
+  });
+
+  it('should revert to LSK when disabling the active token', () => {
+    const state = {
+      token: defaultTokens,
+    };
+    const action = {
+      type: actionTypes.settingsUpdateToken,
+      data: {
+        token: invalidBTCActivationAttempt,
+      },
+    };
+    const changedState = settings(state, action);
+    expect(changedState).to.deep.equal({
+      token: disabledBTC,
+    });
+  });
+
+  it('should revert to LSK if the activated token is already disabled', () => {
+    const state = {
+      token: disabledBTC,
+    };
+    const action = {
+      type: actionTypes.settingsUpdateToken,
+      data: {
+        token: invalidBTCActivationAttempt,
+      },
+    };
+    const changedState = settings(state, action);
+    expect(changedState).to.deep.equal({
+      token: disabledBTC,
+    });
+  });
+
+  it('should change the active token to LSK if disables that token', () => {
+    const state = {
+      token: enabledBTC,
+    };
+    const action = {
+      type: actionTypes.settingsUpdateToken,
+      data: {
+        token: invalidBTCActivationAttempt,
+      },
+    };
+    const changedState = settings(state, action);
+    expect(changedState).to.deep.equal({
+      token: disabledBTC,
+    });
+  });
+
+  it('should change the active token if a new one is passed', () => {
+    const state = {
+      token: defaultTokens,
+    };
+
+    const action = {
+      type: actionTypes.settingsUpdateToken,
+      data: {
+        token: enabledBTC,
+      },
+    };
+
+    const changedState = settings(state, action);
+    expect(changedState).to.deep.equal({
+      token: enabledBTC,
+    });
+  });
+
+  it('should change the active token if a active token and list are correctly passed', () => {
+    const state = {
+      token: disabledBTC,
+    };
+    const action = {
+      type: actionTypes.settingsUpdateToken,
+      data: {
+        token: enabledBTC,
+      },
+    };
+    const changedState = settings(state, action);
+    expect(changedState).to.deep.equal({
+      token: enabledBTC,
+    });
   });
 });
 

--- a/src/store/reducers/settings.test.js
+++ b/src/store/reducers/settings.test.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import settings from './settings';
 import actionTypes from '../../constants/actions';
 
@@ -48,7 +47,7 @@ describe('Reducer: settings(state, action)', () => {
       data: { autoLog: false },
     };
     const changedState = settings(initializeState, action);
-    expect(changedState).to.deep.equal({ autoLog: false, advancedMode: false });
+    expect(changedState).toEqual({ autoLog: false, advancedMode: false });
   });
 
   it('should return updated initializeState if action.type = actionTypes.settingsReset', () => {
@@ -59,7 +58,7 @@ describe('Reducer: settings(state, action)', () => {
       autoLog: false, advancedMode: true,
     };
     const FinalStep = settings(changedState, action);
-    expect(FinalStep).to.deep.equal(initializeState);
+    expect(FinalStep).toEqual(initializeState);
   });
 
   it('should return updated settings if action.type = actionTypes.switchChannel', () => {
@@ -68,7 +67,7 @@ describe('Reducer: settings(state, action)', () => {
       data: { name: 'twitter', value: true },
     };
     const changedState = settings(initializeState, action);
-    expect(changedState.channels).to.deep.equal({ twitter: true });
+    expect(changedState.channels).toEqual({ twitter: true });
   });
 
   it('should return updated state', () => {
@@ -82,7 +81,7 @@ describe('Reducer: settings(state, action)', () => {
       },
     };
     const changedState = settings(state, action);
-    expect(changedState).to.deep.equal({
+    expect(changedState).toEqual({
       token: defaultTokens,
     });
   });
@@ -98,7 +97,7 @@ describe('Reducer: settings(state, action)', () => {
       },
     };
     const changedState = settings(state, action);
-    expect(changedState).to.deep.equal({
+    expect(changedState).toEqual({
       token: disabledBTC,
     });
   });
@@ -114,7 +113,7 @@ describe('Reducer: settings(state, action)', () => {
       },
     };
     const changedState = settings(state, action);
-    expect(changedState).to.deep.equal({
+    expect(changedState).toEqual({
       token: disabledBTC,
     });
   });
@@ -130,7 +129,7 @@ describe('Reducer: settings(state, action)', () => {
       },
     };
     const changedState = settings(state, action);
-    expect(changedState).to.deep.equal({
+    expect(changedState).toEqual({
       token: disabledBTC,
     });
   });
@@ -148,7 +147,7 @@ describe('Reducer: settings(state, action)', () => {
     };
 
     const changedState = settings(state, action);
-    expect(changedState).to.deep.equal({
+    expect(changedState).toEqual({
       token: enabledBTC,
     });
   });
@@ -164,7 +163,7 @@ describe('Reducer: settings(state, action)', () => {
       },
     };
     const changedState = settings(state, action);
-    expect(changedState).to.deep.equal({
+    expect(changedState).toEqual({
       token: enabledBTC,
     });
   });


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #1948 

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Update the settings reducer file adding one more field token in the same way as the mobile team has it, then add a function that will help to validate and update the active token based on the incoming data.

In the other hand I update the **actions/settings.js** file for add the a new action creator that will be on charge to update the token of the settings reducer

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Right now there is only logic for this functionality and not something that can be trigger from the UI so that way I tested was triggering/dispatching the **settingsUpdateToken** action with data and see if the reducer state update based on that.

```
data = {
        token: {
          active: 'LSK',
          list: {
            LSK: true,
            BTC: true,
          },
        },
      };
```

You can change the active value from LSK to BTC and see how the active token now change.


### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
