### PR TITLE
Show hw wallet login link only if Trezor enabled - Closes #1993

### DIFF
--- a/src/components/splashscreen/splashscreen.js
+++ b/src/components/splashscreen/splashscreen.js
@@ -85,11 +85,13 @@ class Splashscreen extends React.Component {
               </Tooltip>
             </span>
 
+            {localStorage.getItem('trezor') ?
             <span className={styles.linkWrapper}>
               <Link className={`${styles.link} signin-hwWallet-button`} to={routes.hwWalletV2.path}>
                 {t('Sign in with a Hardware Wallet')}
               </Link>
-            </span>
+            </span> :
+            null}
           </div>
         </div>
       </React.Fragment>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#1993

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
By showing the link only if `localStorage.getItem('trezor')` is defined.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
- Open splash screen with `localStorage.setItem('trezor', true)` to see the link
- Open splash screen with `localStorage.removeItem('trezor')` to not see the link

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
