### PR TITLE
Cancelling transfer tx on ledger doesn't show transactions failed screen - Closes #2207

### DIFF
--- a/src/components/sendV2/send.js
+++ b/src/components/sendV2/send.js
@@ -30,6 +30,7 @@ class Send extends React.Component {
 
   render() {
     const { fields } = this.state;
+    const { history } = this.props;
 
     return (
       <div className={styles.container}>
@@ -40,7 +41,7 @@ class Send extends React.Component {
             className={styles.wrapper}>
             <Form fields={fields} />
             <Summary />
-            <TransactionStatus history={this.props.history}/>
+            <TransactionStatus history={history}/>
           </MultiStep>
         </div>
       </div>

--- a/src/components/sendV2/summary/summary.js
+++ b/src/components/sendV2/summary/summary.js
@@ -1,9 +1,11 @@
+/* eslint-disable max-lines */
 import React from 'react';
 import ConverterV2 from '../../converterV2';
 import AccountVisual from '../../accountVisual/index';
 import { PrimaryButtonV2, TertiaryButtonV2 } from '../../toolbox/buttons/button';
 import fees from '../../../constants/fees';
 import { fromRawLsk, toRawLsk } from '../../../utils/lsk';
+import { loginType } from '../../../constants/hwConstants';
 import PassphraseInputV2 from '../../passphraseInputV2/passphraseInputV2';
 import Tooltip from '../../toolbox/tooltip/tooltip';
 import links from '../../../constants/externalLinks';
@@ -108,7 +110,22 @@ class Summary extends React.Component {
   }
 
   checkForSuccessOrFailedTransactions() {
-    const { transactions, nextStep, fields } = this.props;
+    const {
+      account,
+      fields,
+      nextStep,
+      transactions,
+    } = this.props;
+
+    if (account.loginType !== loginType.normal && transactions.transactionsCreatedFailed.length) {
+      nextStep({
+        fields: {
+          ...fields,
+          hwTransactionStatus: 'error',
+          isHardwareWalletConnected: true,
+        },
+      });
+    }
 
     if (transactions.transactionsCreated.length && !transactions.transactionsCreatedFailed.length) {
       nextStep({

--- a/src/components/sendV2/transactionStatus/transactionStatus.js
+++ b/src/components/sendV2/transactionStatus/transactionStatus.js
@@ -25,7 +25,8 @@ class TransactionStatus extends React.Component {
   }
 
   componentDidMount() {
-    this.props.searchAccount({ address: this.props.fields.recipient.address });
+    const { searchAccount, fields } = this.props;
+    searchAccount({ address: fields.recipient.address });
     this.transactionBroadcasted();
   }
 
@@ -35,8 +36,15 @@ class TransactionStatus extends React.Component {
   }
 
   transactionBroadcasted() {
-    const { transactions: { transactionsCreated }, transactionBroadcasted } = this.props;
-    transactionsCreated.forEach(tx => transactionBroadcasted(tx));
+    const {
+      transactions: { transactionsCreated, transactionsCreatedFailed },
+      transactionBroadcasted,
+    } = this.props;
+
+    if (transactionsCreated.length) transactionsCreated.forEach(tx => transactionBroadcasted(tx));
+    if (transactionsCreatedFailed.length) {
+      transactionsCreatedFailed.forEach(tx => transactionBroadcasted(tx));
+    }
   }
 
   onBookmarkDropdownToggle() {
@@ -106,8 +114,21 @@ class TransactionStatus extends React.Component {
   }
 
   onRetry() {
-    const { transactions: { broadcastedTransactionsError }, transactionBroadcasted } = this.props;
-    broadcastedTransactionsError.forEach(({ transaction }) => transactionBroadcasted(transaction));
+    const {
+      transactions: { broadcastedTransactionsError },
+      transactionBroadcasted,
+      fields,
+      prevStep,
+      resetTransactionResult,
+    } = this.props;
+
+    if (fields.isHardwareWalletConnected) {
+      resetTransactionResult();
+      prevStep({ ...fields, hwTransactionStatus: false });
+    } else {
+      broadcastedTransactionsError.forEach(({ transaction }) =>
+        transactionBroadcasted(transaction));
+    }
   }
 
   render() {

--- a/src/components/sendV2/transactionStatus/transactionStatus.test.js
+++ b/src/components/sendV2/transactionStatus/transactionStatus.test.js
@@ -113,7 +113,7 @@ describe('TransactionStatus', () => {
     expect(props.finalCallback).toBeCalled();
   });
 
-  it('should call onPrevStep function', () => {
+  it('should call onPrevStep function on hwWallet', () => {
     const newProps = { ...props };
     newProps.fields.isHardwareWalletConnected = true;
     newProps.fields.hwTransactionStatus = 'error';
@@ -121,6 +121,23 @@ describe('TransactionStatus', () => {
       error: { message: 'errorMessage' },
       transaction: { recipient: '123L', amount: 1, reference: 'test' },
     }];
+    wrapper = mount(<TransactionStatus {...newProps} />, options);
+    expect(wrapper).toContainMatchingElement('.report-error-link');
+    wrapper.find('.retry').at(0).simulate('click');
+    expect(props.prevStep).toBeCalled();
+  });
+
+  it('should call broadcast function again in retry', () => {
+    const newProps = { ...props };
+    newProps.transactions = {
+      broadcastedTransactionsError: [{
+        error: { message: 'errorMessage' },
+        transaction: { recipient: '123L', amount: 1, reference: 'test' },
+      }],
+      transactionsCreated: [{ id: 1 }],
+      transactionsCreatedFailed: [{ id: 2 }],
+    };
+
     wrapper = mount(<TransactionStatus {...newProps} />, options);
     expect(wrapper).toContainMatchingElement('.report-error-link');
     wrapper.find('.retry').at(0).simulate('click');

--- a/src/store/reducers/transactions.js
+++ b/src/store/reducers/transactions.js
@@ -101,7 +101,7 @@ const transactions = (state = initialState, action) => { // eslint-disable-line 
       return {
         ...state,
         transactionsCreated: [],
-        transactionsFailed: [],
+        transactionsCreatedFailed: [],
         broadcastedTransactionsError: [],
       };
     case (actionTypes.accountSwitched):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #2207 

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
In this PR I had to update the transactions reducer as there was a problem when reset the transactions status and that was causing that was not clearing properly the object, after this part of the problem is fix the other part is related the logic of how the hardware wallets works.

So after update the send Summary and send Status components that application is able to check properly for when the tx is signed in case of approve and submit an error in case of cancel it, because of this change the logic for detect if a tx was successfully submitted or if failed needed to update in the status component.

### How has this been tested?
<!--- Please describe how you tested your changes. -->

1. Using the hardware wallet Ledger Nano S login to the desktop application.
2. Then go to Wallet -> Send
3. Fill the form for submit.
4. Then in the Summary page you can cancel or accept the tx, if you cancel the tx you will see a properly error message with details.

**NOTE:** All the send components can be improve and reduce the amount of code and the ticket for make this improvement is #2159 


### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
