### PR TITLE
Votes filtering stuck after no results - Closes #2371

### DIFF
--- a/src/components/votes/votesTab.js
+++ b/src/components/votes/votesTab.js
@@ -114,7 +114,7 @@ class VotesTab extends React.Component {
           <div className={`${styles.filterHolder}`}>
             <Input
               className="search"
-              disabled={mergedVotes && !mergedVotes.length}
+              disabled={mergedVotes && !votes.data.length}
               name="filter"
               value={filterValue}
               placeholder={t('Filter by name')}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#2371

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Filter had the wrong condition if it should be disabled, it was checking the length of shown votes instead of the length of total votes;

### How has this been tested?
<!--- Please describe how you tested your changes. -->
As described on the ticket: #2371

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
