### PR TITLE
HW: Cant open accounts selector if last used token is BTC - closes #2400 #2399

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -11,6 +11,7 @@ import { networkStatusUpdated } from './network';
 import { updateTransactions } from './transactions';
 import accountConfig from '../constants/account';
 import actionTypes from '../constants/actions';
+import { tokenMap } from '../constants/tokens';
 
 /**
  * Trigger this action to remove passphrase from account object
@@ -166,15 +167,17 @@ async function getAccounts(tokens, options) {
 
 export const updateEnabledTokenAccount = token => async (dispatch, getState) => {
   const { network: networkConfig, account } = getState();
-  const [error, result] = await to(getAccount({
-    token,
-    networkConfig,
-    passphrase: account.passphrase,
-  }));
-  if (error) {
-    dispatch(errorToastDisplayed({ label: getConnectionErrorMessage(error) }));
-  } else {
-    dispatch(accountUpdated(result));
+  if (token !== tokenMap.LSK.key) {
+    const [error, result] = await to(getAccount({
+      token,
+      networkConfig,
+      passphrase: account.passphrase,
+    }));
+    if (error) {
+      dispatch(errorToastDisplayed({ label: getConnectionErrorMessage(error) }));
+    } else {
+      dispatch(accountUpdated(result));
+    }
   }
 };
 

--- a/src/components/header/signInHeader/index.js
+++ b/src/components/header/signInHeader/index.js
@@ -19,7 +19,7 @@ const mapStateToProps = state => ({
     && state.network.networks[state.settings.token.active || tokenMap.LSK.key].nodeUrl)
     || (state.settings.network && state.settings.network.name === networks.customNode.name
       && state.settings.network.address)) || '',
-  liskAPIClient: getAPIClient(state.settings.token.active || tokenMap.LSK.key, state),
+  liskAPIClient: getAPIClient(tokenMap.LSK.key, state),
 });
 
 const mapDispatchToProps = {

--- a/src/components/hwWalletLogin/hwWalletLogin.js
+++ b/src/components/hwWalletLogin/hwWalletLogin.js
@@ -11,6 +11,12 @@ import styles from './hwWalletLogin.css';
 class HardwareWalletLogin extends React.Component {
   async componentDidMount() {
     await this.updateDeviceList();
+    this.props.settingsUpdated({
+      token: {
+        active: 'LSK',
+        list: { BTC: false, LSK: true },
+      },
+    });
   }
 
   async updateDeviceList() {

--- a/src/components/hwWalletLogin/index.js
+++ b/src/components/hwWalletLogin/index.js
@@ -4,6 +4,7 @@ import { translate } from 'react-i18next';
 import { updateDeviceList } from '../../actions/hwWallets';
 import { getAPIClient } from '../../utils/api/network';
 import { tokenMap } from '../../constants/tokens';
+import { settingsUpdated } from '../../actions/settings';
 import HardwareWalletLogin from './hwWalletLogin';
 
 const mapStateToProps = state => ({
@@ -14,6 +15,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = {
   updateDeviceList,
+  settingsUpdated,
 };
 
 export default connect(

--- a/src/components/setting/setting.js
+++ b/src/components/setting/setting.js
@@ -77,6 +77,7 @@ class Setting extends React.Component {
     const activeCurrency = currencies.indexOf(settings.currency || settingsConst.currencies[0]);
     const hasPendingSecondPassphrase = pending.find(element =>
       element.type === txTypes.setSecondPassphrase) !== undefined;
+    const isHarwareWalletConnected = settings.isHarwareWalletConnected;
 
     return (
       <div className={styles.settingsHolder}>
@@ -137,18 +138,24 @@ class Setting extends React.Component {
                   <p>{t('Enable a network switcher that lets you select testnet or custom node when logging in.')}</p>
                 </div>
               </label>
-              <label className={`${styles.fieldGroup} ${styles.checkboxField} enableBTC`}>
-                <CheckBox
-                  name="BTC"
-                  className={`${styles.checkbox}`}
-                  checked={!!(settings.token && settings.token.list.BTC)}
-                  onChange={this.handleTokenToggle}
-                />
-                <div>
-                  <span className={styles.labelName}>{t('Enable BTC')}</span>
-                  <p>{t('By enabling it, you will be able to manage your BTC inside the application.')}</p>
-                </div>
-              </label>
+              {
+                !isHarwareWalletConnected
+                  ? (
+                    <label className={`${styles.fieldGroup} ${styles.checkboxField} enableBTC`}>
+                      <CheckBox
+                        name="BTC"
+                        className={`${styles.checkbox}`}
+                        checked={!!(settings.token && settings.token.list.BTC)}
+                        onChange={this.handleTokenToggle}
+                      />
+                      <div>
+                        <span className={styles.labelName}>{t('Enable BTC')}</span>
+                        <p>{t('By enabling it, you will be able to manage your BTC inside the application.')}</p>
+                      </div>
+                    </label>
+                  )
+                  : null
+              }
             </section>
             <section>
               <h1>{t('Privacy')}</h1>

--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -19,7 +19,6 @@ import networks from '../../constants/networks';
 import settings from '../../constants/settings';
 import txFilters from '../../constants/transactionFilters';
 
-
 import { getDeviceList, getHWPublicKeyFromIndex } from '../../utils/hwWallet';
 import { loginType } from '../../constants/hwConstants';
 import localJSONStorage from '../../utils/localJSONStorage';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #2400 
-- #2399 

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
For this fix we had to use only LSK network when use is getting accounts from hw wallet as the previous code was using active token what was incorrect.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
1. login to the app.
2. switch to BTC.
3. logout.
4. then sign in with hwwallet
5. there is no more error and no error toaster 

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
