### PR TITLE
Fix recent transactions on dashboard - Closes #2253

### DIFF
--- a/src/components/dashboard/recentTransactions/recentTransactions.css
+++ b/src/components/dashboard/recentTransactions/recentTransactions.css
@@ -37,10 +37,10 @@
       @mixin contentLargest bold;
 
       width: 100%;
-      height: 75px;
+      padding: 16px 0;
       box-sizing: border-box;
       display: flex;
-      justify-content: flex-start;
+      justify-content: space-between;
       align-items: center;
       border-bottom: 1px solid var(--color-mystic);
       cursor: pointer;
@@ -49,6 +49,11 @@
 
       & > span:last-child {
         margin-left: auto;
+      }
+
+      & .avatarAndAddress {
+        display: flex;
+        flex-direction: row;
       }
     }
   }

--- a/src/components/dashboard/recentTransactions/recentTransactions.test.js
+++ b/src/components/dashboard/recentTransactions/recentTransactions.test.js
@@ -33,6 +33,7 @@ describe('Recent Transactions', () => {
       {
         id: 0,
         recipientId: '123456L',
+        senderId: '123456L',
         amount: '0.001',
         token: 'LSK',
         type: 0,
@@ -47,6 +48,7 @@ describe('Recent Transactions', () => {
       {
         id: 2,
         recipientId: '123456L',
+        senderId: '123456L',
         amount: '0.008',
         token: 'LSK',
         type: 1,
@@ -54,6 +56,7 @@ describe('Recent Transactions', () => {
       {
         id: 3,
         recipientId: '234234234L',
+        senderId: '123456L',
         amount: '0.0009',
         token: 'LSK',
         type: 2,
@@ -61,6 +64,7 @@ describe('Recent Transactions', () => {
       {
         id: 4,
         recipientId: '4564346346L',
+        senderId: '123456L',
         amount: '25',
         token: 'LSK',
         type: 3,
@@ -96,6 +100,7 @@ describe('Recent Transactions', () => {
       {
         id: 0,
         recipientId: 'mkakDp2f31btaXdATtAogoqwXcdx1PqqFo',
+        senderId: 'mkakDp2f31btaXdATtAogoqwXcdx1PqqFo',
         amount: '0.001',
         token: 'BTC',
         type: 0,
@@ -103,6 +108,7 @@ describe('Recent Transactions', () => {
       {
         id: 1,
         recipientId: 'mkakDp2f31b3eXdATtAggoqwXcdx1PqqFo',
+        senderId: 'mkakDp2f31btaXdATtAogoqwXcdx1PqqFo',
         amount: '0.0003',
         token: 'BTC',
         type: 0,
@@ -116,7 +122,7 @@ describe('Recent Transactions', () => {
 
   it('Should render Recent Transactions properly with LSK active token', () => {
     expect(wrapper).toContainMatchingElement('TransactionList');
-    expect(wrapper).toContainMatchingElement('TransactionTypeFigure');
+    expect(wrapper).toContainMatchingElement('.transaction-image');
     expect(wrapper).toContainMatchingElement('TransactionAddress');
     expect(wrapper).toContainMatchingElement('TransactionAmount');
     expect(wrapper).toContainMatchingElements(1, 'AccountVisual');
@@ -133,7 +139,6 @@ describe('Recent Transactions', () => {
 
     wrapper.update();
     expect(wrapper).toContainMatchingElement('TransactionList');
-    expect(wrapper).not.toContainMatchingElement('TransactionTypeFigure');
     expect(wrapper).toContainMatchingElement('TransactionAddress');
     expect(wrapper).toContainMatchingElement('TransactionAmount');
     expect(wrapper).not.toContainMatchingElement('AccountVisual');

--- a/src/components/dashboard/recentTransactions/transactionList.js
+++ b/src/components/dashboard/recentTransactions/transactionList.js
@@ -4,7 +4,6 @@ import TransactionTypeFigure from '../../transactions/typeFigure/TransactionType
 import TransactionAddress from '../../transactions/address/TransactionAddress';
 import TransactionAmount from '../../transactions/amount/TransactionAmount';
 import { SecondaryButton } from '../../toolbox/buttons/button';
-import { tokenMap } from '../../../constants/tokens';
 import routes from '../../../constants/routes';
 import styles from './recentTransactions.css';
 
@@ -28,18 +27,12 @@ const TransactionList = ({
           to={`${routes.transactions.pathPrefix}${routes.transactions.path}/${tx.id}`}
           className={`${styles.listRow} transactions-row`}
         >
-          {
-            activeToken === tokenMap.LSK.key
-              ? (
-                <TransactionTypeFigure
-                  address={tx.recipientId}
-                  transactionType={tx.type}
-                />
-              )
-              : null
-          }
+          <TransactionTypeFigure
+            address={account.address === tx.recipientId ? tx.senderId : tx.recipientId}
+            transactionType={tx.type}
+          />
           <TransactionAddress
-            address={tx.recipientId}
+            address={account.address === tx.recipientId ? tx.senderId : tx.recipientId}
             bookmarks={bookmarks}
             t={t}
             token={activeToken}

--- a/src/components/dashboard/recentTransactions/transactionList.js
+++ b/src/components/dashboard/recentTransactions/transactionList.js
@@ -27,21 +27,24 @@ const TransactionList = ({
           to={`${routes.transactions.pathPrefix}${routes.transactions.path}/${tx.id}`}
           className={`${styles.listRow} transactions-row`}
         >
-          <TransactionTypeFigure
-            address={account.address === tx.recipientId ? tx.senderId : tx.recipientId}
-            transactionType={tx.type}
-          />
-          <TransactionAddress
-            address={account.address === tx.recipientId ? tx.senderId : tx.recipientId}
-            bookmarks={bookmarks}
-            t={t}
-            token={activeToken}
-            transactionType={tx.type}
-          />
+          <div className={styles.avatarAndAddress}>
+            <TransactionTypeFigure
+              address={account.address === tx.recipientId ? tx.senderId : tx.recipientId}
+              transactionType={tx.type}
+            />
+            <TransactionAddress
+              address={account.address === tx.recipientId ? tx.senderId : tx.recipientId}
+              bookmarks={bookmarks}
+              t={t}
+              token={activeToken}
+              transactionType={tx.type}
+            />
+          </div>
           <TransactionAmount
             address={account.address}
             token={activeToken}
             transaction={tx}
+            roundTo={2}
           />
         </Link>
       ))

--- a/src/components/liskAmount/index.js
+++ b/src/components/liskAmount/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { fromRawLsk } from '../../utils/lsk';
 import FormattedNumber from '../formattedNumber';
 
-const roundTo = (value, places) => {
+const roundToPlaces = (value, places) => {
   if (!places) {
     return value;
   }
@@ -10,9 +10,9 @@ const roundTo = (value, places) => {
   return Math.round(value * x) / x;
 };
 
-const LiskAmount = props => (
-  props.val !== undefined
-    ? <FormattedNumber val={roundTo(parseFloat(fromRawLsk(props.val)), props.roundTo)} />
+const LiskAmount = ({ val, roundTo }) => (
+  val !== undefined
+    ? <FormattedNumber val={roundToPlaces(parseFloat(fromRawLsk(val)), roundTo)} />
     : <span />
 );
 

--- a/src/components/transactions/amount/TransactionAmount.js
+++ b/src/components/transactions/amount/TransactionAmount.js
@@ -1,39 +1,43 @@
+import PropTypes from 'prop-types';
 import React from 'react';
-import transactionTypes from '../../../constants/transactionTypes';
 import LiskAmount from '../../liskAmount';
 import styles from './transactionAmount.css';
+import transactionTypes from '../../../constants/transactionTypes';
 
-const TransactionAmount = ({ address, transaction, token }) => {
-  const getTransactionType = () => {
-    if (address === transaction.recipientId) {
-      return (
-        <span className={styles.recieve}>
-          <LiskAmount val={transaction.amount} />
-          {' '}
-          {token}
-        </span>
-      );
-    }
-
-    return (
-      <span>
-        {'- '}
-        <LiskAmount val={transaction.amount} />
-        {' '}
-        {token}
-      </span>
-    );
-  };
-
+const TransactionAmount = ({
+  address, transaction, token, roundTo,
+}) => {
+  const isRecieve = address === transaction.recipientId;
   return (
     <div className={`${styles.wrapper} transaction-amount`}>
-      {
-      transaction.type === transactionTypes.send
-        ? getTransactionType()
+      { transaction.type === transactionTypes.send
+        ? (
+          <span className={isRecieve ? styles.recieve : ''}>
+            {isRecieve ? '' : '- '}
+            <LiskAmount val={transaction.amount} roundTo={roundTo} />
+            {' '}
+            {token}
+          </span>
+        )
         : '-'
-    }
+      }
     </div>
   );
+};
+
+TransactionAmount.propTypes = {
+  address: PropTypes.string.isRequired,
+  token: PropTypes.string.isRequired,
+  transaction: PropTypes.shape({
+    type: PropTypes.number.isRequired,
+    amount: PropTypes.string.isRequired,
+    recipientId: PropTypes.string.isRequired,
+  }),
+  roundTo: PropTypes.number,
+};
+
+TransactionAmount.defaultProps = {
+  roundTo: 8,
 };
 
 export default TransactionAmount;

--- a/src/components/transactions/amount/transactionAmount.css
+++ b/src/components/transactions/amount/transactionAmount.css
@@ -6,17 +6,17 @@
   justify-content: center;
   align-items: center;
   box-sizing: border-box;
-  margin-left: auto;
+  margin-left: 8px;
   font-weight: var(--font-weight-bold);
 
   & .recieve {
     border-radius: var(--border-radius-standard);
     display: inline-block;
-    height: 29px;
     padding: 6px 12px;
     background-color: rgba(43, 214, 123, 0.15);
     color: var(--color-deep-green);
     box-sizing: border-box;
     line-height: initial;
+    text-align: right;
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#2253

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
- [x] Fix the logic for displayed address to `account.address === tx.recipientId ? tx.senderId : tx.recipientId`
- [x] Fix styles of "amount" to 
  1) not have a fixed height, so even if it's two lines it's all in the green box
  2) show only at most 2 decimal points on the dashboard as there is not much more space anyway. There was a suggestion to use the same logic as in Lisk Mobile https://github.com/LiskHQ/lisk-mobile/blob/development/src/components/shared/formattedNumber/index.js but that one doesn't handle localization so I didn't use it.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
- Send some transactions with long numbers, e.g. 0.92046708 LSK
- Check how are they displayed on the dashboard

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
