### PR TITLE
Prevent console warnings in registration - Closes #2416

### DIFF
--- a/src/components/register/backupPassphrase.js
+++ b/src/components/register/backupPassphrase.js
@@ -36,7 +36,7 @@ const BackupPassphrase = ({
       <span className={`${registerStyles.button}`}>
         <PrimaryButton
           className={`${registerStyles.continueBtn} yes-its-safe-button`}
-          onClick={nextStep}
+          onClick={() => nextStep()}
         >
           {t('Continue')}
         </PrimaryButton>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#2416

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
I created a function wrapper that makes sure that clicking "Continue" in `backupPassphrase` doesn't pass the click event object to `nectStep` prop.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Follow steps from #2416

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
