### PR TITLE
Transaction Detail for BTC showing same address for sender and recipient

### DIFF
--- a/src/components/transactionsV2/transactionRowV2.js
+++ b/src/components/transactionsV2/transactionRowV2.js
@@ -65,7 +65,7 @@ class TransactionRowV2 extends React.Component {
             transactionType={value.type}
           />
           <TransactionAddress
-            address={value.recipientId}
+            address={props.address === value.senderId ? value.recipientId : value.senderId }
             bookmarks={props.bookmarks}
             t={props.t}
             token={token}

--- a/src/components/transactionsV2/transactionRowV2.js
+++ b/src/components/transactionsV2/transactionRowV2.js
@@ -51,51 +51,63 @@ class TransactionRowV2 extends React.Component {
   }
 
   render() {
-    const { props } = this;
-    const { value, token } = props;
-    const onClick = props.onClick || (() => {});
-    const hasConfirmations = props.value.confirmations && props.value.confirmations > 0;
+    const {
+      address,
+      bookmarks,
+      onClick,
+      t,
+      token,
+      value,
+    } = this.props;
+
     const { isConfirmed } = this.state;
+    const hasConfirmations = value.confirmations && value.confirmations > 0;
+
     return (
-      <TableRow className={`${grid.row} ${styles.row} ${!hasConfirmations ? styles.pending : ''} transactions-row`} onClick={() => onClick(props)}>
+      <TableRow className={`${grid.row} ${styles.row} ${!hasConfirmations ? styles.pending : ''} transactions-row`} onClick={() => onClick(this.props)}>
         <div className={`${grid['col-sm-4']} ${grid['col-lg-3']} transactions-cell`}>
-          <Icon name={props.address === value.senderId ? 'outgoing' : 'incoming' } className={styles.inOutIcon} />
+          <Icon name={address === value.senderId ? 'outgoing' : 'incoming' } className={styles.inOutIcon} />
           <TransactionTypeFigure
-            address={props.address === value.senderId ? value.recipientId : value.senderId }
+            address={address === value.senderId ? value.recipientId : value.senderId }
             transactionType={value.type}
           />
           <TransactionAddress
-            address={props.address === value.senderId ? value.recipientId : value.senderId }
-            bookmarks={props.bookmarks}
-            t={props.t}
+            address={address === value.senderId ? value.recipientId : value.senderId }
+            bookmarks={bookmarks}
+            t={t}
             token={token}
             transactionType={value.type}
           />
         </div>
         <div className={`${grid['col-sm-2']} ${grid['col-lg-2']} transactions-cell`}>
           <div className={`${styles.status} ${!isConfirmed ? styles.showSpinner : styles.showDate}`}>
-            <SpinnerV2 completed={hasConfirmations} label={props.t('Pending...')} />
-            <DateTimeFromTimestamp time={props.value.timestamp} token={token} />
+            <SpinnerV2 completed={hasConfirmations} label={t('Pending...')} />
+            <DateTimeFromTimestamp time={value.timestamp} token={token} />
           </div>
         </div>
         <div className={`${grid['col-sm-1']} ${grid['col-lg-2']} transactions-cell`}>
-          <LiskAmount val={props.value.fee}/>&nbsp;{token}
+          <LiskAmount val={value.fee}/>&nbsp;{token}
         </div>
           <div className={`${grid['col-sm-3']} ${grid['col-lg-3']} transactions-cell`}>
             <TransactionDetailV2
-              t={props.t}
-              transaction={props.value} />
+              t={t}
+              transaction={value} />
           </div>
         <div className={`${grid['col-sm-2']} ${grid['col-lg-2']} transactions-cell`}>
           <TransactionAmount
-            address={props.address}
+            address={address}
             token={token}
-            transaction={props.value}
+            transaction={value}
           />
         </div>
       </TableRow>
     );
   }
 }
+
+/* istanbul ignore next */
+TransactionRowV2.defaultProps = {
+  onClick: () => {},
+};
 
 export default translate()(TransactionRowV2);

--- a/src/utils/api/btc/transactions.js
+++ b/src/utils/api/btc/transactions.js
@@ -41,8 +41,9 @@ const normalizeTransactionsResponse = ({
     address = address || tx.inputs[0].txDetail.scriptPubKey.addresses[0];
     const output = tx.outputs.find(o => o.scriptPubKey.addresses.includes(address));
     const extractedAddress = tx.inputs[0].txDetail.scriptPubKey.addresses[0];
+    const recipientAddress = tx.outputs[0].scriptPubKey.addresses[0];
     data.senderId = validateAddress(tokenMap.BTC.key, extractedAddress) === 0 ? extractedAddress : 'Unparsed Address';
-    data.recipientId = address;
+    data.recipientId = validateAddress(tokenMap.BTC.key, recipientAddress) === 0 ? recipientAddress : 'Unparsed Address';
     data.amount = output.satoshi;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #2051 

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Update the API BTC transaction normalize function to properly get the information and arrange it as should be without pass address parameter to the function

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Switch to BTC active token
go to wallet
check send/receive tx details
then it doesn't be showing the same address to the tx details.


### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
