### PR TITLE
Mainnet is always active after refreshing app - Closes #2200

### DIFF
--- a/src/components/header/signInHeader/signInHeader.js
+++ b/src/components/header/signInHeader/signInHeader.js
@@ -66,7 +66,8 @@ class Header extends React.Component {
       address: network === networks.mainnet.code || network === networks.testnet.code
         ? '' : this.state.address,
     });
-    this.props.settingsUpdated({ network });
+    const { name, address } = this.getNetwork(network);
+    this.props.settingsUpdated({ network: { name, address } });
   }
 
   getNetwork(chosenNetwork) {

--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -21,6 +21,7 @@ import txFilters from '../../constants/transactionFilters';
 
 import { getDeviceList, getHWPublicKeyFromIndex } from '../../utils/hwWallet';
 import { loginType } from '../../constants/hwConstants';
+import localJSONStorage from '../../utils/localJSONStorage';
 
 const updateAccountData = (store) => {
   const { transactions } = store.getState();
@@ -103,13 +104,14 @@ const checkTransactionsAndUpdateAccount = (store, action) => {
 
 // istanbul ignore next
 const getNetworkFromLocalStorage = () => {
-  const mySettings = JSON.parse(localStorage.getItem('settings')) || {};
-  let currentNetwork;
+  const mySettings = localJSONStorage.get('settings', {});
   if (!mySettings.network) return networks.mainnet;
-  if (mySettings.network.name === networks.mainnet.name) currentNetwork = networks.mainnet;
-  if (mySettings.network.name === networks.testnet.name) currentNetwork = networks.testnet;
-  if (mySettings.network.name === networks.customNode.name) currentNetwork = networks.customNode;
-  return { ...currentNetwork, address: mySettings.network.address };
+  return {
+    ...Object.values(networks).find(
+      ({ name }) => name === mySettings.network.name,
+    ) || networks.mainnet,
+    address: mySettings.network.address,
+  };
 };
 
 // eslint-disable-next-line max-statements

--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -101,6 +101,17 @@ const checkTransactionsAndUpdateAccount = (store, action) => {
   }
 };
 
+// istanbul ignore next
+const getNetworkFromLocalStorage = () => {
+  const mySettings = JSON.parse(localStorage.getItem('settings')) || {};
+  let currentNetwork;
+  if (!mySettings.network) return networks.mainnet;
+  if (mySettings.network.name === networks.mainnet.name) currentNetwork = networks.mainnet;
+  if (mySettings.network.name === networks.testnet.name) currentNetwork = networks.testnet;
+  if (mySettings.network.name === networks.customNode.name) currentNetwork = networks.customNode;
+  return { ...currentNetwork, address: mySettings.network.address };
+};
+
 // eslint-disable-next-line max-statements
 const checkNetworkToConnet = () => {
   const autologinData = getAutoLogInData();
@@ -129,10 +140,11 @@ const checkNetworkToConnet = () => {
   }
 
   if (!loginNetwork && !autologinData.liskCoreUrl) {
+    const currentNetwork = getNetworkFromLocalStorage();
     loginNetwork = {
-      name: networks.default.name,
+      name: currentNetwork.name,
       network: {
-        ...networks.default,
+        ...currentNetwork,
       },
     };
   }

--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -102,7 +102,6 @@ const checkTransactionsAndUpdateAccount = (store, action) => {
   }
 };
 
-// istanbul ignore next
 const getNetworkFromLocalStorage = () => {
   const mySettings = localJSONStorage.get('settings', {});
   if (!mySettings.network) return networks.mainnet;

--- a/src/store/middlewares/account.test.js
+++ b/src/store/middlewares/account.test.js
@@ -208,6 +208,14 @@ describe('Account middleware', () => {
     expect(store.dispatch).to.not.have.been.calledWith(liskAPIClientMock);
   });
 
+  it(`should dispatch ${actionTypes.networkSet} on ${actionTypes.storeCreated} if settings with network found in localStorage`, async () => {
+    localStorage.setItem('settings', JSON.stringify({
+      network: 'Testnet',
+    }));
+    await middleware(store)(next)(storeCreatedAction);
+    expect(store.dispatch).to.have.been.calledWith(liskAPIClientMock);
+  });
+
   it(`should clean up on ${actionTypes.accountLoggedOut} `, () => {
     const accountLoggedOutAction = {
       type: actionTypes.accountLoggedOut,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #2200 

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
The **account middleware** was checking every time the app refresh for **liskCoreUrl** property in the settings object in the **LocalStorage**, the problem is that this is only use for development purposes.
So the solution involves update this settings object in the LocalStorage to retain the name of the network every time the user switch it, so when the user refresh the app this is able to read it from the LS and then keep using the same network.
There is only one scenario where this is not being set and is the first time the app run, if there is no previous information about the network then the application use the **default** one (mainnet).


### How has this been tested?
<!--- Please describe how you tested your changes. -->
1. Run the application.
2. Go to settings and enable network switcher.
3. Then in the Sign In page switch for any network
4. Login into the app.
5. Refresh the app.

After refresh the app you will see that now the application is able to retain the selected network.

scenario 2.
1. From the LS remove the settings property.
2. Then Sign In in the app. (In this step there is no network selected)
3. Refresh the app.
4. Default network is being selected (mainnet)

The only way to simulate this is removing and supposing that there is not network property in the settings object in LS, what this means is the user is running the app for first time and without network switcher, so by default will be Sing In into mainnet.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
