### PR TITLE
Clean up jest test output - Closes #1999

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ npm run test
 npm run test-live
 ```
 
+#### Run each time a file changes without generating test coverage report (it's faster)
+```
+NO_COV=true npm run test-live
+```
+
 ## Run end-to-end tests
 In order to run e2e tests you need to install [lisk-core](https://github.com/LiskHQ/lisk)
 

--- a/app/src/modules/autoUpdater.test.js
+++ b/app/src/modules/autoUpdater.test.js
@@ -83,8 +83,8 @@ describe('autoUpdater', () => {
 
   afterEach(() => {
     clock.restore();
-    console.error.restore();
-    console.log.restore();
+    console.error.restore(); // eslint-disable-line no-console
+    console.log.restore(); // eslint-disable-line no-console
   });
 
   it('should call params.autoUpdater.checkForUpdates', () => {
@@ -207,8 +207,9 @@ describe('autoUpdater', () => {
     autoUpdater(params);
     callbacks.error(error);
 
+    // eslint-disable-next-line no-console
     expect(console.error).to.have.been.calledWith('There was a problem updating the application');
-    expect(console.error).to.have.been.calledWith(error);
+    expect(console.error).to.have.been.calledWith(error); // eslint-disable-line no-console
   });
 });
 

--- a/app/src/modules/autoUpdater.test.js
+++ b/app/src/modules/autoUpdater.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai'; // eslint-disable-line import/no-extraneous-dependencies
-import sinon, { spy } from 'sinon'; // eslint-disable-line import/no-extraneous-dependencies
+import sinon, { spy, stub } from 'sinon'; // eslint-disable-line import/no-extraneous-dependencies
 import ipcMock from 'electron-ipc-mock'; // eslint-disable-line import/no-extraneous-dependencies
 import autoUpdater from './autoUpdater';
 
@@ -77,10 +77,14 @@ describe('autoUpdater', () => {
     clock = sinon.useFakeTimers({
       toFake: ['setTimeout', 'clearTimeout', 'Date', 'setInterval'],
     });
+    stub(console, 'error');
+    stub(console, 'log');
   });
 
   afterEach(() => {
     clock.restore();
+    console.error.restore();
+    console.log.restore();
   });
 
   it('should call params.autoUpdater.checkForUpdates', () => {
@@ -199,14 +203,12 @@ describe('autoUpdater', () => {
 
   it('should log any update error', () => {
     const error = new Error('Error: Can not find Squirrel');
-    const consoleSpy = spy(console, 'error');
 
     autoUpdater(params);
     callbacks.error(error);
 
-    expect(consoleSpy).to.have.been.calledWith('There was a problem updating the application');
-    expect(consoleSpy).to.have.been.calledWith(error);
-    consoleSpy.restore();
+    expect(console.error).to.have.been.calledWith('There was a problem updating the application');
+    expect(console.error).to.have.been.calledWith(error);
   });
 });
 

--- a/config/setupJest.js
+++ b/config/setupJest.js
@@ -12,6 +12,7 @@ import ReactPiwik from 'react-piwik';
 import crypto from 'crypto';
 // TODO remove next line after upgrading node version to at least 7
 import 'es7-object-polyfill';
+import { Line } from 'react-chartjs-2';
 
 require('jest-localstorage-mock');
 
@@ -76,3 +77,9 @@ const getSelection = () => ({
 });
 window.getSelection = getSelection;
 document.getSelection = getSelection;
+
+// https://stackoverflow.com/questions/53961469/testing-chart-js-with-jest-enzyme-failed-to-create-chart-cant-acquire-contex
+jest.mock('react-chartjs-2', () => ({
+  Line: () => null,
+  Chart: () => null,
+}));

--- a/config/setupJest.js
+++ b/config/setupJest.js
@@ -12,7 +12,6 @@ import ReactPiwik from 'react-piwik';
 import crypto from 'crypto';
 // TODO remove next line after upgrading node version to at least 7
 import 'es7-object-polyfill';
-import { Line } from 'react-chartjs-2';
 
 require('jest-localstorage-mock');
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -32,7 +32,7 @@ module.exports = {
   },
   collectCoverage: true,
   coverageDirectory: '<rootDir>/coverage/jest',
-  collectCoverageFrom: [
+  collectCoverageFrom: process.env.NO_COV ? [] : [
     'src/**/*.js',
     'app/src/**/*.js',
   ],
@@ -132,7 +132,7 @@ module.exports = {
     'src/components/headerV2/headerV2.js',
     'src/components/registerV2/registerV2.js',
   ],
-  coverageThreshold: {
+  coverageThreshold: process.env.NO_COV ? {} : {
     global: {
       branches: 90,
       functions: 90,

--- a/jest.config.js
+++ b/jest.config.js
@@ -157,6 +157,7 @@ module.exports = {
   },
   setupFiles: [
     '<rootDir>/config/setupJest.js',
+    'jest-canvas-mock',
   ],
   transform: {
     '^.+\\.js$': 'babel-jest',

--- a/jest.config.js
+++ b/jest.config.js
@@ -167,11 +167,13 @@ module.exports = {
     TEST: true,
     VERSION: '',
   },
-  coverageReporters: [
+  coverageReporters: process.env.ON_JENKINS ? [
     'text',
-    'html',
     'lcov',
     'cobertura',
+  ] : [
+    'html',
+    'json',
   ],
   reporters: [
     'default',

--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
     "identity-obj-proxy": "3.0.0",
     "imports-loader": "0.8.0",
     "jest": "23.6.0",
+    "jest-canvas-mock": "2.0.0",
     "jest-environment-enzyme": "7.0.1",
     "jest-enzyme": "7.0.1",
     "jest-junit": "5.2.0",

--- a/src/components/toolbox/calendar/yearView.test.js
+++ b/src/components/toolbox/calendar/yearView.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import moment from 'moment';
 import { shallow } from 'enzyme';
 import YearView from './yearView';
 
@@ -9,7 +10,7 @@ describe('Calendar YearView', () => {
     setCurrentView: jest.fn(),
     setShowingDate: jest.fn(),
     selectedDate: '',
-    showingDate: '01.03.19',
+    showingDate: moment('2019-03-01'),
   };
 
   beforeEach(() => {

--- a/src/components/toolbox/dropdownV2/dropdownV2.test.js
+++ b/src/components/toolbox/dropdownV2/dropdownV2.test.js
@@ -5,9 +5,10 @@ import DropdownV2 from './dropdownV2';
 
 describe('Dropdown V2', () => {
   let wrapper;
+  const DummyChild = () => <span></span>;
 
   beforeEach(() => {
-    wrapper = mount(<DropdownV2 showDropdown={false} />);
+    wrapper = mount(<DropdownV2 showDropdown={false} ><DummyChild /></DropdownV2>);
   });
 
   it('Should render with dropdown closed', () => {

--- a/src/components/transactionsV2/explorerTransactionsV2/explorerTransactionsV2.test.js
+++ b/src/components/transactionsV2/explorerTransactionsV2/explorerTransactionsV2.test.js
@@ -135,7 +135,7 @@ describe('ExplorerTransactions V2 Component', () => {
         rewards: '140500000000',
         username: accounts.delegate.username,
         vote: '9876965713168313',
-        lastBlock: { timestamp: 0 },
+        lastBlock: 0,
         txDelegateRegister: { timestamp: 0 },
       },
     };

--- a/src/components/transactionsV2/filters/amountFieldGroup.test.js
+++ b/src/components/transactionsV2/filters/amountFieldGroup.test.js
@@ -51,7 +51,7 @@ describe('AmountFieldGroup', () => {
   describe('Error handling', () => {
     it('Should handle amountFrom greater than amountTo', () => {
       wrapper.find('.amountFromInput input').simulate('change', { target: { name: 'amountFrom', value: '99.9' } });
-      wrapper.setProps({ filters: { ...props.filters, amountFrom: '99.9'} });
+      wrapper.setProps({ filters: { ...props.filters, amountFrom: '99.9' } });
       wrapper.find('.amountToInput input').simulate('change', { target: { name: 'amountTo', value: '99' } });
       jest.advanceTimersByTime(300);
       wrapper.update();

--- a/src/components/transactionsV2/filters/amountFieldGroup.test.js
+++ b/src/components/transactionsV2/filters/amountFieldGroup.test.js
@@ -51,7 +51,7 @@ describe('AmountFieldGroup', () => {
   describe('Error handling', () => {
     it('Should handle amountFrom greater than amountTo', () => {
       wrapper.find('.amountFromInput input').simulate('change', { target: { name: 'amountFrom', value: '99.9' } });
-      wrapper.setProps({ filters: { amountFrom: '99.9' } });
+      wrapper.setProps({ filters: { ...props.filters, amountFrom: '99.9'} });
       wrapper.find('.amountToInput input').simulate('change', { target: { name: 'amountTo', value: '99' } });
       jest.advanceTimersByTime(300);
       wrapper.update();

--- a/src/components/transactionsV2/walletTransactionsV2/walletTransactionsV2.test.js
+++ b/src/components/transactionsV2/walletTransactionsV2/walletTransactionsV2.test.js
@@ -133,7 +133,7 @@ describe('WalletTransactions V2 Component', () => {
           rewards: '140500000000',
           username: accounts.delegate.username,
           vote: '9876965713168313',
-          lastBlock: { timestamp: 0 },
+          lastBlock: 0,
           txDelegateRegister: { timestamp: 0 },
         },
       },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#1999

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
- Fixed setup of unit tests so that there are almost no warnings
<img width="681" alt="Screenshot 2019-05-10 at 14 40 32" src="https://user-images.githubusercontent.com/1254342/57579651-8f0b1100-749f-11e9-9479-edd64eb192b8.png">

- The only one I couldn't find a solution for is in `customRoute`
- Now it is more visible that some tests are slow and should be examined
<img width="749" alt="Screenshot 2019-05-10 at 14 40 42" src="https://user-images.githubusercontent.com/1254342/57579691-ee692100-749f-11e9-8edc-a9774aa193e6.png">

- I also created a new option to run tests without generating a test coverage report for faster TDD (see README.md)


### How has this been tested?
<!--- Please describe how you tested your changes. -->
Run `npm run test` and see the output.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
