### PR TITLE
Fix e2e flaky test on 1.19

### DIFF
--- a/test/constants/selectors.js
+++ b/test/constants/selectors.js
@@ -232,6 +232,7 @@ const ss = {
   walletHeader: '.wallet-header',
   toast: '.toast',
   confirmDelegateButton: '.confirm-button',
+  coinRow: '.coin-row',
 };
 
 export default ss;

--- a/test/constants/settings.js
+++ b/test/constants/settings.js
@@ -1,0 +1,24 @@
+/**
+ * Generates setting object as needed.
+ * @param {Object} options -> Object data to update generated settings as needed.
+ * @returns Object with default settings to put into localStorage.
+ */
+const getSettings = ({ btc = false }) => ({
+  areTermsOfUseAccepted: true,
+  token: {
+    list: {
+      BTC: btc,
+    },
+  },
+});
+
+const settings = getSettings({});
+const settingsWithBtc = getSettings({ btc: true });
+
+const setSettings = data => window.localStorage.setItem('settings', JSON.stringify(data));
+
+export default {
+  settings,
+  settingsWithBtc,
+  setSettings,
+};

--- a/test/constants/settings.js
+++ b/test/constants/settings.js
@@ -1,24 +1,10 @@
-/**
- * Generates setting object as needed.
- * @param {Object} options -> Object data to update generated settings as needed.
- * @returns Object with default settings to put into localStorage.
- */
-const getSettings = ({ btc = false }) => ({
+const settings = {
   areTermsOfUseAccepted: true,
   token: {
     list: {
-      BTC: btc,
+      BTC: false,
     },
   },
-});
-
-const settings = getSettings({});
-const settingsWithBtc = getSettings({ btc: true });
-
-const setSettings = data => window.localStorage.setItem('settings', JSON.stringify(data));
-
-export default {
-  settings,
-  settingsWithBtc,
-  setSettings,
 };
+
+export default settings;

--- a/test/cypress/e2e/login.spec.js
+++ b/test/cypress/e2e/login.spec.js
@@ -3,6 +3,7 @@ import { fromRawLsk } from '../../../src/utils/lsk';
 import accounts from '../../constants/accounts';
 import ss from '../../constants/selectors';
 import urls from '../../constants/urls';
+import { settingsWithBtc, setSettings } from '../../constants/settings';
 import chooseNetwork from '../utils/chooseNetwork';
 import loginUI from '../utils/loginUI';
 
@@ -111,5 +112,23 @@ describe('Login Page', () => {
     chooseNetwork('invalid');
     loginUI(accounts.genesis.passphrase);
     cy.get(ss.errorPopup).contains('Unable to connect to the node');
+  });
+
+  describe('Login with BTC enabled', () => {
+    beforeEach(() => {
+      cy.server();
+      cy.route('/account/**').as('btcAccount');
+      setSettings({ ...settingsWithBtc, showNetwork: true });
+    });
+
+    ['main', 'test', 'dev'].forEach((name) => {
+      it(`Login to ${name}net with BTC enable`, () => {
+        cy.visit(urls.login);
+        chooseNetwork(name);
+        loginUI(accounts.genesis.passphrase);
+        cy.wait('@btcAccount');
+        cy.get(ss.coinRow).should('have.length', 2);
+      });
+    });
   });
 });

--- a/test/cypress/e2e/login.spec.js
+++ b/test/cypress/e2e/login.spec.js
@@ -3,7 +3,6 @@ import { fromRawLsk } from '../../../src/utils/lsk';
 import accounts from '../../constants/accounts';
 import ss from '../../constants/selectors';
 import urls from '../../constants/urls';
-import { settingsWithBtc, setSettings } from '../../constants/settings';
 import chooseNetwork from '../utils/chooseNetwork';
 import loginUI from '../utils/loginUI';
 
@@ -116,9 +115,13 @@ describe('Login Page', () => {
 
   describe('Login with BTC enabled', () => {
     beforeEach(() => {
+      const btcSettings = {
+        showNetwork: true,
+        token: { list: { BTC: true } },
+      };
       cy.server();
       cy.route('/account/**').as('btcAccount');
-      setSettings({ ...settingsWithBtc, showNetwork: true });
+      cy.mergeObjectWithLocalStorage('settings', btcSettings);
     });
 
     ['main', 'test', 'dev'].forEach((name) => {

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -24,7 +24,8 @@
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 import networks from '../../constants/networks';
-import { settings, setSettings } from '../../constants/settings';
+import settings from '../../constants/settings';
+import { deepMergeObj } from '../../../src/utils/helpers';
 
 before(() => {
   // Check if lisk core is running
@@ -32,11 +33,17 @@ before(() => {
 });
 
 beforeEach(() => {
-  setSettings(settings);
+  window.localStorage.setItem('settings', JSON.stringify(settings));
 });
 
 Cypress.Commands.add('addToLocalStorage', (item, value) => {
   window.localStorage.setItem(item, value);
+});
+
+Cypress.Commands.add('mergeObjectWithLocalStorage', (item, data) => {
+  const localStorageData = JSON.parse(window.localStorage.getItem(item)) || {};
+  const newData = JSON.stringify(deepMergeObj(localStorageData, data));
+  window.localStorage.setItem(item, newData);
 });
 
 Cypress.Commands.add('addObjectToLocalStorage', (item, key, value) => {

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -24,6 +24,7 @@
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 import networks from '../../constants/networks';
+import { settings, setSettings } from '../../constants/settings';
 
 before(() => {
   // Check if lisk core is running
@@ -31,7 +32,7 @@ before(() => {
 });
 
 beforeEach(() => {
-  window.localStorage.setItem('settings', '{"areTermsOfUseAccepted": true}');
+  setSettings(settings);
 });
 
 Cypress.Commands.add('addToLocalStorage', (item, value) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#2273 
This fix is only for 1.19.x since for the 1.20.x the implementation of cucumber was merged, and will need another PR for that one.

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Added a utils to easily update settings on localStorage;  
Disabled BTC by default on tests;  
Created scenarios to to test login with BTC enabled.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
e2e should not be failing anymore.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
