### PR TITLE
Second passphrase is not checked for each word - Closes #2322

### DIFF
--- a/src/components/passphraseInput/passphraseInput.js
+++ b/src/components/passphraseInput/passphraseInput.js
@@ -82,9 +82,10 @@ class passphraseInput extends React.Component {
   // eslint-disable-next-line max-statements
   validatePassphrase({ values, inputsLength = this.state.inputsLength, focus = null }) {
     let errorState = { validationError: '', partialPassphraseError: [], passphraseIsInvalid: false };
+
     const passphrase = values.join(' ').trim();
     if (!isValidPassphrase(passphrase)) {
-      errorState = getPassphraseValidationErrors(passphrase);
+      errorState = getPassphraseValidationErrors(values);
       errorState.passphraseIsInvalid = errorState.validationError === this.props.t('Passphrase is not valid');
     }
 

--- a/src/components/transactionSummary/index.js
+++ b/src/components/transactionSummary/index.js
@@ -47,17 +47,15 @@ class TransactionSummary extends React.Component {
   }
 
   checkSecondPassphrase(passphrase, error) {
-    let feedback = error || '';
+    const { account, t } = this.props;
     const expectedPublicKey = !error && extractPublicKey(passphrase);
-    const isPassphraseValid = this.props.account.secondPublicKey === expectedPublicKey;
+    const isPassphraseValid = account.secondPublicKey === expectedPublicKey;
+    const feedback = !error && !isPassphraseValid ? t('Oops! Wrong passphrase') : '';
 
-    if (feedback === '' && !isPassphraseValid) {
-      feedback = this.props.t('Oops! Wrong passphrase');
-    }
     this.setState({
       secondPassphrase: {
         ...this.state.secondPassphrase,
-        isValid: feedback === '' && passphrase !== '',
+        isValid: !error && feedback === '' && passphrase !== '',
         feedback,
         value: passphrase,
       },

--- a/src/utils/passphrase.js
+++ b/src/utils/passphrase.js
@@ -118,19 +118,19 @@ export const isValidPassphrase = (passphrase) => {
 };
 
 export const getPassphraseValidationErrors = (passphrase) => {
-  const passphraseArray = passphrase.trim().split(' ');
-
   const partialPassphraseError = [];
-  const invalidWords = passphraseArray.filter((word) => {
-    const isNotInDictionary = !inDictionary(word);
-    partialPassphraseError[passphraseArray.indexOf(word)] = isNotInDictionary;
+  const invalidWords = passphrase.filter((word) => {
+    const isNotInDictionary = word !== '' && !inDictionary(word);
+    partialPassphraseError[passphrase.indexOf(word)] = isNotInDictionary;
     return isNotInDictionary;
   });
 
+  const filteredPassphrase = passphrase.filter(word => !!word);
+
   let validationError = i18next.t('Passphrase is not valid');
 
-  if (passphraseArray.length < 12) {
-    validationError = i18next.t('Passphrase should have 12 words, entered passphrase has {{length}}', { length: passphraseArray.length });
+  if (filteredPassphrase.length < 12) {
+    validationError = i18next.t('Passphrase should have 12 words, entered passphrase has {{length}}', { length: filteredPassphrase.length });
   }
 
   if (invalidWords.length > 0) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#2322 

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
On second passphrase it was always marking all the fields with error, if any error was found.  
Updated the validation to only highlight the correct ones.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Follow steps on the issue #2322 

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
