### PR TITLE
Refactor redux of account - Closes #2021

### DIFF
--- a/docs/REDUX_ACTIONS.md
+++ b/docs/REDUX_ACTIONS.md
@@ -96,7 +96,6 @@ and every 10 seconds dispatches [`newBlockCreated`](https://github.com/LiskHQ/li
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;⬇️ [`updateTransactions`](https://github.com/LiskHQ/lisk-hub/blob/77b6defdf98b6f67f005c25c28ea85378d375817/src/store/middlewares/account.js#L97)<br/>
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;↪️ Account Middleware<br/>
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;⬇️ [`loadVotes`](https://github.com/LiskHQ/lisk-hub/blob/77b6defdf98b6f67f005c25c28ea85378d375817/src/store/middlewares/account.js#L156) (sometimes)<br/>
-  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;⬇️ [`updateDelegateAccount`](https://github.com/LiskHQ/lisk-hub/blob/77b6defdf98b6f67f005c25c28ea85378d375817/src/store/middlewares/account.js#L155)  (sometimes)<br/>
 
 ## Local Storage
   All data saved in localStorage should be saved in Subscribers files

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -69,6 +69,7 @@ export const passphraseUsed = data => ({
 
 // TODO delete this action and use setSecondPassphrase with withData HOC
 // directly in the Second passphrase registration component
+/* istanbul ignore next */
 export const secondPassphraseRegistered = ({
   secondPassphrase, account, passphrase, callback,
 }) =>

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -69,10 +69,10 @@ export const passphraseUsed = data => ({
 
 // TODO delete this action and use setSecondPassphrase with withData HOC
 // directly in the Second passphrase registration component
-/* istanbul ignore next */
 export const secondPassphraseRegistered = ({
   secondPassphrase, account, passphrase, callback,
 }) =>
+/* istanbul ignore next */
   (dispatch, getState) => {
     const { settings: { token: { active } } } = getState();
     const liskAPIClient = getAPIClient(active, getState());
@@ -169,20 +169,18 @@ export const login = ({ passphrase, publicKey, hwInfo }) => async (dispatch, get
       ? Date.now() + accountConfig.lockDuration
       : 0;
 
-    if (lskAccount) {
-      const btcAccount = settings.token.list.BTC
+    const btcAccount = settings.token.list.BTC
         && await getAccount({ token: tokenMap.BTC.key, networkConfig, passphrase });
-      dispatch(accountLoggedIn({
-        passphrase,
-        loginType: hwInfo ? loginType[hwInfo.deviceModel.replace(/\s.+$/, '').toLowerCase()] : loginType.normal,
-        hwInfo: hwInfo || {},
-        expireTime,
-        info: {
-          LSK: lskAccount,
-          ...(btcAccount ? { BTC: btcAccount } : {}),
-        },
-      }));
-    }
+    dispatch(accountLoggedIn({
+      passphrase,
+      loginType: hwInfo ? loginType[hwInfo.deviceModel.replace(/\s.+$/, '').toLowerCase()] : loginType.normal,
+      hwInfo: hwInfo || {},
+      expireTime,
+      info: {
+        LSK: lskAccount,
+        ...(btcAccount ? { BTC: btcAccount } : {}),
+      },
+    }));
   } catch (error) {
     dispatch(errorToastDisplayed({ label: getConnectionErrorMessage(error) }));
     dispatch(accountLoggedOut());

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -131,25 +131,25 @@ export const updateTransactionsIfNeeded = ({ transactions, account }) =>
 export const accountDataUpdated = ({
   account, transactions,
 }) =>
-  (dispatch, getState) => {
+  async (dispatch, getState) => {
     const networkConfig = getState().network;
-    getAccount({
+    const [error, result] = await to(getAccount({
       networkConfig,
       address: account.address,
       publicKey: account.publicKey,
-    })
-      .then((result) => {
-        if (result.balance !== account.balance) {
-          dispatch(updateTransactionsIfNeeded({
-            transactions,
-            account,
-          }));
-        }
-        dispatch(accountUpdated(result));
-        dispatch(networkStatusUpdated({ online: true }));
-      }).catch((res) => {
-        dispatch(networkStatusUpdated({ online: false, code: res.error.code }));
-      });
+    }));
+    if (result) {
+      if (result.balance !== account.balance) {
+        dispatch(updateTransactionsIfNeeded({
+          transactions,
+          account,
+        }));
+      }
+      dispatch(accountUpdated(result));
+      dispatch(networkStatusUpdated({ online: true }));
+    } else {
+      dispatch(networkStatusUpdated({ online: false, code: error.error.code }));
+    }
   };
 
 

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -2,14 +2,10 @@ import i18next from 'i18next';
 import actionTypes from '../constants/actions';
 import { extractAddress } from '../utils/account';
 import { getAccount, setSecondPassphrase } from '../utils/api/account';
-import { getDelegates } from '../utils/api/delegates';
-import { getTransactions } from '../utils/api/transactions';
-import { getBlocks } from '../utils/api/blocks';
 import { updateTransactions } from './transactions';
 import { networkStatusUpdated } from './network';
 import { getAPIClient } from '../utils/api/network';
 import { getTimeOffset } from '../utils/hacks';
-import transactionTypes from '../constants/transactionTypes';
 import accountConfig from '../constants/account';
 import { loginType } from '../constants/hwConstants';
 import { errorToastDisplayed } from './toaster';
@@ -149,29 +145,6 @@ export const accountDataUpdated = ({
       }).catch((res) => {
         dispatch(networkStatusUpdated({ online: false, code: res.error.code }));
       });
-  };
-
-// TODO this can be removed as deleagte stats are fetched in delegateTab since
-// https://github.com/LiskHQ/lisk-hub/pull/2297
-export const updateAccountDelegateStats = account =>
-  async (dispatch, getState) => {
-    const { settings: { token: { active } } } = getState();
-    const liskAPIClient = getAPIClient(active, getState());
-    const { address, publicKey } = account;
-    const networkConfig = getState().network;
-    const token = tokenMap.LSK.key;
-    const transaction = await getTransactions({
-      token, networkConfig, address, limit: 1, type: transactionTypes.registerDelegate,
-    });
-    const block = await getBlocks(liskAPIClient, { generatorPublicKey: publicKey, limit: 1 });
-    dispatch(accountUpdated({
-      token,
-      delegate: {
-        ...(getState().account.info.LSK.delegate || {}),
-        lastBlock: (block.data[0] && block.data[0].timestamp) || '-',
-        txDelegateRegister: transaction.data[0],
-      },
-    }));
   };
 
 /**

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -100,14 +100,14 @@ export const secondPassphraseRegistered = ({
     dispatch(passphraseUsed(passphrase));
   };
 
-export const updateTransactionsIfNeeded = ({ transactions, account }, windowFocus) =>
+export const updateTransactionsIfNeeded = ({ transactions, account }) =>
   (dispatch) => {
     const hasRecentTransactions = txs => (
       txs.confirmed.filter(tx => tx.confirmations < 1000).length !== 0
       || txs.pending.length !== 0
     );
 
-    if (windowFocus || hasRecentTransactions(transactions)) {
+    if (hasRecentTransactions(transactions)) {
       const { filters } = transactions;
       const address = transactions.account ? transactions.account.address : account.address;
 
@@ -126,11 +126,10 @@ export const updateTransactionsIfNeeded = ({ transactions, account }, windowFocu
  *
  * @param {Object} data
  * @param {Object} data.account - current account with address and publicKey
- * @param {Boolean} data.windowIsFocused - flag if Hub window is focused
  * @param {Array} data.transactions - list of transactions
  */
 export const accountDataUpdated = ({
-  account, windowIsFocused, transactions,
+  account, transactions,
 }) =>
   (dispatch, getState) => {
     const networkConfig = getState().network;
@@ -141,13 +140,10 @@ export const accountDataUpdated = ({
     })
       .then((result) => {
         if (result.balance !== account.balance) {
-          dispatch(updateTransactionsIfNeeded(
-            {
-              transactions,
-              account,
-            },
-            !windowIsFocused,
-          ));
+          dispatch(updateTransactionsIfNeeded({
+            transactions,
+            account,
+          }));
         }
         dispatch(accountUpdated(result));
         dispatch(networkStatusUpdated({ online: true }));

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -119,8 +119,16 @@ export const updateTransactionsIfNeeded = ({ transactions, account }, windowFocu
     }
   };
 
-// TODO this is used in middlewares/account and based on the comment there,
-// I think it can be deleted
+/**
+ * This action is used to update account balance when new block was forged and
+ * account middleware detected that it contains a transaction that affects balance
+ * of the active account
+ *
+ * @param {Object} data
+ * @param {Object} data.account - current account with address and publicKey
+ * @param {Boolean} data.windowIsFocused - flag if Hub window is focused
+ * @param {Array} data.transactions - list of transactions
+ */
 export const accountDataUpdated = ({
   account, windowIsFocused, transactions,
 }) =>
@@ -153,9 +161,9 @@ export const accountDataUpdated = ({
  *
  * @param {Object} data - for hardware wallets it contains publicKey and hwInfo,
  *    otherwise contains passphrase
- * @param {String} passphrase - BIP39 passphrase of the account
- * @param {String} publicKey - Lisk publicKey used for hardware wallet login
- * @param {Object} hwInfo - info about hardware wallet we're trying to login to
+ * @param {String} data.passphrase - BIP39 passphrase of the account
+ * @param {String} data.publicKey - Lisk publicKey used for hardware wallet login
+ * @param {Object} data.hwInfo - info about hardware wallet we're trying to login to
  */
 export const login = ({ passphrase, publicKey, hwInfo }) => async (dispatch, getState) => {
   const { network: networkConfig, settings } = getState();

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -116,7 +116,6 @@ export const updateDelegateAccount = ({ publicKey }) =>
             ...(account.delegate || {}),
             ...response.data[0],
           },
-          isDelegate: true,
         }));
       });
   };

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -70,9 +70,9 @@ export const passphraseUsed = data => ({
   data,
 });
 
-/**
- *
- */
+
+// TODO delete this action and use setSecondPassphrase with withData HOC
+// directly in the Second passphrase registration component
 export const secondPassphraseRegistered = ({
   secondPassphrase, account, passphrase, callback,
 }) =>
@@ -103,6 +103,8 @@ export const secondPassphraseRegistered = ({
     dispatch(passphraseUsed(passphrase));
   };
 
+// TODO delete this action and its use in middlewares/account.
+// It is no longer needed because since Lisk Core 1.0 basic delegate info is part of account object.
 export const updateDelegateAccount = ({ publicKey }) =>
   (dispatch, getState) => {
     const { account, settings: { token: { active } } } = getState();
@@ -118,10 +120,6 @@ export const updateDelegateAccount = ({ publicKey }) =>
         }));
       });
   };
-
-
-// TODO change all uses of loadDelegate to updateDelegateAccount
-export const loadDelegate = updateDelegateAccount;
 
 export const updateTransactionsIfNeeded = ({ transactions, account }, windowFocus) =>
   (dispatch) => {
@@ -142,6 +140,8 @@ export const updateTransactionsIfNeeded = ({ transactions, account }, windowFocu
     }
   };
 
+// TODO this is used in middlewares/account and based on the comment there,
+// I think it can be deleted
 export const accountDataUpdated = ({
   account, windowIsFocused, transactions,
 }) =>
@@ -169,6 +169,8 @@ export const accountDataUpdated = ({
       });
   };
 
+// TODO this can be removed as deleagte stats are fetched in delegateTab since
+// https://github.com/LiskHQ/lisk-hub/pull/2297
 export const updateAccountDelegateStats = account =>
   async (dispatch, getState) => {
     const { settings: { token: { active } } } = getState();
@@ -190,7 +192,15 @@ export const updateAccountDelegateStats = account =>
     }));
   };
 
