### PR TITLE
Network Switcher - Remaining Parts - Closes #1982

### DIFF
--- a/src/actions/network/lsk.js
+++ b/src/actions/network/lsk.js
@@ -41,6 +41,11 @@ export const networkSet = data => async (dispatch) => {
         nethash,
       }));
     }).catch((error) => {
+      dispatch(generateAction(data, {
+        nodeUrl: data.network.address,
+        custom: data.network.custom,
+        code: data.network.code,
+      }));
       dispatch(errorToastDisplayed({ label: error }));
     });
   } else if (data.name === networks.testnet.name

--- a/src/components/header/signInHeader/index.js
+++ b/src/components/header/signInHeader/index.js
@@ -2,7 +2,7 @@
 import { connect } from 'react-redux';
 import Header from './signInHeader';
 import { networkSet } from '../../../actions/network';
-import { errorToastDisplayed, successToastDisplayed } from '../../../actions/toaster';
+import { errorToastDisplayed } from '../../../actions/toaster';
 import { settingsUpdated } from '../../../actions/settings';
 import networks from '../../../constants/networks';
 import { tokenMap } from '../../../constants/tokens';
@@ -26,7 +26,6 @@ const mapDispatchToProps = {
   errorToastDisplayed,
   networkSet,
   settingsUpdated,
-  successToastDisplayed,
 };
 
 export default connect(

--- a/src/components/header/signInHeader/index.js
+++ b/src/components/header/signInHeader/index.js
@@ -2,20 +2,23 @@
 import { connect } from 'react-redux';
 import Header from './signInHeader';
 import { networkSet } from '../../../actions/network';
-import { errorToastDisplayed } from '../../../actions/toaster';
+import { errorToastDisplayed, successToastDisplayed } from '../../../actions/toaster';
 import { settingsUpdated } from '../../../actions/settings';
 import networks from '../../../constants/networks';
 import { tokenMap } from '../../../constants/tokens';
 import { getAPIClient } from '../../../utils/api/network';
 
+// eslint-disable-next-line complexity
 const mapStateToProps = state => ({
   account: state.account,
   network: state.network,
   settings: state.settings,
   selectedNetwork: (state.network.networks.LSK && state.network.networks.LSK.code)
     || networks.mainnet.code,
-  address: (state.network.networks[state.settings.token.active || tokenMap.LSK.key]
-    && state.network.networks[state.settings.token.active || tokenMap.LSK.key].nodeUrl) || '',
+  address: ((state.network.networks[state.settings.token.active || tokenMap.LSK.key]
+    && state.network.networks[state.settings.token.active || tokenMap.LSK.key].nodeUrl)
+    || (state.settings.network && state.settings.network.name === networks.customNode.name
+      && state.settings.network.address)) || '',
   liskAPIClient: getAPIClient(state.settings.token.active || tokenMap.LSK.key, state),
 });
 
@@ -23,6 +26,7 @@ const mapDispatchToProps = {
   errorToastDisplayed,
   networkSet,
   settingsUpdated,
+  successToastDisplayed,
 };
 
 export default connect(

--- a/src/components/header/signInHeader/signInHeader.js
+++ b/src/components/header/signInHeader/signInHeader.js
@@ -8,7 +8,6 @@ import { Input } from '../../toolbox/inputs';
 import { addHttp, getAutoLogInData, findMatchingLoginNetwork } from '../../../utils/login';
 import getNetwork, { getNetworksList } from '../../../utils/getNetwork';
 import { parseSearchParams } from '../../../utils/searchParams';
-
 import Icon from '../../toolbox/icon';
 import UserAccount from '../../topBar/accountMenu/userAccount';
 import networks from '../../../constants/networks';
@@ -16,6 +15,7 @@ import styles from './signInHeader.css';
 import formStyles from '../../send/form/form.css';
 import Dropdown from '../../toolbox/dropdown/dropdown';
 import Spinner from '../../spinner/spinner';
+import keyCodes from '../../../constants/keyCodes';
 import svg from '../../../utils/svgIcons';
 
 class Header extends React.Component {
@@ -40,6 +40,7 @@ class Header extends React.Component {
     };
     this.toggleDropdown = this.toggleDropdown.bind(this);
     this.handleSettingsToggle = this.handleSettingsToggle.bind(this);
+    this.onConnectToCustomNode = this.onConnectToCustomNode.bind(this);
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -67,7 +68,9 @@ class Header extends React.Component {
         ? '' : this.state.address,
     });
     const { name, address } = this.getNetwork(network);
-    this.props.settingsUpdated({ network: { name, address } });
+    if (address !== 'http://') {
+      this.props.settingsUpdated({ network: { name, address } });
+    }
   }
 
   getNetwork(chosenNetwork) {
@@ -130,6 +133,13 @@ class Header extends React.Component {
 
   handleSettingsToggle() {
     this.setState({ showSettingDrowdown: !this.state.showSettingDrowdown });
+  }
+
+  onConnectToCustomNode(e) {
+    e.stopPropagation();
+    this.setState({ isValidationLoading: true });
+    this.validateCorrectNode(networks.customNode.code, this.state.address);
+    this.changeNetwork(networks.customNode.code);
   }
 
   /* istanbul ignore next */
@@ -200,6 +210,8 @@ class Header extends React.Component {
                               placeholder={this.props.t('ie. 192.168.0.1')}
                               size="s"
                               className={`custom-network ${formStyles.input} ${this.state.validationError ? styles.errorInput : ''}`}
+                              onKeyDown={e => e.keyCode === keyCodes.enter
+                                && this.onConnectToCustomNode(e)}
                             />
                             <div className={styles.icons}>
                               <Spinner className={`${styles.spinner} ${this.state.isValidationLoading && this.state.address ? styles.show : styles.hide}`} />
@@ -231,18 +243,7 @@ class Header extends React.Component {
                                     <PrimaryButton
                                       disabled={this.state.connected}
                                     /* istanbul ignore next */
-                                      onClick={(e) => {
-                                        e.stopPropagation();
-
-                                        this.setState({ isValidationLoading: true });
-                                        this.loaderTimeout = setTimeout(() => {
-                                          this.validateCorrectNode(
-                                            networks.customNode.code,
-                                            this.state.address,
-                                          );
-                                          this.changeNetwork(networks.customNode.code);
-                                        }, 300);
-                                      }}
+                                      onClick={this.onConnectToCustomNode}
                                       className={`${styles.button} ${styles.backButton} connect-button`}
                                     >
                                       {this.state.connected ? t('Connected') : t('Connect')}

--- a/src/components/header/signInHeader/signInHeader.js
+++ b/src/components/header/signInHeader/signInHeader.js
@@ -76,7 +76,7 @@ class Header extends React.Component {
   // eslint-disable-next-line max-statements
   async checkNodeStatus(showErrorToaster = true) {
     const {
-      liskAPIClient, errorToastDisplayed, successToastDisplayed, network,
+      liskAPIClient, errorToastDisplayed, network,
     } = this.props;
 
     if (liskAPIClient) {
@@ -84,9 +84,8 @@ class Header extends React.Component {
         network: network.networks.LSK.code,
         activeNetwork: network.networks.LSK.code,
       });
-      const [error, response] = await to(liskAPIClient.node.getConstants());
+      const [error] = await to(liskAPIClient.node.getConstants());
 
-      if (response) successToastDisplayed({ label: 'Successfully connected to the node.' });
       if (error) {
         if (network.name === networks.customNode.name) {
           this.setState(({ validationError: true }));

--- a/src/components/header/signInHeader/signInHeader.js
+++ b/src/components/header/signInHeader/signInHeader.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import React from 'react';
 import Lisk from '@liskhq/lisk-client';
 import { translate } from 'react-i18next';
@@ -20,8 +21,8 @@ import svg from '../../../utils/svgIcons';
 
 class Header extends React.Component {
   // eslint-disable-next-line max-statements
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     const { liskCoreUrl } = getAutoLogInData();
     let loginNetwork = findMatchingLoginNetwork();
     let address = '';
@@ -29,8 +30,9 @@ class Header extends React.Component {
     if (loginNetwork) loginNetwork = loginNetwork.slice(-1).shift();
     if (!loginNetwork) {
       loginNetwork = liskCoreUrl ? networks.customNode : networks.default;
-      address = liskCoreUrl || '';
+      address = liskCoreUrl || props.address;
     }
+
     this.state = {
       address,
       showDropdown: false,
@@ -38,9 +40,19 @@ class Header extends React.Component {
       network: loginNetwork.code,
       isFirstTime: true,
     };
+
     this.toggleDropdown = this.toggleDropdown.bind(this);
     this.handleSettingsToggle = this.handleSettingsToggle.bind(this);
     this.onConnectToCustomNode = this.onConnectToCustomNode.bind(this);
+  }
+
+  shouldComponentUpdate(nextProps) {
+    const { address } = this.props;
+    if (address !== nextProps.address) {
+      this.setState({ address: nextProps.address });
+      return false;
+    }
+    return true;
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -199,12 +211,9 @@ class Header extends React.Component {
                             }}
                           >
                             {network.label}
-
                             <Input
                               autoComplete="off"
-                              onChange={(value) => {
-                                this.changeAddress(value);
-                              }}
+                              onChange={(value) => { this.changeAddress(value); }}
                               name="customNetwork"
                               value={this.state.address}
                               placeholder={this.props.t('ie. 192.168.0.1')}

--- a/src/components/header/signInHeader/signInHeader.js
+++ b/src/components/header/signInHeader/signInHeader.js
@@ -46,13 +46,9 @@ class Header extends React.Component {
     this.onConnectToCustomNode = this.onConnectToCustomNode.bind(this);
   }
 
-  shouldComponentUpdate(nextProps) {
+  componentDidUpdate(prevProps) {
     const { address } = this.props;
-    if (address !== nextProps.address) {
-      this.setState({ address: nextProps.address });
-      return false;
-    }
-    return true;
+    if (address !== prevProps.address) this.setState({ address });
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/src/components/splashscreen/index.js
+++ b/src/components/splashscreen/index.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { translate } from 'react-i18next';
 import { getActiveTokenAccount } from '../../utils/account';
 import { settingsUpdated } from '../../actions/settings';
+import { errorToastDisplayed } from '../../actions/toaster';
 import { getAPIClient } from '../../utils/api/network';
 import Splashscreen from './splashscreen';
 
@@ -14,6 +15,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = {
+  errorToastDisplayed,
   settingsUpdated,
 };
 

--- a/src/components/splashscreen/splashscreen.css
+++ b/src/components/splashscreen/splashscreen.css
@@ -102,6 +102,7 @@
 
   &:hover {
     text-decoration: underline;
+    cursor: pointer;
   }
 
   & > img {

--- a/src/components/splashscreen/splashscreen.js
+++ b/src/components/splashscreen/splashscreen.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { translate } from 'react-i18next';
-
+import { to } from 'await-to-js';
 import routes from '../../constants/routes';
 import { getAutoLogInData, findMatchingLoginNetwork } from '../../utils/login';
 import { parseSearchParams } from '../../utils/searchParams';
@@ -35,6 +35,7 @@ class Splashscreen extends React.Component {
     this.secondIteration = false;
 
     this.networks = getNetworksList();
+    this.checkNodeStatus = this.checkNodeStatus.bind(this);
   }
 
   componentDidMount() {
@@ -73,6 +74,16 @@ class Splashscreen extends React.Component {
       && network.networks[token.active].nodeUrl === prevNetwork.networks[token.active].nodeUrl;
   }
 
+  async checkNodeStatus() {
+    const { errorToastDisplayed, history, liskAPIClient } = this.props;
+    // istanbul ignore else
+    if (liskAPIClient) {
+      const [error, response] = await to(liskAPIClient.node.getConstants());
+      if (response) history.push(routes.dashboard.path);
+      if (error) errorToastDisplayed({ label: `Unable to connect to the node, Error: ${error.message}` });
+    }
+  }
+
   render() {
     const { t } = this.props;
 
@@ -98,9 +109,12 @@ class Splashscreen extends React.Component {
             <span>{t('or')}</span>
           </span>
           <span className={styles.linkWrapper}>
-            <Link className={`${styles.link} explore-as-guest-button`} to={routes.dashboard.path}>
+            <span
+              className={`${styles.link} explore-as-guest-button`}
+              onClick={this.checkNodeStatus}
+            >
               {t('Explore as a guest')}
-            </Link>
+            </span>
             <Tooltip
               className={`${styles.tooltip}`}
               styles={{ infoIcon: styles.infoIcon }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #1982 

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
The fix in this PR is implement it in header/signInHeader/signInHeader.js file.

- [x] Validate when the network is change and if it custom node change only if address is entered.
- [x] User be able to submit the custom url address pressing the enter button.
- [x] If custom node network is selected but no url address is entered then keep the previous network.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
1. Run the app.
2. Go to the Sign In page.
3. Open the developers tools and check the network value in the settings in local storage.
4. Then change the network from mainnet to testnet.
5. Then change network selecting only custom network (settings shouldn't be update)
6. Enter custom node URL address.
7. press enter (network should be change now).

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
