### PR TITLE
Hide "Edit voting" button for hardware wallets - Closes #2097

### DIFF
--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -58,7 +58,7 @@
   "Auto-logout": "Auto-logout",
   "Back": "Back",
   "Back to Delegates": "Back to Delegates",
-  "Back to Voting": "Back to Voting",
+  "Back to Voting Table": "Back to Voting Table",
   "Back to wallet": "Back to wallet",
   "Balance": "Balance",
   "Balance details": "Balance details",

--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -58,7 +58,7 @@
   "Auto-logout": "Auto-logout",
   "Back": "Back",
   "Back to Delegates": "Back to Delegates",
-  "Back to Voting summary": "Back to Voting summary",
+  "Back to Voting": "Back to Voting",
   "Back to wallet": "Back to wallet",
   "Balance": "Balance",
   "Balance details": "Balance details",

--- a/src/components/transactionSummary/index.js
+++ b/src/components/transactionSummary/index.js
@@ -104,24 +104,24 @@ class TransactionSummary extends React.Component {
         : null
       }
     </div>
-    <footer className='summary-footer'>
-      {isHardwareWalletConnected ?
-        null :
-        <PrimaryButtonV2
-          className={`${styles.confirmBtn} confirm-button`}
-          disabled={
-            (!!account.secondPublicKey && !secondPassphrase.isValid) ||
-            confirmButton.disabled}
-          onClick={this.confirmOnClick}>
-          {confirmButton.label}
-        </PrimaryButtonV2>
-      }
-      <TertiaryButtonV2
-        className={`${styles.editBtn} cancel-button`}
-        onClick={cancelButton.onClick}>
-        {cancelButton.label}
-      </TertiaryButtonV2>
-    </footer>
+    {isHardwareWalletConnected ?
+      null :
+      <footer className='summary-footer'>
+          <PrimaryButtonV2
+            className={`${styles.confirmBtn} confirm-button`}
+            disabled={
+              (!!account.secondPublicKey && !secondPassphrase.isValid) ||
+              confirmButton.disabled}
+            onClick={this.confirmOnClick}>
+            {confirmButton.label}
+          </PrimaryButtonV2>
+        <TertiaryButtonV2
+          className={`${styles.editBtn} cancel-button`}
+          onClick={cancelButton.onClick}>
+          {cancelButton.label}
+        </TertiaryButtonV2>
+      </footer>
+    }
   </div>;
   }
 }

--- a/src/components/votingV2/votingSummary.js
+++ b/src/components/votingV2/votingSummary.js
@@ -55,7 +55,7 @@ const VotingSummary = ({
                   title: t('Voting failed'),
                   message: errorMessage || t('Oops, looks like something went wrong. Please try again.'),
                   primaryButon: {
-                    title: t('Back to Voting'),
+                    title: t('Back to Voting Table'),
                     onClick: () => {
                       history.push(routes.delegates.path);
                     },

--- a/src/components/votingV2/votingSummary.js
+++ b/src/components/votingV2/votingSummary.js
@@ -15,7 +15,7 @@ import VoteUrlProcessor from '../voteUrlProcessorV2';
 import styles from './votingV2.css';
 
 const VotingSummary = ({
-  t, votes, history, account, nextStep, votePlaced, prevStep, voteLookupStatus,
+  t, votes, history, account, nextStep, votePlaced, voteLookupStatus,
 }) => {
   const {
     maxCountOfVotes,
@@ -55,8 +55,10 @@ const VotingSummary = ({
                   title: t('Voting failed'),
                   message: errorMessage || t('Oops, looks like something went wrong. Please try again.'),
                   primaryButon: {
-                    title: t('Back to Voting summary'),
-                    onClick: prevStep,
+                    title: t('Back to Voting'),
+                    onClick: () => {
+                      history.push(routes.delegates.path);
+                    },
                   },
                   error: text,
                 }),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#2097

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
I changed the condition to hide not only the primary but also the secondary button in the case of a hardware wallet.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Try to vote with a hardware wallet.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
