### PR TITLE
Fix load more transactions - Closes #2267

### DIFF
--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -108,7 +108,7 @@ export const searchAccount = ({ address }) =>
   };
 
 export const searchTransactions = ({
-  address, limit, filter, showLoading = true, customFilters = {},
+  address, limit, offset, filter, showLoading = true, customFilters = {},
   actionType = actionTypes.searchTransactions,
 }) =>
   (dispatch, getState) => {
@@ -123,7 +123,7 @@ export const searchTransactions = ({
     /* istanbul ignore else */
     if (networkConfig) {
       getTransactions({
-        networkConfig, address, limit, filters,
+        networkConfig, address, limit, offset, filters,
       })
         .then((transactionsResponse) => {
           dispatch({


### PR DESCRIPTION
It didn't set the offset and loaded same transactions again

<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#2267 

The bug was introduced by me in https://github.com/LiskHQ/lisk-hub/commit/acb4db919a9fc5ad88e3600dcbd140c9d369dcc3#diff-2388babe98c94f40ee0790c31b155968 during the redux refactor.

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
`offset` param was missing in the action.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Follow steps in #2267

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
