### PR TITLE
Fix tooltip link alignment - Closes #2306

### DIFF
--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -344,6 +344,7 @@
   "Save": "Save",
   "Save changes": "Save changes",
   "Save it on a encrypted hard drive: USB key or a backup drive": "Save it on a encrypted hard drive: USB key or a backup drive",
+  "Save the passphrase": "Save the passphrase",
   "Save your passphrase": "Save your passphrase",
   "Search within the network...": "Search within the network...",
   "Second Passphrase": "Second Passphrase",

--- a/src/components/delegateRegistration/summary/summary.css
+++ b/src/components/delegateRegistration/summary/summary.css
@@ -24,7 +24,7 @@
   }
 }
 
-footer {
+.summaryContainer > footer {
   width: 100%;
   box-sizing: border-box;
   display: flex;

--- a/src/components/passphraseBackup/index.js
+++ b/src/components/passphraseBackup/index.js
@@ -47,7 +47,7 @@ class PassphraseBackup extends React.Component {
                 {t('Passphrase')}
 
                 <Tooltip
-                  title="Save the passphrase"
+                  title={t('Save the passphrase')}
                   footer={(
                     <a
                       href={links.howToStorePassphrase}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#2306

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
- [x] There was global css for `footer` in delegate registration, so I made the selector more specific.
- [x] Also found one string missing from i18n and fixed it.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
- Go to "Create account" and hover the tooltip
- Check that delegate registration styles keep the same

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
