### PR TITLE
Enabling BTC shouldn't require app restart or logout/login - Closes #2211

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -164,26 +164,17 @@ async function getAccounts(tokens, options) {
   }, Promise.resolve({}));
 }
 
-export const updatedLoggedinAddresses = tokens => async (dispatch, getState) => {
-  const { network: networkConfig, account, settings } = getState();
-  const newTokens = (Array.isArray(tokens)
-    ? tokens
-    : [tokens]
-  ).filter(key => settings.token.list[key]);
-  if (!newTokens.length) return;
-
-  const [error, info] = await to(getAccounts(newTokens, {
-    networkConfig, passphrase: account.passphrase,
+export const updateEnabledTokensAccounts = token => async (dispatch, getState) => {
+  const { network: networkConfig, account } = getState();
+  const [error, result] = await to(getAccount({
+    token,
+    networkConfig,
+    passphrase: account.passphrase,
   }));
   if (error) {
     dispatch(errorToastDisplayed({ label: getConnectionErrorMessage(error) }));
   } else {
-    dispatch(accountUpdated({
-      info: {
-        ...account.info,
-        ...info,
-      },
-    }));
+    dispatch(accountUpdated(result));
   }
 };
 

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -164,6 +164,29 @@ async function getAccounts(tokens, options) {
   }, Promise.resolve({}));
 }
 
+export const updatedLoggedinAddresses = tokens => async (dispatch, getState) => {
+  const { network: networkConfig, account, settings } = getState();
+  const newTokens = (Array.isArray(tokens)
+    ? tokens
+    : [tokens]
+  ).filter(key => settings.token.list[key]);
+  if (!newTokens.length) return;
+
+  const [error, info] = await to(getAccounts(newTokens, {
+    networkConfig, passphrase: account.passphrase,
+  }));
+  if (error) {
+    dispatch(errorToastDisplayed({ label: getConnectionErrorMessage(error) }));
+  } else {
+    dispatch(accountUpdated({
+      info: {
+        ...account.info,
+        ...info,
+      },
+    }));
+  }
+};
+
 /**
  * This action is used on login to fetch account info for all enabled token
  *

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -164,7 +164,7 @@ async function getAccounts(tokens, options) {
   }, Promise.resolve({}));
 }
 
-export const updateEnabledTokensAccounts = token => async (dispatch, getState) => {
+export const updateEnabledTokenAccount = token => async (dispatch, getState) => {
   const { network: networkConfig, account } = getState();
   const [error, result] = await to(getAccount({
     token,

--- a/src/actions/account.test.js
+++ b/src/actions/account.test.js
@@ -6,7 +6,7 @@ import {
   removePassphrase,
   accountDataUpdated,
   updateTransactionsIfNeeded,
-  updatedLoggedinAddresses,
+  updateEnabledTokensAccounts,
   login,
 } from './account';
 import * as accountApi from '../utils/api/account';
@@ -330,7 +330,7 @@ describe('actions: account', () => {
     });
   });
 
-  describe('updatedLoggedinAddresses', () => {
+  describe('updateEnabledTokensAccounts', () => {
     let state;
     const getState = () => (state);
     const {
@@ -361,29 +361,19 @@ describe('actions: account', () => {
 
     it('should call account api and dispatch accountUpdated ', async () => {
       accountApi.getAccount.mockResolvedValue({ balance, address });
-      await updatedLoggedinAddresses(['BTC'])(dispatch, getState);
+      await updateEnabledTokensAccounts('BTC')(dispatch, getState);
       expect(dispatch).toHaveBeenCalledWith({
         type: actionTypes.accountUpdated,
-        data: {
-          info: {
-            BTC: { address, balance },
-          },
-        },
+        data: expect.objectContaining({ address, balance }),
       });
     });
 
     it('should dispatch errorToastDisplayed if getAccount fails ', async () => {
       accountApi.getAccount.mockRejectedValue({ error: 'custom error' });
-      await updatedLoggedinAddresses(['BTC'])(dispatch, getState);
+      await updateEnabledTokensAccounts('BTC')(dispatch, getState);
       expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
         type: actionTypes.toastDisplayed,
       }));
-    });
-
-    it('should not call dispatch if token is not enabled', async () => {
-      state.settings.token.list.BTC = false;
-      await updatedLoggedinAddresses(['BTC'])(dispatch, getState);
-      expect(dispatch).not.toBeCalled();
     });
   });
 });

--- a/src/actions/account.test.js
+++ b/src/actions/account.test.js
@@ -6,7 +6,7 @@ import {
   removePassphrase,
   accountDataUpdated,
   updateTransactionsIfNeeded,
-  updateEnabledTokensAccounts,
+  updateEnabledTokenAccount,
   login,
 } from './account';
 import * as accountApi from '../utils/api/account';
@@ -330,7 +330,7 @@ describe('actions: account', () => {
     });
   });
 
-  describe('updateEnabledTokensAccounts', () => {
+  describe('updateEnabledTokenAccount', () => {
     let state;
     const getState = () => (state);
     const {
@@ -361,7 +361,7 @@ describe('actions: account', () => {
 
     it('should call account api and dispatch accountUpdated ', async () => {
       accountApi.getAccount.mockResolvedValue({ balance, address });
-      await updateEnabledTokensAccounts('BTC')(dispatch, getState);
+      await updateEnabledTokenAccount('BTC')(dispatch, getState);
       expect(dispatch).toHaveBeenCalledWith({
         type: actionTypes.accountUpdated,
         data: expect.objectContaining({ address, balance }),
@@ -370,7 +370,7 @@ describe('actions: account', () => {
 
     it('should dispatch errorToastDisplayed if getAccount fails ', async () => {
       accountApi.getAccount.mockRejectedValue({ error: 'custom error' });
-      await updateEnabledTokensAccounts('BTC')(dispatch, getState);
+      await updateEnabledTokenAccount('BTC')(dispatch, getState);
       expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
         type: actionTypes.toastDisplayed,
       }));

--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -223,8 +223,9 @@ const accountMiddleware = store => next => (action) => {
       break;
     case actionTypes.settingsUpdated: {
       const tokensList = action.data.token && action.data.token.list;
-      const token = tokensList && Object.keys(tokensList)[0];
-      if (tokensList[token]) {
+      const token = tokensList && Object.keys(tokensList)
+        .find(t => tokensList[t]);
+      if (tokensList && tokensList[token]) {
         store.dispatch(updateEnabledTokensAccounts(token));
       }
       break;

--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -1,6 +1,7 @@
 import {
   accountDataUpdated,
   updateTransactionsIfNeeded,
+  updatedLoggedinAddresses,
   login,
 } from '../../actions/account';
 import { loadVotes } from '../../actions/voting';
@@ -220,6 +221,14 @@ const accountMiddleware = store => next => (action) => {
     case actionTypes.accountLoggedOut:
       store.dispatch(emptyTransactionsData());
       break;
+    case actionTypes.settingsUpdated: {
+      const { token = {} } = action.data;
+      const tokenKeys = token.list && Object.keys(token.list);
+      if (tokenKeys) {
+        store.dispatch(updatedLoggedinAddresses(tokenKeys));
+      }
+      break;
+    }
     /* istanbul ignore next */
     default: break;
   }

--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -1,7 +1,7 @@
 import {
   accountDataUpdated,
   updateTransactionsIfNeeded,
-  updateEnabledTokensAccounts,
+  updateEnabledTokenAccount,
   login,
 } from '../../actions/account';
 import { loadVotes } from '../../actions/voting';
@@ -226,7 +226,7 @@ const accountMiddleware = store => next => (action) => {
       const token = tokensList && Object.keys(tokensList)
         .find(t => tokensList[t]);
       if (tokensList && tokensList[token]) {
-        store.dispatch(updateEnabledTokensAccounts(token));
+        store.dispatch(updateEnabledTokenAccount(token));
       }
       break;
     }

--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -1,7 +1,7 @@
 import {
   accountDataUpdated,
   updateTransactionsIfNeeded,
-  updatedLoggedinAddresses,
+  updateEnabledTokensAccounts,
   login,
 } from '../../actions/account';
 import { loadVotes } from '../../actions/voting';
@@ -222,10 +222,10 @@ const accountMiddleware = store => next => (action) => {
       store.dispatch(emptyTransactionsData());
       break;
     case actionTypes.settingsUpdated: {
-      const { token = {} } = action.data;
-      const tokenKeys = token.list && Object.keys(token.list);
-      if (tokenKeys) {
-        store.dispatch(updatedLoggedinAddresses(tokenKeys));
+      const tokensList = action.data.token && action.data.token.list;
+      const token = tokensList && Object.keys(tokensList)[0];
+      if (tokensList[token]) {
+        store.dispatch(updateEnabledTokensAccounts(token));
       }
       break;
     }

--- a/src/store/middlewares/account.test.js
+++ b/src/store/middlewares/account.test.js
@@ -92,6 +92,7 @@ describe('Account middleware', () => {
 
     next = spy();
     spy(accountActions, 'updateTransactionsIfNeeded');
+    spy(accountActions, 'updateEnabledTokensAccounts');
     stubGetAccount = stub(accountApi, 'getAccount').returnsPromise();
     transactionsActionsStub = spy(transactionsActions, 'updateTransactions');
     stubTransactions = stub(transactionsApi, 'getTransactions').returnsPromise().resolves(true);
@@ -103,6 +104,7 @@ describe('Account middleware', () => {
 
   afterEach(() => {
     accountActions.updateTransactionsIfNeeded.restore();
+    accountActions.updateEnabledTokensAccounts.restore();
     transactionsActionsStub.restore();
     stubGetAccount.restore();
     stubTransactions.restore();
@@ -230,6 +232,7 @@ describe('Account middleware', () => {
       data: { token: { list: { BTC: true } } },
     };
     middleware(store)(next)(settingsUpdatedAction);
+    expect(accountActions.updateEnabledTokensAccounts).to.have.been.calledWith('BTC');
     expect(store.dispatch).to.have.been.calledWith();
   });
 });

--- a/src/store/middlewares/account.test.js
+++ b/src/store/middlewares/account.test.js
@@ -92,7 +92,7 @@ describe('Account middleware', () => {
 
     next = spy();
     spy(accountActions, 'updateTransactionsIfNeeded');
-    spy(accountActions, 'updateEnabledTokensAccounts');
+    spy(accountActions, 'updateEnabledTokenAccount');
     stubGetAccount = stub(accountApi, 'getAccount').returnsPromise();
     transactionsActionsStub = spy(transactionsActions, 'updateTransactions');
     stubTransactions = stub(transactionsApi, 'getTransactions').returnsPromise().resolves(true);
@@ -104,7 +104,7 @@ describe('Account middleware', () => {
 
   afterEach(() => {
     accountActions.updateTransactionsIfNeeded.restore();
-    accountActions.updateEnabledTokensAccounts.restore();
+    accountActions.updateEnabledTokenAccount.restore();
     transactionsActionsStub.restore();
     stubGetAccount.restore();
     stubTransactions.restore();
@@ -232,7 +232,7 @@ describe('Account middleware', () => {
       data: { token: { list: { BTC: true } } },
     };
     middleware(store)(next)(settingsUpdatedAction);
-    expect(accountActions.updateEnabledTokensAccounts).to.have.been.calledWith('BTC');
+    expect(accountActions.updateEnabledTokenAccount).to.have.been.calledWith('BTC');
     expect(store.dispatch).to.have.been.calledWith();
   });
 });

--- a/src/store/middlewares/account.test.js
+++ b/src/store/middlewares/account.test.js
@@ -223,4 +223,13 @@ describe('Account middleware', () => {
     middleware(store)(next)(accountLoggedOutAction);
     expect(store.dispatch).to.have.been.calledWith({ type: actionTypes.emptyTransactionsData });
   });
+
+  it(`should update logged accounts on ${actionTypes.settingsUpdated} with enabled tokens`, async () => {
+    const settingsUpdatedAction = {
+      type: actionTypes.settingsUpdated,
+      data: { token: { list: { BTC: true } } },
+    };
+    middleware(store)(next)(settingsUpdatedAction);
+    expect(store.dispatch).to.have.been.calledWith();
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#2211

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Added action to get necessary accounts when account list changes.  
Added middleware to accounts middleware, to trigger the above action when the `settings.token.list` changes.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
1. Make sure that BTC is disabled on settings;
2. Login, should only have the LSK account listed;
3. Go to settings and enable BTC;
4. It should show BTC on the token switcher and dashboard.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