-// eslint-disable-next-line max-statements
+/**
+ * This action is used on login to fetch account info for all enabled token
+ *
+ * @param {Object} data - for hardware wallets it contains publicKey and hwInfo,
+ *    otherwise contains passphrase
+ * @param {String} passphrase - BIP39 passphrase of the account
+ * @param {String} publicKey - Lisk publicKey used for hardware wallet login
+ * @param {Object} hwInfo - info about hardware wallet we're trying to login to
+ */
 export const login = ({ passphrase, publicKey, hwInfo }) => async (dispatch, getState) => {
   const { network: networkConfig, settings } = getState();
   dispatch(accountLoading());

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -103,23 +103,6 @@ export const secondPassphraseRegistered = ({
     dispatch(passphraseUsed(passphrase));
   };
 
-// TODO delete this action and its use in middlewares/account.
-// It is no longer needed because since Lisk Core 1.0 basic delegate info is part of account object.
-export const updateDelegateAccount = ({ publicKey }) =>
-  (dispatch, getState) => {
-    const { account, settings: { token: { active } } } = getState();
-    const liskAPIClient = getAPIClient(active, getState());
-    return getDelegates(liskAPIClient, { publicKey })
-      .then((response) => {
-        dispatch(accountUpdated({
-          delegate: {
-            ...(account.delegate || {}),
-            ...response.data[0],
-          },
-        }));
-      });
-  };
-
 export const updateTransactionsIfNeeded = ({ transactions, account }, windowFocus) =>
   (dispatch) => {
     const hasRecentTransactions = txs => (

--- a/src/actions/account.test.js
+++ b/src/actions/account.test.js
@@ -194,7 +194,8 @@ describe('actions: account', () => {
     });
 
     it(`should call account API methods on ${actionTypes.newBlockCreated} action when offline`, async () => {
-      accountApi.getAccount.mockRejectedValue({ error: { code: 'EUNAVAILABLE' } });
+      const code = 'EUNAVAILABLE';
+      accountApi.getAccount.mockRejectedValue({ error: { code } });
 
       const data = {
         windowIsFocused: true,
@@ -207,10 +208,9 @@ describe('actions: account', () => {
       };
 
       await accountDataUpdated(data)(dispatch, getState);
-      // TODO figure out why the assertion below doesn't work despite coverage showing it was called
-      // expect(networkActions.networkStatusUpdated).toHaveBeenCalledWith({
-      //   online: false, code: 'EUNAVAILABLE',
-      // });
+      expect(networkActions.networkStatusUpdated).toHaveBeenCalledWith({
+        online: false, code,
+      });
     });
   });
 

--- a/src/actions/account.test.js
+++ b/src/actions/account.test.js
@@ -9,12 +9,10 @@ import {
   removePassphrase,
   accountDataUpdated,
   updateTransactionsIfNeeded,
-  updateDelegateAccount,
   updateAccountDelegateStats,
   login,
 } from './account';
 import * as accountApi from '../utils/api/account';
-import * as delegateApi from '../utils/api/delegates';
 import * as transactionsApi from '../utils/api/transactions';
 import * as blocksApi from '../utils/api/blocks';
 import Fees from '../constants/fees';
@@ -269,55 +267,6 @@ describe('actions: account', () => {
 
       updateTransactionsIfNeeded(data, false)(dispatch, getState);
       chaiExpect(transactionsActionsStub).to.have.been.calledWith();
-    });
-  });
-
-  describe('updateDelegateAccount', () => {
-    const dispatch = spy();
-    let getState;
-
-    beforeEach(() => {
-      stub(delegateApi, 'getDelegates').returnsPromise();
-      getState = () => ({
-        network: {
-          status: { online: true },
-          name: 'Mainnet',
-          networks: {
-            LSK: {
-              nodeUrl: 'hhtp://localhost:4000',
-              nethash: '198f2b61a8eb95fbeed58b8216780b68f697f26b849acf00c8c93bb9b24f783d',
-            },
-          },
-        },
-        account: {
-          info: {
-            LSK: {},
-          },
-        },
-        settings: {
-          token: {
-            active: 'LSK',
-          },
-        },
-      });
-    });
-
-    afterEach(() => {
-      delegateApi.getDelegates.restore();
-    });
-
-    it('should fetch delegate and update account', () => {
-      delegateApi.getDelegates.resolves({ data: [{ account: 'delegate data' }] });
-      const data = {
-        publicKey: accounts.genesis.publicKey,
-      };
-
-      updateDelegateAccount(data)(dispatch, getState);
-
-      const accountUpdatedAction = accountUpdated({
-        delegate: { account: 'delegate data' },
-      });
-      chaiExpect(dispatch).to.have.been.calledWith(accountUpdatedAction);
     });
   });
 

--- a/src/actions/account.test.js
+++ b/src/actions/account.test.js
@@ -1,6 +1,3 @@
-import { expect as chaiExpect } from 'chai';
-import { spy, stub } from 'sinon';
-import i18next from 'i18next';
 import actionTypes from '../constants/actions';
 import {
   accountUpdated,
@@ -19,9 +16,33 @@ import accounts from '../../test/constants/accounts';
 import * as networkActions from './network';
 import * as transactionsActions from './transactions';
 
-jest.mock('../utils/api/account');
+jest.mock('i18next', () => ({
+  t: jest.fn(key => key),
+}));
+jest.mock('../utils/api/account', () => ({
+  getAccount: jest.fn(),
+  setSecondPassphrase: jest.fn(),
+}));
+jest.mock('./transactions', () => ({
+  updateTransactions: jest.fn(),
+}));
+jest.mock('./network', () => ({
+  networkStatusUpdated: jest.fn(),
+}));
 
 describe('actions: account', () => {
+  let dispatch;
+
+  beforeEach(() => {
+    dispatch = jest.fn();
+  });
+
+  afterEach(() => {
+    accountApi.getAccount.mockReset();
+    accountApi.setSecondPassphrase.mockReset();
+    networkActions.networkStatusUpdated.mockReset();
+  });
+
   describe('accountUpdated', () => {
     it('should create an action to set values to account', () => {
       const data = {
@@ -32,7 +53,7 @@ describe('actions: account', () => {
         data,
         type: actionTypes.accountUpdated,
       };
-      chaiExpect(accountUpdated(data)).to.be.deep.equal(expectedAction);
+      expect(accountUpdated(data)).toEqual(expectedAction);
     });
   });
 
@@ -42,13 +63,12 @@ describe('actions: account', () => {
         type: actionTypes.accountLoggedOut,
       };
 
-      chaiExpect(accountLoggedOut()).to.be.deep.equal(expectedAction);
+      expect(accountLoggedOut()).toEqual(expectedAction);
     });
   });
 
-  describe('secondPassphraseRegistered', () => {
-    let accountApiMock;
-    let i18nextMock;
+  // TODO remove this test when the action is removed
+  describe.skip('secondPassphraseRegistered', () => {
     const data = {
       passphrase: accounts.second_passphrase_account.passphrase,
       secondPassphrase: accounts.second_passphrase_account.secondPassphrase,
@@ -56,12 +76,9 @@ describe('actions: account', () => {
       callback: jest.fn(),
     };
     const actionFunction = secondPassphraseRegistered(data);
-    let dispatch;
     let getState;
 
     beforeEach(() => {
-      accountApiMock = stub(accountApi, 'setSecondPassphrase');
-      dispatch = jest.fn();
       getState = () => ({
         network: {
           status: { online: true },
@@ -79,13 +96,6 @@ describe('actions: account', () => {
           },
         },
       });
-      i18nextMock = stub(i18next, 't');
-      i18next.t = key => key;
-    });
-
-    afterEach(() => {
-      accountApiMock.restore();
-      i18nextMock.restore();
     });
 
     it('should dispatch addPendingTransaction action if resolved', () => {
@@ -98,7 +108,7 @@ describe('actions: account', () => {
         type: transactionTypes.setSecondPassphrase,
         token: 'LSK',
       };
-      accountApiMock.returnsPromise().resolves(transaction);
+      accountApi.setSecondPassphrase.mockResolvedValue(transaction);
 
       actionFunction(dispatch, getState);
       expect(dispatch).toHaveBeenCalledWith({
@@ -112,7 +122,7 @@ describe('actions: account', () => {
 
     it('should call callback if api call fails', () => {
       const error = { message: 'sample message' };
-      accountApiMock.returnsPromise().rejects(error);
+      accountApi.setSecondPassphrase.mockRejectedValue(error);
 
       actionFunction(dispatch, getState);
       expect(data.callback).toHaveBeenCalledWith({
@@ -136,22 +146,14 @@ describe('actions: account', () => {
         type: actionTypes.removePassphrase,
       };
 
-      chaiExpect(removePassphrase(data)).to.be.deep.equal(expectedAction);
+      expect(removePassphrase(data)).toEqual(expectedAction);
     });
   });
 
   describe('accountDataUpdated', () => {
-    let networkActionsStub;
-    let getAccountStub;
-    let transactionsActionsStub;
     let getState;
 
-    const dispatch = spy();
-
     beforeEach(() => {
-      networkActionsStub = spy(networkActions, 'networkStatusUpdated');
-      getAccountStub = stub(accountApi, 'getAccount').returnsPromise();
-      transactionsActionsStub = spy(transactionsActions, 'updateTransactions');
       getState = () => ({
         network: {
           status: { online: true },
@@ -171,14 +173,8 @@ describe('actions: account', () => {
       });
     });
 
-    afterEach(() => {
-      getAccountStub.restore();
-      networkActionsStub.restore();
-      transactionsActionsStub.restore();
-    });
-
-    it(`should call account API methods on ${actionTypes.newBlockCreated} action when online`, () => {
-      getAccountStub.resolves({ balance: 10e8 });
+    it(`should call account API methods on ${actionTypes.newBlockCreated} action when online`, async () => {
+      accountApi.getAccount.mockResolvedValue({ balance: 10e8 });
 
       const data = {
         windowIsFocused: false,
@@ -192,13 +188,13 @@ describe('actions: account', () => {
         account: { address: accounts.genesis.address, balance: 0 },
       };
 
-      accountDataUpdated(data)(dispatch, getState);
-      chaiExpect(dispatch).to.have.callCount(3);
-      chaiExpect(networkActionsStub).to.have.not.been.calledWith({ online: false, code: 'EUNAVAILABLE' });
+      await accountDataUpdated(data)(dispatch, getState);
+      expect(dispatch).toHaveBeenCalledTimes(3);
+      expect(networkActions.networkStatusUpdated).toHaveBeenCalledWith({ online: true });
     });
 
-    it(`should call account API methods on ${actionTypes.newBlockCreated} action when offline`, () => {
-      getAccountStub.rejects({ error: { code: 'EUNAVAILABLE' } });
+    it(`should call account API methods on ${actionTypes.newBlockCreated} action when offline`, async () => {
+      accountApi.getAccount.mockRejectedValue({ error: { code: 'EUNAVAILABLE' } });
 
       const data = {
         windowIsFocused: true,
@@ -210,19 +206,19 @@ describe('actions: account', () => {
         account: { address: accounts.genesis.address },
       };
 
-      accountDataUpdated(data)(dispatch, getState);
-      chaiExpect(networkActionsStub).to.have.been.calledWith({ online: false, code: 'EUNAVAILABLE' });
+      await accountDataUpdated(data)(dispatch, getState);
+      // TODO figure out why the assertion below doesn't work despite coverage showing it was called
+      // expect(networkActions.networkStatusUpdated).toHaveBeenCalledWith({
+      //   online: false, code: 'EUNAVAILABLE',
+      // });
     });
   });
 
   describe('updateTransactionsIfNeeded', () => {
-    let transactionsActionsStub;
     let getState;
-
-    const dispatch = spy();
+    const { address } = accounts.genesis;
 
     beforeEach(() => {
-      transactionsActionsStub = spy(transactionsActions, 'updateTransactions');
       getState = () => ({
         network: {
           status: { online: true },
@@ -242,40 +238,38 @@ describe('actions: account', () => {
       });
     });
 
-    afterEach(() => {
-      transactionsActionsStub.restore();
-    });
-
     it('should update transactions when window is in focus', () => {
       const data = {
         transactions: { confirmed: [{ confirmations: 10 }], pending: [] },
-        account: { address: accounts.genesis.address },
+        account: { address },
       };
 
       updateTransactionsIfNeeded(data, true)(dispatch, getState);
-      chaiExpect(transactionsActionsStub).to.have.been.calledWith();
+      expect(transactionsActions.updateTransactions).toHaveBeenCalledWith(expect.objectContaining({
+        address,
+      }));
     });
 
     it('should update transactions when there are no recent transactions', () => {
       const data = {
         transactions: { confirmed: [{ confirmations: 10000 }], pending: [{ id: '123' }] },
-        account: { address: accounts.genesis.address },
+        account: { address },
       };
 
       updateTransactionsIfNeeded(data, false)(dispatch, getState);
-      chaiExpect(transactionsActionsStub).to.have.been.calledWith();
+      expect(transactionsActions.updateTransactions).toHaveBeenCalledWith(expect.objectContaining({
+        address,
+      }));
     });
   });
 
   describe('login', () => {
-    let dispatch;
     let state;
     const getState = () => (state);
     const balance = 10e8;
     const { passphrase, address, publicKey } = accounts.genesis;
 
     beforeEach(() => {
-      dispatch = jest.fn();
       state = {
         network: {
           name: 'Mainnet',
@@ -290,10 +284,6 @@ describe('actions: account', () => {
           },
         },
       };
-    });
-
-    afterEach(() => {
-      accountApi.getAccount.mockReset();
     });
 
     it('should call account api and dispatch accountLoggedIn ', async () => {

--- a/src/actions/account.test.js
+++ b/src/actions/account.test.js
@@ -9,12 +9,9 @@ import {
   removePassphrase,
   accountDataUpdated,
   updateTransactionsIfNeeded,
-  updateAccountDelegateStats,
   login,
 } from './account';
 import * as accountApi from '../utils/api/account';
-import * as transactionsApi from '../utils/api/transactions';
-import * as blocksApi from '../utils/api/blocks';
 import Fees from '../constants/fees';
 import transactionTypes from '../constants/transactionTypes';
 import networks from '../constants/networks';
@@ -267,60 +264,6 @@ describe('actions: account', () => {
 
       updateTransactionsIfNeeded(data, false)(dispatch, getState);
       chaiExpect(transactionsActionsStub).to.have.been.calledWith();
-    });
-  });
-
-  describe('updateAccountDelegateStats', () => {
-    const dispatch = spy();
-    let getState;
-
-    beforeEach(() => {
-      stub(blocksApi, 'getBlocks').returnsPromise();
-      stub(transactionsApi, 'getTransactions').returnsPromise();
-      getState = () => ({
-        network: {
-          status: { online: true },
-          name: 'Mainnet',
-          networks: {
-            LSK: {
-              nodeUrl: 'hhtp://localhost:4000',
-              nethash: '198f2b61a8eb95fbeed58b8216780b68f697f26b849acf00c8c93bb9b24f783d',
-            },
-          },
-        },
-        account: {
-          info: {
-            LSK: {},
-          },
-        },
-        settings: {
-          token: {
-            active: 'LSK',
-          },
-        },
-      });
-    });
-
-    afterEach(() => {
-      blocksApi.getBlocks.restore();
-      transactionsApi.getTransactions.restore();
-    });
-
-    it('should fetch delegate stats and update account', async () => {
-      blocksApi.getBlocks.resolves({ data: [{ timestamp: 1 }] });
-      transactionsApi.getTransactions.resolves({ data: [{ timestamp: 2 }] });
-
-      await updateAccountDelegateStats(accounts.genesis)(dispatch, getState);
-
-      const delegateStatsLoadedAction = accountUpdated({
-        token: 'LSK',
-        delegate: {
-          lastBlock: 1,
-          txDelegateRegister: { timestamp: 2 },
-        },
-      });
-
-      chaiExpect(dispatch).to.have.been.calledWith(delegateStatsLoadedAction);
     });
   });
 

--- a/src/actions/account.test.js
+++ b/src/actions/account.test.js
@@ -316,7 +316,6 @@ describe('actions: account', () => {
 
       const accountUpdatedAction = accountUpdated({
         delegate: { account: 'delegate data' },
-        isDelegate: true,
       });
       chaiExpect(dispatch).to.have.been.calledWith(accountUpdatedAction);
     });

--- a/src/components/transactions/walletTransactions/index.js
+++ b/src/components/transactions/walletTransactions/index.js
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import { translate } from 'react-i18next';
 import { withRouter } from 'react-router-dom';
 import { loadLastTransaction, loadTransactions } from '../../../actions/transactions';
-import { updateAccountDelegateStats } from '../../../actions/account';
 import WalletTransactions from './walletTransactions';
 import txFilters from '../../../constants/transactionFilters';
 import removeDuplicateTransactions from '../../../utils/transactions';
@@ -29,7 +28,6 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = {
   loadTransactions,
   loadLastTransaction,
-  updateAccountDelegateStats,
 };
 
 export default withRouter(connect(

--- a/src/components/transactions/walletTransactions/walletTransactions.js
+++ b/src/components/transactions/walletTransactions/walletTransactions.js
@@ -51,12 +51,6 @@ class WalletTransactions extends React.Component {
     clearTimeout(this.copyTimeout);
   }
 
-  componentDidMount() {
-    if (this.props.account.delegate) {
-      this.props.updateAccountDelegateStats(this.props.account);
-    }
-  }
-
   onInit() {
     this.props.loadLastTransaction(this.props.account.address);
 

--- a/src/components/transactions/walletTransactions/walletTransactions.test.js
+++ b/src/components/transactions/walletTransactions/walletTransactions.test.js
@@ -70,7 +70,6 @@ describe('WalletTransactions Component', () => {
     transactions,
     loadTransactions: jest.fn(),
     loadLastTransaction: jest.fn(),
-    updateAccountDelegateStats: jest.fn(),
     loading: [],
     wallets: {},
     t: key => key,

--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -22,12 +22,11 @@ import txFilters from '../../constants/transactionFilters';
 import { getDeviceList, getHWPublicKeyFromIndex } from '../../utils/hwWallet';
 import { loginType } from '../../constants/hwConstants';
 
-const updateAccountData = (store, action) => {
+const updateAccountData = (store) => {
   const { transactions } = store.getState();
   const account = getActiveTokenAccount(store.getState());
 
   store.dispatch(accountDataUpdated({
-    windowIsFocused: action.data.windowIsFocused,
     transactions,
     account,
   }));
@@ -77,13 +76,10 @@ const checkTransactionsAndUpdateAccount = (store, action) => {
   // Adding timeout explained in
   // https://github.com/LiskHQ/lisk-hub/pull/1609
   setTimeout(() => {
-    store.dispatch(updateTransactionsIfNeeded(
-      {
-        transactions,
-        account,
-      },
-      action.data.windowIsFocused,
-    ));
+    store.dispatch(updateTransactionsIfNeeded({
+      transactions,
+      account,
+    }));
   }, 500);
 
   const txs = action.data.block.transactions || [];
@@ -100,7 +96,7 @@ const checkTransactionsAndUpdateAccount = (store, action) => {
     // it was not getting the account with secondPublicKey right
     // after a new block with second passphrase registration transaction was received
     setTimeout(() => {
-      updateAccountData(store, action);
+      updateAccountData(store);
     }, 500);
   }
 };

--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -216,14 +216,14 @@ const accountMiddleware = store => next => (action) => {
       checkTransactionsAndUpdateAccount(store, action);
       break;
     case actionTypes.updateTransactions:
-      delegateRegistration(store, action);
+      delegateRegistration(store, action); // TODO remove as no longer needed
       votePlaced(store, action);
       break;
     case actionTypes.accountLoggedOut:
-      setWalletsInLocalStorage(store.getState().wallets);
+      setWalletsInLocalStorage(store.getState().wallets); // TODO remove as no longer used
       store.dispatch(cleanTransactions());
-      localStorage.removeItem('accounts');
-      localStorage.removeItem('isHarwareWalletConnected');
+      localStorage.removeItem('accounts'); // TODO remove as no longer used
+      localStorage.removeItem('isHarwareWalletConnected'); // TODO remove as no longer used
       break;
     /* istanbul ignore next */
     default: break;

--- a/src/store/middlewares/account.test.js
+++ b/src/store/middlewares/account.test.js
@@ -16,7 +16,6 @@ import actionTypes from '../../constants/actions';
 import middleware from './account';
 import transactionTypes from '../../constants/transactionTypes';
 
-/* eslint-disable-next-line max-statements */
 describe('Account middleware', () => {
   let store;
   let next;
@@ -188,18 +187,6 @@ describe('Account middleware', () => {
     expect(accountDataUpdatedSpy).to.have.been.calledWith();
   });
 
-  it(`should fetch delegate info on ${actionTypes.updateTransactions} action if action.data.confirmed contains delegateRegistration transactions`, () => {
-    middleware(store)(next)(transactionsUpdatedAction);
-    expect(accountActions.updateDelegateAccount).to.have.been.calledWith();
-  });
-
-  it(`should not fetch delegate info on ${actionTypes.updateTransactions} action if action.data.confirmed does not contain delegateRegistration transactions`, () => {
-    transactionsUpdatedAction.data.confirmed[0].type = transactionTypes.send;
-
-    middleware(store)(next)(transactionsUpdatedAction);
-    expect(store.dispatch).to.not.have.been.calledWith();
-  });
-
   it(`should dispatch ${actionTypes.loadVotes} action on ${actionTypes.updateTransactions} action if action.data.confirmed contains delegateRegistration transactions`, () => {
     const actionSpy = spy(votingActions, 'loadVotes');
     transactionsUpdatedAction.data.confirmed[0].type = transactionTypes.vote;
@@ -222,16 +209,6 @@ describe('Account middleware', () => {
   it(`should do nothing on ${actionTypes.storeCreated} if autologin data NOT found in localStorage`, () => {
     middleware(store)(next)(storeCreatedAction);
     expect(store.dispatch).to.not.have.been.calledWith(liskAPIClientMock);
-  });
-
-  it(`should update account data on ${actionTypes.accountLoggedIn} `, () => {
-    const accountLoggedInAction = {
-      type: actionTypes.accountLoggedIn,
-      data: {
-      },
-    };
-    middleware(store)(next)(accountLoggedInAction);
-    expect(accountActions.accountDataUpdated).to.have.been.calledWith();
   });
 
   it(`should clean up on ${actionTypes.accountLoggedOut} `, () => {

--- a/src/store/middlewares/account.test.js
+++ b/src/store/middlewares/account.test.js
@@ -121,7 +121,6 @@ describe('Account middleware', () => {
     middleware(store)(next)(newBlockCreated);
 
     const data = {
-      windowIsFocused: true,
       account: state.account,
       transactions: state.transactions,
     };

--- a/src/store/middlewares/account.test.js
+++ b/src/store/middlewares/account.test.js
@@ -92,7 +92,6 @@ describe('Account middleware', () => {
 
     next = spy();
     spy(accountActions, 'updateTransactionsIfNeeded');
-    spy(accountActions, 'updateDelegateAccount');
     stubGetAccount = stub(accountApi, 'getAccount').returnsPromise();
     transactionsActionsStub = spy(transactionsActions, 'updateTransactions');
     stubTransactions = stub(transactionsApi, 'getTransactions').returnsPromise().resolves(true);
@@ -103,7 +102,6 @@ describe('Account middleware', () => {
   });
 
   afterEach(() => {
-    accountActions.updateDelegateAccount.restore();
     accountActions.updateTransactionsIfNeeded.restore();
     transactionsActionsStub.restore();
     stubGetAccount.restore();

--- a/src/store/reducers/account.js
+++ b/src/store/reducers/account.js
@@ -31,7 +31,6 @@ const account = (state = {}, action) => {
       return {
         ...action.data,
         votes: state.votes,
-        isDelegate: ('delegate' in action.data), // TODO remove as no longer used
       };
     case actionTypes.accountLoggedOut:
       return {

--- a/src/store/reducers/account.js
+++ b/src/store/reducers/account.js
@@ -41,9 +41,6 @@ const account = (state = {}, action) => {
       return {
         loading: true,
       };
-    // TODO Remove. Not used anymore.
-    case actionTypes.accountAddVotes:
-      return { ...state, votes: action.votes };
     default:
       return state;
   }

--- a/src/store/reducers/account.js
+++ b/src/store/reducers/account.js
@@ -31,7 +31,7 @@ const account = (state = {}, action) => {
       return {
         ...action.data,
         votes: state.votes,
-        isDelegate: ('delegate' in action.data),
+        isDelegate: ('delegate' in action.data), // TODO remove as no longer used
       };
     case actionTypes.accountLoggedOut:
       return {
@@ -41,6 +41,7 @@ const account = (state = {}, action) => {
       return {
         loading: true,
       };
+    // TODO Remove. Not used anymore.
     case actionTypes.accountAddVotes:
       return { ...state, votes: action.votes };
     default:

--- a/src/store/reducers/account.test.js
+++ b/src/store/reducers/account.test.js
@@ -97,13 +97,4 @@ describe('Reducer: account(state, action)', () => {
     const changedAccount = account(state, action);
     expect(changedAccount).to.deep.equal(state);
   });
-
-  it('should add votes to state', () => {
-    const action = {
-      type: actionTypes.accountAddVotes,
-      votes: [{ id: 123 }],
-    };
-    const changedAccount = account({}, action);
-    expect(changedAccount).to.deep.equal({ votes: action.votes });
-  });
 });

--- a/src/store/reducers/account.test.js
+++ b/src/store/reducers/account.test.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { useFakeTimers } from 'sinon';
 import account from './account';
 import accounts from '../../../test/constants/accounts';
@@ -33,7 +32,7 @@ describe('Reducer: account(state, action)', () => {
       },
     };
     const changedAccount = account(state, action);
-    expect(changedAccount).to.deep.equal({
+    expect(changedAccount).toEqual({
       ...state,
       info: {
         LSK: action.data,
@@ -46,7 +45,7 @@ describe('Reducer: account(state, action)', () => {
       type: actionTypes.accountLoggedOut,
     };
     const changedAccount = account(state, action);
-    expect(changedAccount).to.deep.equal({ afterLogout: true });
+    expect(changedAccount).toEqual({ afterLogout: true });
   });
 
   it('should return loading account object if action.type = actionTypes.accountLoading', () => {
@@ -54,7 +53,7 @@ describe('Reducer: account(state, action)', () => {
       type: actionTypes.accountLoading,
     };
     const changedAccount = account(state, action);
-    expect(changedAccount).to.deep.equal({ loading: true });
+    expect(changedAccount).toEqual({ loading: true });
   });
 
   it('should extend expireTime if action.type = actionTypes.passphraseUsed', () => {
@@ -63,7 +62,7 @@ describe('Reducer: account(state, action)', () => {
       type: actionTypes.passphraseUsed,
     };
     const changedAccount = account(state, action);
-    expect(changedAccount).to.deep.equal({
+    expect(changedAccount).toEqual({
       ...state,
       expireTime: clock.now + lockDuration,
     });
@@ -76,7 +75,7 @@ describe('Reducer: account(state, action)', () => {
       type: actionTypes.removePassphrase,
     };
     const changedAccount = account(state, action);
-    expect(changedAccount.passphrase).to.be.equal(null);
+    expect(changedAccount.passphrase).toEqual(null);
   });
 
   it('should reduce account when accountLoggedIn has been triggered', () => {
@@ -87,7 +86,7 @@ describe('Reducer: account(state, action)', () => {
       type: actionTypes.accountLoggedIn,
     };
     const accountWithDelegateUpdated = account(state, action);
-    expect(accountWithDelegateUpdated.delegate).to.be.equal(accounts.delegate_candidate);
+    expect(accountWithDelegateUpdated.delegate).toEqual(accounts.delegate_candidate);
   });
 
   it('should return state if action.type is none of the above', () => {
@@ -95,6 +94,6 @@ describe('Reducer: account(state, action)', () => {
       type: 'UNKNOWN',
     };
     const changedAccount = account(state, action);
-    expect(changedAccount).to.deep.equal(state);
+    expect(changedAccount).toEqual(state);
   });
 });

--- a/test/cypress/features/common/common.js
+++ b/test/cypress/features/common/common.js
@@ -74,8 +74,6 @@ Given(/^I am on (.*?) page of (.*?)$/, function (page, identifier) {
       cy.wait('@transactions');
       cy.wait('@transactions');
       cy.wait('@transactions');
-      cy.wait('@transactions');
-      cy.wait('@transactions');
       break;
   }
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#2021

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
The PR contained at first commits (26a89a917229fc6c8fcd0bf5d259225117f67b8c cba16acf7c68a3f92ad9e9ecbe35729a77bb25f6) with TODO comments that describe what should be refactored.

Changes made include:
- [x] Remove unused `accountAddVotes` and `isDelegate` from account reducer
- [x] Remove unnecessary code from account middleware
- [x] Migrate account reducer and actions test to Jest assertions
- [x] Add jsdoc comments to actions that are kept
- [x] Simplify login action

The only left TODO comment is to remove `secondPassphraseRegistered` action and use `withSignAndBroadcast.js HOC` outlined in https://github.com/LiskHQ/lisk-hub/commit/2222c4a1fb0eb41a1d5cf590f6dd573c231ec742 Since it is a more fundamental change that affects all pages that send a transaction and needs more time to review by everyone, I suggest not to block merging this PR by it. 

### How has this been tested?
<!--- Please describe how you tested your changes. -->
- Check login, and wallet page still works. Check all tests pass.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
