### PR TITLE
Implement logic to persist selected delegates to local storage - Closes #1974

### DIFF
--- a/config/setupJest.js
+++ b/config/setupJest.js
@@ -34,10 +34,10 @@ const localStorageMock = (() => {
   let store = {};
 
   return {
-    getItem: key => store[key] || null,
-    setItem: (key, value) => {
+    getItem: jest.fn().mockImplementation(key => store[key] || null),
+    setItem: jest.fn().mockImplementation((key, value) => {
       store[key] = value.toString();
-    },
+    }),
     removeItem: (key) => {
       delete store[key];
     },

--- a/src/actions/voting.js
+++ b/src/actions/voting.js
@@ -95,6 +95,11 @@ export const votePlaced = ({
     }
   };
 
+const addPersistedVotes = votesList => (
+  // TODO implement adding persisted votes
+  votesList
+);
+
 /**
  * Gets the list of delegates current account has voted for
  *
@@ -104,9 +109,10 @@ export const loadVotes = ({ address, type }) =>
     const liskAPIClient = getAPIClient(tokenMap.LSK.key, getState());
     getVotes(liskAPIClient, { address })
       .then((response) => {
+        const list = type === 'update' ? response.data.votes : addPersistedVotes(response.data.votes);
         dispatch({
           type: type === 'update' ? actionTypes.votesUpdated : actionTypes.votesAdded,
-          data: { list: response.data.votes },
+          data: { list },
         });
       });
   };

--- a/src/actions/voting.js
+++ b/src/actions/voting.js
@@ -1,6 +1,11 @@
 import to from 'await-to-js';
 
 import { addPendingTransaction } from './transactions';
+import {
+  addPersistedVotes,
+  getVotingError,
+  getVotingLists,
+} from '../utils/voting';
 import { errorToastDisplayed } from './toaster';
 import { getAPIClient } from '../utils/api/network';
 import { getTimeOffset } from '../utils/hacks';
@@ -9,12 +14,10 @@ import {
   getDelegates,
   castVotes,
 } from '../utils/api/delegates';
-import { getVotingLists, getVotingError } from '../utils/voting';
 import { passphraseUsed } from './account';
 import { tokenMap } from '../constants/tokens';
 import { updateDelegateCache } from '../utils/delegates';
 import actionTypes from '../constants/actions';
-import localJSONStorage from '../utils/localJSONStorage';
 
 /**
  * Add data to the list of all delegates
@@ -96,17 +99,6 @@ export const votePlaced = ({
       callback({ success: true });
     }
   };
-
-const addPersistedVotes = (address, votesList) => {
-  const votesDict = localJSONStorage.get(`votes-${address}`, {});
-  return votesList.map(vote => ({
-    ...vote,
-    unconfirmed: votesDict[vote.username] ? votesDict[vote.username].unconfirmed : true,
-    confirmed: votesDict[vote.username] ? votesDict[vote.username].confirmed : true,
-  })).concat(Object.keys(votesDict)
-    .filter(username => votesDict[username].unconfirmed)
-    .map(username => ({ username, ...votesDict[username] })));
-};
 
 /**
  * Gets the list of delegates current account has voted for

--- a/src/actions/voting.test.js
+++ b/src/actions/voting.test.js
@@ -142,7 +142,11 @@ describe('actions: voting', () => {
     const data = {
       address: '8096217735672704724L',
     };
-    const delegates = delegateList;
+    const delegates = delegateList.map(delegate => ({
+      ...delegate,
+      confirmed: true,
+      unconfirmed: true,
+    }));
 
     beforeEach(() => {
       delegateApiMock = sinon.stub(delegateApi, 'getVotes').returnsPromise();

--- a/src/components/delegates/delegates.js
+++ b/src/components/delegates/delegates.js
@@ -18,6 +18,12 @@ class Delegates extends React.Component {
     this.getOnboardingSlides = this.getOnboardingSlides.bind(this);
   }
 
+  componentDidUpdate() {
+    if (getTotalActions(this.props.votes) > 0 && !this.state.votingModeEnabled) {
+      this.setState({ votingModeEnabled: true });
+    }
+  }
+
   toggleVotingMode() {
     if (this.state.votingModeEnabled) {
       this.props.clearVotes();

--- a/src/components/delegates/delegates.test.js
+++ b/src/components/delegates/delegates.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import PropTypes from 'prop-types';
 import thunk from 'redux-thunk';
 import { BrowserRouter as Router } from 'react-router-dom';
@@ -65,5 +65,21 @@ describe('Delegates', () => {
     wrapper.find('.cancel-voting-button').at(0).simulate('click');
     expect(wrapper.find('.addedVotes')).to.have.lengthOf(0);
   });
-});
 
+  it('should enable voting mode if votes.props stops being empty', () => {
+    wrapper = shallow(<Delegates {...{ ...props, votes: {} } } />);
+    expect(wrapper.find('VotingHeader')).to.have.prop('votingModeEnabled', false);
+    wrapper.setProps({
+      votes: {
+        username1: {
+          confirmed: false,
+          unconfirmed: true,
+          username: 'username1',
+          publicKey: 'sample_key',
+        },
+      },
+    });
+    wrapper.update();
+    expect(wrapper.find('VotingHeader')).to.have.prop('votingModeEnabled', true);
+  });
+});

--- a/src/store/middlewares/voting.js
+++ b/src/store/middlewares/voting.js
@@ -70,12 +70,21 @@ const fetchVotes = (store) => {
   }));
 };
 
+const persistVotes = (account, votes) => {
+  console.log('TODO implement persisting votes', account, votes); // eslint-disable-line no-console
+};
+
 const votingMiddleware = store => next => (action) => {
   next(action);
   switch (action.type) {
     case actionTypes.votesAdded:
       fetchVotes(store);
       lookupDelegatesFromUrl(store, action);
+      break;
+    case actionTypes.votesUpdated:
+    case actionTypes.votesCleared:
+    case actionTypes.voteToggled:
+      persistVotes(store.account, store.voting.votes);
       break;
     case actionTypes.accountLoggedOut:
       store.dispatch(delegatesAdded({ list: [] }));

--- a/src/store/middlewares/voting.js
+++ b/src/store/middlewares/voting.js
@@ -1,7 +1,7 @@
 import { getDelegates } from '../../utils/api/delegates';
 import { loadDelegateCache } from '../../utils/delegates';
 import { persistVotes } from '../../utils/voting';
-import { voteLookupStatusUpdated, voteToggled, loadVotes, delegatesAdded } from '../../actions/voting';
+import { voteLookupStatusUpdated, voteToggled, delegatesAdded } from '../../actions/voting';
 import actionTypes from '../../constants/actions';
 
 const updateLookupStatus = (store, list, username) => {
@@ -60,23 +60,11 @@ const lookupDelegatesFromUrl = (store, action) => {
   }
 };
 
-const fetchVotes = (store) => {
-  // TODO investigate if this function is needed here at all
-  // or maybe it should be moved somewhere else (e.g. urlVotesFound action)
-  const state = store.getState();
-  const address = state.account.address;
-  store.dispatch(loadVotes({
-    address,
-    type: 'update',
-  }));
-};
-
 const votingMiddleware = store => next => (action) => {
   next(action);
   const state = store.getState();
   switch (action.type) {
     case actionTypes.votesAdded:
-      fetchVotes(store);
       lookupDelegatesFromUrl(store, action);
       break;
     case actionTypes.votesUpdated:

--- a/src/store/reducers/voting.js
+++ b/src/store/reducers/voting.js
@@ -51,14 +51,7 @@ const voting = (state = { // eslint-disable-line complexity
         ...state,
         votes: action.data.list
           .reduce((votesDict, delegate) => {
-            votesDict[delegate.username] = {
-              confirmed: true,
-              unconfirmed: true,
-              publicKey: delegate.publicKey,
-              productivity: delegate.productivity,
-              rank: delegate.rank,
-              address: delegate.address,
-            };
+            votesDict[delegate.username] = delegate;
             return votesDict;
           }, {}),
       };

--- a/src/store/reducers/voting.test.js
+++ b/src/store/reducers/voting.test.js
@@ -76,8 +76,8 @@ describe('Reducer: voting(state, action)', () => { // eslint-disable-line max-st
     };
     const expectedState = {
       votes: {
-        username1: { confirmed: true, unconfirmed: true, ...delegate1 },
-        username2: { confirmed: true, unconfirmed: true, ...delegate2 },
+        username1: { ...delegate1, username: 'username1' },
+        username2: { ...delegate2, username: 'username2' },
       },
       delegates: [],
     };

--- a/src/utils/voting.js
+++ b/src/utils/voting.js
@@ -80,4 +80,3 @@ export const persistVotes = (address, votes) => {
     }, {}),
   );
 };
-

--- a/src/utils/voting.test.js
+++ b/src/utils/voting.test.js
@@ -1,0 +1,72 @@
+import { addPersistedVotes, getPersistedVotes, persistVotes } from './voting';
+
+describe('Utils: voting', () => {
+  const address = '1240978124L';
+  const votesDict = {
+    username1: {
+      confirmed: true,
+      unconfirmed: false,
+      publicKey: 'random_public_key_1',
+      username: 'username1',
+    },
+    username2: {
+      confirmed: true,
+      unconfirmed: false,
+      publicKey: 'random_public_key_2',
+      username: 'username2',
+    },
+    username3: {
+      confirmed: false,
+      unconfirmed: true,
+      publicKey: 'random_public_key_3',
+      username: 'username3',
+    },
+    username5: {
+      confirmed: false,
+      unconfirmed: false,
+      publicKey: 'random_public_key_5',
+      username: 'username5',
+    },
+  };
+  const votesList = [{
+    ...votesDict.username1,
+  }, {
+    ...votesDict.username2,
+    unconfirmed: true,
+  }, {
+    confirmed: true,
+    unconfirmed: true,
+    publicKey: 'random_public_key_4',
+    username: 'username4',
+  }];
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  describe('getPersistedVotes', () => {
+    it('should load votes from localStorage', () => {
+      localStorage.setItem(`votes-${address}`, JSON.stringify(votesDict));
+      expect(getPersistedVotes(address)).toEqual(votesDict);
+    });
+  });
+
+  describe('persistVotes', () => {
+    it('should store votes to localStorage', () => {
+      persistVotes(address, votesDict);
+      expect(localStorage.setItem).toHaveBeenCalledWith(`votes-${address}`, JSON.stringify(votesDict));
+    });
+  });
+
+  describe('addPersistedVotes', () => {
+    it('should return votesDict with vote statuses from localStorage', () => {
+      localStorage.setItem(`votes-${address}`, JSON.stringify(votesDict));
+      expect(addPersistedVotes(address, votesList)).toEqual([
+        votesDict.username1,
+        votesDict.username2,
+        votesList[2],
+        votesDict.username3,
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#1974 

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
- votes that were locally changed are persisted into `votes-${account.address}` `localStorage` on relevant actions in voting middleware.
- this localStorage is used to update the status of votes when loading from server.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
- Select some delegates, and refresh the page - you should still see them
- Select some delegates, "Cancel voting", and refresh the page -  you shouldn't see any delegates selected

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
