### PR TITLE
Fix e2e flaky tests - Closes #2273

### DIFF
--- a/test/constants/settings.js
+++ b/test/constants/settings.js
@@ -1,3 +1,5 @@
+import { deepMergeObj } from '../../src/utils/helpers';
+
 /**
  * Generates setting object as needed.
  * @param {Object} options -> Object data to update generated settings as needed.
@@ -13,14 +15,15 @@ const getSettings = ({ btc = false, showNetwork = false }) => ({
   },
 });
 
-const settings = getSettings({});
 const settingsWithBtc = getSettings({ btc: true });
 
-const setSettings = data => window.localStorage.setItem('settings', JSON.stringify(data));
+const setSettingsInLocalStorage = (data) => {
+  const localSettings = JSON.parse(window.localStorage.getItem('settings')) || {};
+  window.localStorage.setItem('settings', JSON.stringify(deepMergeObj(localSettings, data)));
+};
 
 export default {
-  settings,
   settingsWithBtc,
-  setSettings,
+  setSettingsInLocalStorage,
   getSettings,
 };

--- a/test/constants/settings.js
+++ b/test/constants/settings.js
@@ -1,0 +1,24 @@
+/**
+ * Generates setting object as needed.
+ * @param {Object} options -> Object data to update generated settings as needed.
+ * @returns Object with default settings to put into localStorage.
+ */
+const getSettings = ({ btc = false }) => ({
+  areTermsOfUseAccepted: true,
+  token: {
+    list: {
+      BTC: btc,
+    },
+  },
+});
+
+const settings = getSettings({});
+const settingsWithBtc = getSettings({ btc: true });
+
+const setSettings = data => window.localStorage.setItem('settings', JSON.stringify(data));
+
+export default {
+  settings,
+  settingsWithBtc,
+  setSettings,
+};

