### PR TITLE
Align Help center page with the latest design - Closes #2205

### DIFF
--- a/src/components/help/help.css
+++ b/src/components/help/help.css
@@ -94,8 +94,7 @@
   }
 
   & p {
-    margin: 0;
-    padding: 0;
+    margin-top: 0;
     margin-bottom: 29px;
   }
 
@@ -103,6 +102,7 @@
     text-align: center;
     width: 228px;
     border-radius: 3px;
+    margin-left: 8px;
   }
 
   & ul {
@@ -132,6 +132,14 @@
   .articleContainer {
     padding-right: 0 !important;
     padding-left: 0 !important;
+
+    & p {
+      padding-right: 85px;
+    }
+
+    & button {
+      margin-left: 0;
+    }
   }
 
   .wrapper {

--- a/src/components/help/help.js
+++ b/src/components/help/help.js
@@ -45,29 +45,31 @@ class Help extends React.Component {
             <Illustration name='helpCenter' />
           </section>
         </section>
-
         <section className={`${grid.row} ${styles.helpSection} help-articles`}>
           <article className={`${grid['col-sm-12']} ${grid['col-md-4']} ${styles.articleContainer}`}>
             <h4>
               <Icon name='helpCenter' className={styles.titleIcon} />
               {this.props.t('Help Center')}
             </h4>
-            <p className={styles.faqWrapper}>
-              {this.props.t('Perhaps your question has already been raised in our FAQ')}
-            </p>
-            <Button className='help-visit-center' onClick={() => this.visitHelpCenter() }>
-              {this.props.t('Visit Help Center')}
-            </Button>
+            <section className={grid.row}>
+              <p className={`${grid['col-sm-6']} ${grid['col-md-12']}`}>
+                {this.props.t('Perhaps your question has already been raised in our FAQ')}
+              </p>
+              <Button className='help-visit-center' onClick={() => this.visitHelpCenter() }>
+                {this.props.t('Visit Help Center')}
+              </Button>
+            </section>
           </article>
-
           <article className={`${grid['col-sm-12']} ${grid['col-md-4']} ${styles.articleContainer}`}>
             <h4>
               <Icon name='academy' className={styles.titleIcon} />
               {this.props.t('Academy')}
             </h4>
-              <p>{this.props.t('Learn about blockchain with our comprehensive knowledge base.')}
+            <section className={grid.row}>
+              <p className={`${grid['col-sm-6']} ${grid['col-md-12']}`}>
+                {this.props.t('Learn about blockchain with our comprehensive knowledge base.')}
               </p>
-              <div>
+              <div className={grid['col-sm-6']}>
                 <ul>
                   <li>
                     <a target='_blank' href={links.explainBlockchain} rel='noopener noreferrer'>
@@ -89,18 +91,18 @@ class Help extends React.Component {
                   </li>
                 </ul>
               </div>
+            </section>
           </article>
-
           <article className={`${grid['col-sm-12']} ${grid['col-md-4']} ${styles.articleContainer}`}>
             <h4>
               <Icon name='liskChat' className={styles.titleIcon} />
               {this.props.t('Lisk.Chat')}
             </h4>
-              <div>
-                <p>{this.props.t('Don’t be a stranger! Connect with our worldwide community.')}
-                </p>
-              </div>
-              <div>
+            <section className={grid.row}>
+              <p className={`${grid['col-sm-6']} ${grid['col-md-12']}`}>
+                {this.props.t('Don’t be a stranger! Connect with our worldwide community.')}
+              </p>
+              <div className={grid['col-sm-6']}>
                 <ul>
                   <li>
                     <a target='_blank' href={links.liskChat} rel='noopener noreferrer'>
@@ -116,6 +118,7 @@ class Help extends React.Component {
                   </li>
                 </ul>
               </div>
+            </section>
           </article>
         </section>
       </Box>


### PR DESCRIPTION
### What issue have I solved?
It is described in #2205.


### How has this been tested?
The design of the help center page on small breakpoint should be aligned with the latest design.


### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
