### PR TITLE
Fix fee in balance chart and transaction table 

### DIFF
--- a/src/components/transactions/transactionRow.js
+++ b/src/components/transactions/transactionRow.js
@@ -88,7 +88,8 @@ class TransactionRow extends React.Component {
         </div>
         <div className={`${columnClassNames.fee} transactions-cell`}>
           <LiskAmount val={value.fee} />
-          {`&nbsp;${token}`}
+          &nbsp;
+          {token}
         </div>
         <div className={`${columnClassNames.details} transactions-cell`}>
           <TransactionDetail

--- a/src/utils/balanceChart.js
+++ b/src/utils/balanceChart.js
@@ -138,8 +138,8 @@ export const getChartDateFormat = (transactions) => {
 };
 
 
-const isIncomming = (tx, address) => tx.senderId === address;
-const isOutgoing = (tx, address) => tx.recipientId === address;
+const isIncomming = (tx, address) => tx.recipientId === address;
+const isOutgoing = (tx, address) => tx.senderId === address;
 
 /**
  * Returns value in interger format of the amount that was added or subtracted from the balance
@@ -175,7 +175,7 @@ export const getBalanceData = ({
       : balances;
     return [
       ...tmpBalances,
-      { x: txDate, y: (parseInt(lastBalance.y, 10) + txValue) },
+      { x: txDate, y: (parseInt(lastBalance.y, 10) - txValue) },
     ];
   }, [{ x: moment(), y: +balance }]).reverse().map(d => ({ ...d, y: +fromRawLsk(d.y) }));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
- Fee on transactions table contained "&nbsp"
- Balance chart could go to minus

![Screenshot 2019-08-08 at 17 22 37](https://user-images.githubusercontent.com/1254342/62715648-347f4380-ba01-11e9-8a2b-59431afbdfad.png)


### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Straightforwardly :-) 

### How has this been tested?
<!--- Please describe how you tested your changes. -->
See account `15610359283786884938L` on Testnet https://ci.lisk.io/test/lisk-hub/PR-2336/#/explorer/accounts/15610359283786884938L

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
