### PR TITLE
switching mainnet and testnet is mismatched - closes #2030

### DIFF
--- a/src/components/setting/index.js
+++ b/src/components/setting/index.js
@@ -5,6 +5,7 @@ import Setting from './setting';
 import { settingsUpdated } from '../../actions/settings';
 import { toastDisplayed } from '../../actions/toaster';
 import { accountUpdated } from '../../actions/account';
+import { networkSet } from '../../actions/network';
 import { getActiveTokenAccount } from '../../utils/account';
 
 const mapStateToProps = state => ({
@@ -17,6 +18,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = {
   accountUpdated,
+  networkSet,
   settingsUpdated,
   toastDisplayed,
 };

--- a/src/components/setting/setting.js
+++ b/src/components/setting/setting.js
@@ -9,7 +9,6 @@ import links from '../../constants/externalLinks';
 import settingsConst from '../../constants/settings';
 import styles from './setting.css';
 import txTypes from '../../constants/transactionTypes';
-import networks from '../../constants/networks';
 import SecondPassphraseSetting from './secondPassphrase';
 
 class Setting extends React.Component {
@@ -23,19 +22,6 @@ class Setting extends React.Component {
     this.handleCheckboxChange = this.handleCheckboxChange.bind(this);
     this.toggleAutoLog = this.toggleAutoLog.bind(this);
     this.handleTokenToggle = this.handleTokenToggle.bind(this);
-  }
-
-  // istanbul ignore next
-  componentDidUpdate(prevProps) {
-    const {
-      settings, account, settingsUpdated, networkSet,
-    } = this.props;
-    if (Object.entries(account).length === 1
-      && prevProps.settings.showNetwork !== settings.showNetwork
-      && !settings.showNetwork) {
-      settingsUpdated({ network: { name: networks.mainnet.name } });
-      networkSet(networks.mainnet);
-    }
   }
 
   handleTokenToggle({ target: { name } }) {

--- a/src/components/setting/setting.js
+++ b/src/components/setting/setting.js
@@ -9,6 +9,7 @@ import links from '../../constants/externalLinks';
 import settingsConst from '../../constants/settings';
 import styles from './setting.css';
 import txTypes from '../../constants/transactionTypes';
+import networks from '../../constants/networks';
 import SecondPassphraseSetting from './secondPassphrase';
 
 class Setting extends React.Component {
@@ -22,6 +23,19 @@ class Setting extends React.Component {
     this.handleCheckboxChange = this.handleCheckboxChange.bind(this);
     this.toggleAutoLog = this.toggleAutoLog.bind(this);
     this.handleTokenToggle = this.handleTokenToggle.bind(this);
+  }
+
+  // istanbul ignore next
+  componentDidUpdate(prevProps) {
+    const {
+      settings, account, settingsUpdated, networkSet,
+    } = this.props;
+    if (Object.entries(account).length === 1
+      && prevProps.settings.showNetwork !== settings.showNetwork
+      && !settings.showNetwork) {
+      settingsUpdated({ network: { name: networks.mainnet.name } });
+      networkSet(networks.mainnet);
+    }
   }
 
   handleTokenToggle({ target: { name } }) {

--- a/src/components/topBar/index.js
+++ b/src/components/topBar/index.js
@@ -4,6 +4,7 @@ import { withRouter } from 'react-router';
 import { translate } from 'react-i18next';
 import { accountLoggedOut, accountUpdated } from '../../actions/account';
 import { settingsUpdated } from '../../actions/settings';
+import { networkSet } from '../../actions/network';
 import accountConfig from '../../constants/account';
 import TopBar from './topBar';
 
@@ -12,12 +13,14 @@ const mapStateToProps = state => ({
   network: state.network,
   token: state.settings.token,
   autoLogout: state.settings.autoLog,
+  settings: state.settings,
 });
 
 const mapDispatchToProps = {
-  settingsUpdated,
   logOut: accountLoggedOut,
+  networkSet,
   resetTimer: () => accountUpdated({ expireTime: Date.now() + accountConfig.lockDuration }),
+  settingsUpdated,
 };
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(translate()(TopBar)));

--- a/src/components/topBar/topBar.js
+++ b/src/components/topBar/topBar.js
@@ -33,7 +33,7 @@ class TopBar extends React.Component {
 
   onLogout() {
     const {
-      logOut, history, settings, settingsUpdated, networkSet, network,
+      logOut, history, settings, networkSet, network,
     } = this.props;
 
     Piwik.trackingEvent('Header', 'button', 'Open logout dialog');
@@ -41,7 +41,6 @@ class TopBar extends React.Component {
     history.replace(`${routes.dashboard.path}`);
 
     if (!settings.showNetwork && network.name !== networks.mainnet.name) {
-      settingsUpdated({ network: { name: networks.mainnet.name } });
       networkSet(networks.mainnet);
     }
   }

--- a/src/components/topBar/topBar.js
+++ b/src/components/topBar/topBar.js
@@ -8,6 +8,7 @@ import menuLinks from './constants';
 import Dropdown from '../toolbox/dropdown/dropdown';
 import SearchBar from '../searchBar';
 import Network from './network';
+import networks from '../../constants/networks';
 import styles from './topBar.css';
 
 import OutsideClickHandler from '../toolbox/outsideClickHandler';
@@ -31,9 +32,18 @@ class TopBar extends React.Component {
   }
 
   onLogout() {
+    const {
+      logOut, history, settings, settingsUpdated, networkSet, network,
+    } = this.props;
+
     Piwik.trackingEvent('Header', 'button', 'Open logout dialog');
-    this.props.logOut();
-    this.props.history.replace(`${routes.dashboard.path}`);
+    logOut();
+    history.replace(`${routes.dashboard.path}`);
+
+    if (!settings.showNetwork && network.name !== networks.mainnet.name) {
+      settingsUpdated({ network: { name: networks.mainnet.name } });
+      networkSet(networks.mainnet);
+    }
   }
 
   onHandleClick(name) {

--- a/src/components/topBar/topBar.test.js
+++ b/src/components/topBar/topBar.test.js
@@ -57,7 +57,11 @@ describe('TopBar', () => {
         },
       },
     },
+    settings: {
+      network: { name: 'Custom Nodee', address: 'hhtp://localhost:4000' },
+    },
     settingsUpdated: jest.fn(),
+    networkSet: jest.fn(),
   };
 
   const history = {

--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -102,6 +102,7 @@ const checkTransactionsAndUpdateAccount = (store, action) => {
   }
 };
 
+// istanbul ignore next
 const getNetworkFromLocalStorage = () => {
   const mySettings = localJSONStorage.get('settings', {});
   if (!mySettings.network) return networks.mainnet;
@@ -114,7 +115,7 @@ const getNetworkFromLocalStorage = () => {
 };
 
 // eslint-disable-next-line max-statements
-const checkNetworkToConnet = () => {
+const checkNetworkToConnet = (storeSettings) => {
   const autologinData = getAutoLogInData();
   let loginNetwork = findMatchingLoginNetwork();
 
@@ -140,14 +141,24 @@ const checkNetworkToConnet = () => {
     };
   }
 
+  // istanbul ignore next
   if (!loginNetwork && !autologinData.liskCoreUrl) {
-    const currentNetwork = getNetworkFromLocalStorage();
-    loginNetwork = {
-      name: currentNetwork.name,
-      network: {
-        ...currentNetwork,
-      },
-    };
+    if (storeSettings.showNetwork) {
+      const currentNetwork = getNetworkFromLocalStorage();
+      loginNetwork = {
+        name: currentNetwork.name,
+        network: {
+          ...currentNetwork,
+        },
+      };
+    } else {
+      loginNetwork = {
+        name: networks.mainnet.name,
+        network: {
+          ...networks.mainnet,
+        },
+      };
+    }
   }
 
   return loginNetwork;
@@ -155,6 +166,7 @@ const checkNetworkToConnet = () => {
 
 // eslint-disable-next-line max-statements
 const autoLogInIfNecessary = async (store) => {
+  const actualSettings = store && store.getState().settings;
   const autologinData = getAutoLogInData();
   let loginNetwork;
 
@@ -180,7 +192,7 @@ const autoLogInIfNecessary = async (store) => {
       };
     }
   } else {
-    loginNetwork = checkNetworkToConnet();
+    loginNetwork = checkNetworkToConnet(actualSettings);
   }
 
   store.dispatch(await networkSet(loginNetwork));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #2030 

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
The solution consists in check in the settings if the network switcher is on or off and based on that at the time of logout update the settings to switch to Mainnet in case the actual network is Testnet or Custom Node.

So in other words.

1. If network switcher is off the current network is Mainnet in this case there is nothing to change.
2. If network switcher is on and current network is Mainnet in this case there is nothing to change.
3. If network switcher is on and current network is Testnet or Custom Node, in this case there is nothing to change.
4. If network switcher is on and current network is Testnet or Custom Node, and use login and from settings page disable (OFF) the network switcher, then when he logout the code check this and if actual network it is different from Mainnet and network switcher if OFF then update the settings and network to default on (Mainnet).

### How has this been tested?
<!--- Please describe how you tested your changes. -->

1. Sign-in to TestNet
2. Go o Setting
3. Disabled network switcher.
5. Logout
6. Sign-in again
7. Actual network should be Mainnet

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
