### PR TITLE
Copy to clipboard not working on wallet page - Closes #2154

### DIFF
--- a/src/components/toolbox/copyToClipboard/index.js
+++ b/src/components/toolbox/copyToClipboard/index.js
@@ -54,10 +54,12 @@ class CopyToClipboard extends React.Component {
   }
 }
 
+const DefaultContainer = ({ children, onClick }) => <span onClick={onClick} >{children}</span>;
+
 CopyToClipboard.defaultProps = {
   className: '',
   copyClassName: '',
-  Container: React.Fragment,
+  Container: DefaultContainer,
 };
 
 export default (translate()(CopyToClipboard));

--- a/src/components/toolbox/copyToClipboard/index.test.js
+++ b/src/components/toolbox/copyToClipboard/index.test.js
@@ -4,8 +4,7 @@ import PropTypes from 'prop-types';
 import i18n from '../../../i18n';
 import CopyToClipboard from './index';
 
-// TODO Figure out why adding Container prop to CopyToClipboard breaks the tests and fix them
-describe.skip('CopyToClipboard', () => {
+describe('CopyToClipboard', () => {
   let wrapper;
   const props = {
     text: 'test',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#2154 

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Cherry picked commit 414a56e37eceeff4c53e9c69f5eb517b71c8ddd9 fixing defaultContainer for copyToClipboard component  on toolbox.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Go to `/wallet` and try clicking on the address to copy and the copy link in request dropdown.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