--- a/test/constants/settings.js
+++ b/test/constants/settings.js
@@ -1,29 +1,10 @@
-import { deepMergeObj } from '../../src/utils/helpers';
-
-/**
- * Generates setting object as needed.
- * @param {Object} options -> Object data to update generated settings as needed.
- * @returns Object with default settings to put into localStorage.
- */
-const getSettings = ({ btc = false, showNetwork = false }) => ({
+const settings = {
   areTermsOfUseAccepted: true,
-  showNetwork,
   token: {
     list: {
-      BTC: btc,
+      BTC: false,
     },
   },
-});
-
-const settingsWithBtc = getSettings({ btc: true });
-
-const setSettingsInLocalStorage = (data) => {
-  const localSettings = JSON.parse(window.localStorage.getItem('settings')) || {};
-  window.localStorage.setItem('settings', JSON.stringify(deepMergeObj(localSettings, data)));
 };
 
-export default {
-  settingsWithBtc,
-  setSettingsInLocalStorage,
-  getSettings,
-};
+export default settings;

--- a/test/constants/settings.js
+++ b/test/constants/settings.js
@@ -3,8 +3,9 @@
  * @param {Object} options -> Object data to update generated settings as needed.
  * @returns Object with default settings to put into localStorage.
  */
-const getSettings = ({ btc = false }) => ({
+const getSettings = ({ btc = false, showNetwork = false }) => ({
   areTermsOfUseAccepted: true,
+  showNetwork,
   token: {
     list: {
       BTC: btc,
@@ -21,4 +22,5 @@ export default {
   settings,
   settingsWithBtc,
   setSettings,
+  getSettings,
 };

--- a/test/cypress/features/common/common.js
+++ b/test/cypress/features/common/common.js
@@ -7,8 +7,7 @@ import compareBalances from '../../utils/compareBalances';
 import urls from '../../../constants/urls';
 
 Given(/^I autologin as ([^\s]+) to ([^\s]+)$/, function (account, network) {
-  localStorage.setItem('liskCoreUrl', networks[network].node);
-  localStorage.setItem('loginKey', accounts[account].passphrase);
+  cy.autologin(accounts[account].passphrase, networks[network].node);
 });
 
 Given(/^I login$/, function () {

--- a/test/cypress/features/common/common.js
+++ b/test/cypress/features/common/common.js
@@ -12,8 +12,11 @@ Given(/^I autologin as ([^\s]+) to ([^\s]+)$/, function (account, network) {
 });
 
 Given(/^I login$/, function () {
+  cy.server();
+  cy.route('/account/**').as('btcAccount');
   cy.get(ss.loginBtn).should('be.enabled');
   cy.get(ss.loginBtn).click();
+  cy.wait('@btcAccount');
 });
 
 Then(/^I enter ([^\s]+) passphrase of ([^\s]+)$/, function (passphraseType, accountName) {

--- a/test/cypress/features/login/login.js
+++ b/test/cypress/features/login/login.js
@@ -3,13 +3,12 @@ import { Given } from 'cypress-cucumber-preprocessor/steps';
 import urls from '../../../constants/urls';
 import accounts from '../../../constants/accounts';
 import networks from '../../../constants/networks';
-import { setSettingsInLocalStorage } from '../../../constants/settings';
 import ss from '../../../constants/selectors';
 import numeral from 'numeral';
 import { fromRawLsk } from '../../../../src/utils/lsk';
 
 Given(/^showNetwork setting is true$/, function () {
-  setSettingsInLocalStorage({ showNetwork: true });
+  cy.mergeObjectWithLocalStorage('settings', { showNetwork: true });
 });
 
 Given(/^I should be connected to ([^\s]+)$/, function (networkName) {

--- a/test/cypress/features/login/login.js
+++ b/test/cypress/features/login/login.js
@@ -3,13 +3,13 @@ import { Given } from 'cypress-cucumber-preprocessor/steps';
 import urls from '../../../constants/urls';
 import accounts from '../../../constants/accounts';
 import networks from '../../../constants/networks';
-import { setSettings, getSettings } from '../../../constants/settings';
+import { setSettingsInLocalStorage } from '../../../constants/settings';
 import ss from '../../../constants/selectors';
 import numeral from 'numeral';
 import { fromRawLsk } from '../../../../src/utils/lsk';
 
 Given(/^showNetwork setting is true$/, function () {
-  setSettings(getSettings({ showNetwork: true }));
+  setSettingsInLocalStorage({ showNetwork: true });
 });
 
 Given(/^I should be connected to ([^\s]+)$/, function (networkName) {

--- a/test/cypress/features/login/login.js
+++ b/test/cypress/features/login/login.js
@@ -3,12 +3,13 @@ import { Given } from 'cypress-cucumber-preprocessor/steps';
 import urls from '../../../constants/urls';
 import accounts from '../../../constants/accounts';
 import networks from '../../../constants/networks';
+import { setSettings, getSettings } from '../../../constants/settings';
 import ss from '../../../constants/selectors';
 import numeral from 'numeral';
 import { fromRawLsk } from '../../../../src/utils/lsk';
 
 Given(/^showNetwork setting is true$/, function () {
-  cy.addObjectToLocalStorage('settings', 'showNetwork', true);
+  setSettings(getSettings({ showNetwork: true }));
 });
 
 Given(/^I should be connected to ([^\s]+)$/, function (networkName) {

--- a/test/cypress/features/search.feature
+++ b/test/cypress/features/search.feature
@@ -1,32 +1,38 @@
 Feature: Search
 
-  Background:
+  Scenario: Search for Transaction in mainnet, signed off
     Given I am on Dashboard page
     Then I open search
-
-  Scenario: Search for Transaction in mainnet, signed off
     When I search for transaction 881002485778658401
     And I open transaction suggestion
     Then I should be on Tx Details page of 881002485778658401
 
   Scenario: Search for Transaction in devnet, signed in
     Given I autologin as genesis to devnet
+    Given I am on Dashboard page
+    Then I open search
     When I search for transaction 18173130528211925456
     And I open transaction suggestion
     Then I should be on Tx Details page of 18173130528211925456
 
   Scenario: Search for Delegate in testnet, signed in
     Given I autologin as genesis to testnet
+    Given I am on Dashboard page
+    Then I open search
     When I search for delegate zero
     And I open delegate suggestion
     Then I should be on Delegate page of zero
 
   Scenario: Search for Lisk ID
+    Given I am on Dashboard page
+    Then I open search
     When I search for account 537318935439898807L
     And I open account suggestion
     Then I should be on Account page of 537318935439898807L
 
   Scenario: Search for non-existent account
+    Given I am on Dashboard page
+    Then I open search
     When I search for delegate 43th3j4bt324
     Then I should see no results
 

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -24,7 +24,7 @@
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 import networks from '../../constants/networks';
-import { settings, setSettings } from '../../constants/settings';
+import { settingsWithBtc, setSettingsInLocalStorage } from '../../constants/settings';
 
 before(() => {
   // Check if lisk core is running
@@ -32,7 +32,7 @@ before(() => {
 });
 
 beforeEach(() => {
-  setSettings(settings);
+  setSettingsInLocalStorage(settingsWithBtc);
 });
 
 Cypress.Commands.add('addToLocalStorage', (item, value) => {

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -24,7 +24,8 @@
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 import networks from '../../constants/networks';
-import { settingsWithBtc, setSettingsInLocalStorage } from '../../constants/settings';
+import settings from '../../constants/settings';
+import { deepMergeObj } from '../../../src/utils/helpers';
 
 before(() => {
   // Check if lisk core is running
@@ -32,11 +33,21 @@ before(() => {
 });
 
 beforeEach(() => {
-  setSettingsInLocalStorage(settingsWithBtc);
+  const btcSettings = deepMergeObj(
+    settings,
+    { token: { list: { BTC: true } } },
+  );
+  window.localStorage.setItem('settings', JSON.stringify(btcSettings));
 });
 
 Cypress.Commands.add('addToLocalStorage', (item, value) => {
   window.localStorage.setItem(item, value);
+});
+
+Cypress.Commands.add('mergeObjectWithLocalStorage', (item, data) => {
+  const localStorageData = JSON.parse(window.localStorage.getItem(item)) || {};
+  const newData = JSON.stringify(deepMergeObj(localStorageData, data));
+  window.localStorage.setItem(item, newData);
 });
 
 Cypress.Commands.add('addObjectToLocalStorage', (item, key, value) => {

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -24,6 +24,7 @@
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 import networks from '../../constants/networks';
+import { settings, setSettings } from '../../constants/settings';
 
 before(() => {
   // Check if lisk core is running
@@ -31,7 +32,7 @@ before(() => {
 });
 
 beforeEach(() => {
-  window.localStorage.setItem('settings', '{"areTermsOfUseAccepted": true}');
+  setSettings(settings);
 });
 
 Cypress.Commands.add('addToLocalStorage', (item, value) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#2273
Follow up for #2274 to fix flaky tests after cucumber.

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Created settings util file, to easily generate settings and set into the localStorage.
Added wait to login to only continue after fetching BTC data.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
E2E tests shouldn't be failing

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
