### PR TITLE
Fix loading voted delegates - Closes #2093

### DIFF
--- a/src/components/votingListViewV2/votingListViewV2.js
+++ b/src/components/votingListViewV2/votingListViewV2.js
@@ -84,8 +84,7 @@ class VotingListViewV2 extends React.Component {
   }
 
   loadMore() {
-    const list = this.filter(this.props.delegates);
-    this.loadDelegates(this.query, false, list[list.length - 1].rank);
+    this.loadDelegates(this.query, false, this.props.delegates.length);
   }
 
   setActiveFilter(filter) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#2093


### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
The problem was that it was using the displayed list for getting the offset for the delegates api call. I changed it to use all loaded delegates list to determine the offset. This way user still has to click multiple times on "Load more", be at least will get the votes eventually. 

I didn't want to complicate the code to handle this situation since it is IMO quite an edge case.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Follow steps in #2093

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
