### PR TITLE
Currency dropdown in settings is kinda buggy - Closes #2305

### DIFF
--- a/src/components/toolbox/select/index.js
+++ b/src/components/toolbox/select/index.js
@@ -46,7 +46,7 @@ class Select extends React.Component {
         onOutsideClick={this.toggleIsOpen}
         className={`${styles.wrapper} ${className}`}
       >
-        <label className={styles.inputHolder}>
+        <label className={`${styles.inputHolder} ${isOpen ? styles.isOpen : ''}`}>
           <Input
             readOnly
             value={options[selected].label}

--- a/src/components/toolbox/select/index.js
+++ b/src/components/toolbox/select/index.js
@@ -50,7 +50,7 @@ class Select extends React.Component {
           <Input
             readOnly
             value={options[selected].label}
-            onFocus={this.toggleIsOpen}
+            onClick={this.toggleIsOpen}
             size={size}
           />
         </label>

--- a/src/components/toolbox/select/index.test.js
+++ b/src/components/toolbox/select/index.test.js
@@ -22,7 +22,7 @@ describe('Select toolbox component', () => {
     const newProps = { ...props, selected: 1 };
     const wrapper = shallow(<Select {...newProps} />);
     expect(wrapper.find('Input')).toHaveValue(props.options[1].label);
-    wrapper.find('Input').simulate('focus');
+    wrapper.find('Input').simulate('click');
     wrapper.find('.option').first().simulate('click', { target: { dataset: { index: 0 } } });
     expect(wrapper.find('Input')).toHaveValue(props.options[0].label);
   });

--- a/src/components/toolbox/select/select.css
+++ b/src/components/toolbox/select/select.css
@@ -21,11 +21,16 @@
   }
 
   &::after {
+    transition: transform var(--animation-speed-fastest) linear;
     border: 4px solid transparent;
     border-bottom: 0 none;
     border-top: 4px solid var(--color-slate-gray);
     content: '';
     position: absolute;
     right: 20px;
+  }
+
+  &.isOpen::after {
+    transform: rotate(180deg);
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #2305 

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
In this PR just 2 things are change.

-[x] Change the onFocus to onClick for the currency input.
-[x] Add a css class to rotate the arrow when the dropdown is open/close.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
1. Run the app.
2. Go to settings page.
3. Do a click in the currency input.
4. See the arrow rotating.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
