### PR TITLE
Disconnecting wallet doesn't log you out - closes #2209

### DIFF
--- a/src/store/middlewares/hwWallet.js
+++ b/src/store/middlewares/hwWallet.js
@@ -34,9 +34,10 @@ const hwWalletMiddleware = store => next => (action) => {
 
     ipc.on('hwDisconnected', (event, { model }) => {
       const state = store.getState();
-      const { account } = state;
+      const { account, settings } = state;
+      const activeToken = settings.token.active || 'LSK';
 
-      if (account.address) {
+      if (account.info[activeToken].address) {
         if (account.hwInfo && account.hwInfo.deviceId) {
           store.dispatch(dialogDisplayed({
             childComponent: Alert,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #2209

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
The hardware wallet middleware had a wrong validation for detect when the wallet is disconnected, so in this PR I just update that middleware and not is working properly.


### How has this been tested?
<!--- Please describe how you tested your changes. -->

1. Run the app in electron.
2. Login using a hardware wallet (ledger nano S).
3. Once into the app remove the device (the wire) connection.
4. A dialog should show up and then after user confirm logout


### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
