### PR TITLE
Fix transaction detail page of pending transactions

### DIFF
--- a/src/utils/api/lsk/transactions.js
+++ b/src/utils/api/lsk/transactions.js
@@ -86,7 +86,7 @@ export const getSingleTransaction = ({
       if (response.data.length !== 0) {
         resolve(response);
       } else {
-        apiClient.node.getTransactions('unconfirmed', { id }).then((unconfirmedRes) => {
+        apiClient.node.getTransactions('ready', { id }).then((unconfirmedRes) => {
           if (unconfirmedRes.data.length !== 0) {
             resolve(unconfirmedRes);
           } else {
@@ -96,16 +96,6 @@ export const getSingleTransaction = ({
       }
     }).catch(reject);
 });
-
-
-export const unconfirmedTransactions = (liskAPIClient, address, limit = 20, offset = 0, sort = 'timestamp:desc') =>
-  liskAPIClient.node.getTransactions('unconfirmed', {
-    senderId: address,
-    limit,
-    offset,
-    sort,
-  });
-
 
 export const create = (transaction, transactionType) => new Promise((resolve, reject) => {
   try {

--- a/src/utils/api/lsk/transactions.test.js
+++ b/src/utils/api/lsk/transactions.test.js
@@ -3,7 +3,6 @@ import Lisk from '@liskhq/lisk-client';
 import {
   send,
   getTransactions,
-  unconfirmedTransactions,
   getSingleTransaction,
   create,
   broadcast,
@@ -129,15 +128,8 @@ describe('Utils: Transactions API', () => {
     it('should apiClient.node.getTransactions if empty response', async () => {
       apiClient.transactions.get.mockResolvedValue({ data: [] });
       const [error] = await to(getSingleTransaction({ apiClient, id }));
-      expect(apiClient.node.getTransactions).toHaveBeenCalledWith('unconfirmed', { id });
+      expect(apiClient.node.getTransactions).toHaveBeenCalledWith('ready', { id });
       expect(error).toEqual(new Error(`Transaction with id "${id}" not found`));
-    });
-  });
-
-  describe('unconfirmedTransactions', () => {
-    it('should return a promise', () => {
-      const promise = unconfirmedTransactions(apiClient);
-      expect(typeof promise.then).toEqual('function');
     });
   });
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#2369 

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
The problem was that Lisk Core API changed, 'unconfirmed' status is no
longer valid. 'ready' status is used instead.

More info:
https://lisk.io/documentation/lisk-core/api#/Node/getPooledTransactions
https://github.com/LiskHQ/lips/blob/master/proposals/lip-0006.md#queues-used-in-the-transaction-pool

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Follow steps in #2369

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
