### PR TITLE
Disable next button if second passphrase invalid - Closes #1957

### DIFF
--- a/src/components/sendV2/summary/summary.js
+++ b/src/components/sendV2/summary/summary.js
@@ -110,7 +110,7 @@ class Summary extends React.Component {
     this.setState({
       secondPassphrase: {
         ...this.state.secondPassphrase,
-        isValid: isPassphraseValid && !!error,
+        isValid: feedback === '' && passphrase !== '',
         feedback,
         value: passphrase,
       },
@@ -137,8 +137,6 @@ class Summary extends React.Component {
   render() {
     const { account, fields, t } = this.props;
     const { secondPassphrase, isHardwareWalletConnected } = this.state;
-    let isBtnDisabled = secondPassphrase.hasSecondPassphrase && secondPassphrase.feedback !== '' && !secondPassphrase.isValid;
-    isBtnDisabled = isBtnDisabled || isHardwareWalletConnected;
 
     const confirmBtnMessage = isHardwareWalletConnected
       ? t('Confirm on {{deviceModel}}', { deviceModel: account.hwInfo.deviceModel })
@@ -225,7 +223,11 @@ class Summary extends React.Component {
           <PrimaryButtonV2
             className={`${styles.confirmBtn} on-nextStep send-button`}
             onClick={this.nextStep}
-            disabled={isBtnDisabled}>
+            disabled={
+              (secondPassphrase.hasSecondPassphrase &&
+                !secondPassphrase.isValid)
+              || isHardwareWalletConnected
+            }>
             {confirmBtnMessage}
           </PrimaryButtonV2>
 

--- a/src/components/sendV2/summary/summary.js
+++ b/src/components/sendV2/summary/summary.js
@@ -100,30 +100,21 @@ class Summary extends React.Component {
   }
 
   checkSecondPassphrase(passphrase, error) {
-    // istanbul ignore else
-    if (!error) {
-      const expectedPublicKey = extractPublicKey(passphrase);
-      const isPassphraseValid = this.props.account.secondPublicKey === expectedPublicKey;
+    let feedback = error || '';
+    const expectedPublicKey = !error && extractPublicKey(passphrase);
+    const isPassphraseValid = this.props.account.secondPublicKey === expectedPublicKey;
 
-      if (isPassphraseValid) {
-        this.setState({
-          secondPassphrase: {
-            ...this.state.secondPassphrase,
-            isValid: true,
-            feedback: '',
-            value: passphrase,
-          },
-        });
-      } else {
-        this.setState({
-          secondPassphrase: {
-            ...this.state.secondPassphrase,
-            isValid: false,
-            feedback: this.props.t('Oops! Wrong passphrase'),
-          },
-        });
-      }
+    if (feedback === '' && !isPassphraseValid) {
+      feedback = this.props.t('Oops! Wrong passphrase');
     }
+    this.setState({
+      secondPassphrase: {
+        ...this.state.secondPassphrase,
+        isValid: isPassphraseValid && !!error,
+        feedback,
+        value: passphrase,
+      },
+    });
   }
 
   prevStep() {
@@ -146,8 +137,8 @@ class Summary extends React.Component {
   render() {
     const { account, fields, t } = this.props;
     const { secondPassphrase, isHardwareWalletConnected } = this.state;
-    let isBtnDisabled = secondPassphrase.hasSecondPassphrase && secondPassphrase.isValid !== '' && !secondPassphrase.isValid;
-    isBtnDisabled = !isBtnDisabled && isHardwareWalletConnected;
+    let isBtnDisabled = secondPassphrase.hasSecondPassphrase && secondPassphrase.feedback !== '' && !secondPassphrase.isValid;
+    isBtnDisabled = isBtnDisabled || isHardwareWalletConnected;
 
     const confirmBtnMessage = isHardwareWalletConnected
       ? t('Confirm on {{deviceModel}}', { deviceModel: account.hwInfo.deviceModel })

--- a/src/components/sendV2/summary/summary.test.js
+++ b/src/components/sendV2/summary/summary.test.js
@@ -99,7 +99,7 @@ describe('Summary', () => {
   });
 
   it('should disable "Next" button if secondPassphrase invalid for active account', () => {
-    expect(wrapper.find('.send-button').at(0).prop('disabled')).toBeFalsy();
+    expect(wrapper.find('.send-button').at(0).prop('disabled')).toBeTruthy();
     const clipboardData = {
       getData: () => accounts['second passphrase account'].passphrase,
     };

--- a/src/components/sendV2/summary/summary.test.js
+++ b/src/components/sendV2/summary/summary.test.js
@@ -98,6 +98,15 @@ describe('Summary', () => {
     expect(props.prevStep).toBeCalled();
   });
 
+  it('should disable "Next" button if secondPassphrase invalid for active account', () => {
+    expect(wrapper.find('.send-button').at(0).prop('disabled')).toBeFalsy();
+    const clipboardData = {
+      getData: () => accounts['second passphrase account'].passphrase,
+    };
+    wrapper.find('passphraseInputV2 input').first().simulate('paste', { clipboardData });
+    expect(wrapper.find('.send-button').at(0).prop('disabled')).toBeTruthy();
+  });
+
   it('should goind to next page if everyting is successfull', () => {
     const clipboardData = {
       getData: () => accounts['second passphrase account'].secondPassphrase,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#1957

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
- Fixed the `isBtnDisabled` condition
- Wrote a unit test to test it
- Refactored `checkSecondPassphrase` while I was figuring out how it works and what the fix should be.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Try to send with https://github.com/LiskHQ/lisk-hub/blob/804bea2d216e11d4f77dcd2c7174779b20cc1106/test/constants/accounts.js#L43-L47 on localhost

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
