### PR TITLE
Implement and use getAccountsFromDevice util - Closes #2444

### DIFF
--- a/libs/hwManager/communication.js
+++ b/libs/hwManager/communication.js
@@ -32,7 +32,9 @@ const executeCommand = (action, payload) => (
  * not information in screen
  */
 const getPublicKey = async (data) => {
-  const response = await executeCommand(IPC_MESSAGES.GET_PUBLICK_KEY, data);
+  const response = await executeCommand(IPC_MESSAGES.HW_COMMAND, {
+    action: IPC_MESSAGES.GET_PUBLICK_KEY, data,
+  });
   return response;
 };
 

--- a/libs/hwManager/constants.js
+++ b/libs/hwManager/constants.js
@@ -18,6 +18,6 @@ export const IPC_MESSAGES = {
   HW_DISCONNECTED: 'hwDisconnected',
 };
 export const FUNCTION_TYPES = {
-  GET_PUBLICKEY: 'getPublicKey',
-  SIGN_TX: 'signTransaction',
+  [IPC_MESSAGES.GET_PUBLICK_KEY]: 'getPublicKey',
+  [IPC_MESSAGES.SIGN_TRANSACTION]: 'signTransaction',
 };

--- a/libs/hwManager/manufacturers/trezor/index.js
+++ b/libs/hwManager/manufacturers/trezor/index.js
@@ -95,7 +95,10 @@ const signTransaction = async (transporter, { device, data }) => {
   });
 };
 
+const checkIfInsideLiskApp = async ({ device }) => device;
+
 export default {
+  checkIfInsideLiskApp,
   getPublicKey,
   listener,
   signTransaction,

--- a/libs/hwManager/utils.js
+++ b/libs/hwManager/utils.js
@@ -1,4 +1,5 @@
 /* istanbul ignore file */
+import { to } from 'await-to-js';
 import { REQUEST, RESPONSE } from './constants';
 
 /**
@@ -10,10 +11,12 @@ import { REQUEST, RESPONSE } from './constants';
  */
 export const createCommand = (subscriber, { command, fn }) => {
   subscriber.on(`${command}.${REQUEST}`, async (event, ...args) => {
-    Promise.resolve(fn(...args))
-      .then(result => ({ success: true, data: result }))
-      .catch(error => ({ success: false, data: error }))
-      .then(result => event.sender.send(`${command}.${RESPONSE}`, result));
+    const [error, data] = await to(fn(...args));
+    event.sender.send(`${command}.${RESPONSE}`, {
+      success: !error,
+      data,
+      error,
+    });
   });
 };
 

--- a/src/components/hwWalletLogin/hwWalletLogin.js
+++ b/src/components/hwWalletLogin/hwWalletLogin.js
@@ -37,7 +37,7 @@ class HardwareWalletLogin extends React.Component {
   render() {
     const {
       history,
-      liskAPIClient,
+      network,
       t,
     } = this.props;
     const { devices } = this.state;
@@ -53,7 +53,7 @@ class HardwareWalletLogin extends React.Component {
             <SelectAccount
               t={t}
               devices={devices}
-              liskAPIClient={liskAPIClient}
+              networkConfig={network}
               history={history}
             />
           </MultiStep>

--- a/src/components/hwWalletLogin/hwWalletLogin.js
+++ b/src/components/hwWalletLogin/hwWalletLogin.js
@@ -47,7 +47,7 @@ class HardwareWalletLogin extends React.Component {
           <MultiStep
             className={`${grid['col-xs-10']}`}
           >
-            <Loading t={t} devices={devices} />
+            <Loading t={t} devices={devices} network={network} />
             <SelectDevice t={t} devices={devices} />
             <UnlockDevice t={t} devices={devices} history={history} />
             <SelectAccount

--- a/src/components/hwWalletLogin/index.js
+++ b/src/components/hwWalletLogin/index.js
@@ -2,13 +2,11 @@
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { translate } from 'react-i18next';
-import { getAPIClient } from '../../utils/api/network';
 import { settingsUpdated } from '../../actions/settings';
-import { tokenMap } from '../../constants/tokens';
 import HardwareWalletLogin from './hwWalletLogin';
 
 const mapStateToProps = state => ({
-  liskAPIClient: getAPIClient(state.settings.token.active || tokenMap.LSK.key, state),
+  network: state.network,
 });
 
 const mapDispatchToProps = {

--- a/src/components/hwWalletLogin/loading.js
+++ b/src/components/hwWalletLogin/loading.js
@@ -14,7 +14,7 @@ class Loading extends React.Component {
   }
 
   goNextIfDeviceConnected() {
-    if (this.props.devices.length > 0) {
+    if (this.props.devices.length > 0 && this.props.network.name) {
       this.props.nextStep();
     }
   }

--- a/src/components/hwWalletLogin/loading.test.js
+++ b/src/components/hwWalletLogin/loading.test.js
@@ -9,6 +9,7 @@ describe('HW Wallet -> Loading', () => {
     devices: [],
     nextStep: jest.fn(),
     t: key => key,
+    network: { name: 'Mainnet' },
   };
 
 

--- a/src/components/hwWalletLogin/selectAccount/selectAccount.js
+++ b/src/components/hwWalletLogin/selectAccount/selectAccount.js
@@ -1,3 +1,4 @@
+import { to } from 'await-to-js';
 import React from 'react';
 import { TertiaryButton } from '../../toolbox/buttons/button';
 import { getAccountsFromDevice } from '../../../utils/hwManager';
@@ -11,7 +12,6 @@ class SelectAccount extends React.Component {
     super(props);
 
     this.state = {
-      activeDevice: null,
       accountOnEditMode: -1,
       hwAccounts: [],
     };
@@ -51,14 +51,18 @@ class SelectAccount extends React.Component {
   }
 
   async getAccountsFromDevice() {
-    const { device, liskAPIClient } = this.props;
-    let hwAccounts = await getAccountsFromDevice({ device, liskAPIClient });
-    hwAccounts = hwAccounts.map((account, index) => ({
-      ...account,
-      name: this.getNameFromAccount(account.address),
-      shouldShow: !!account.balance || index === 0,
-    }));
-    this.setState({ hwAccounts });
+    const { device, networkConfig, errorToastDisplayed } = this.props;
+    const [error, accounts] = await to(getAccountsFromDevice({ device, networkConfig }));
+    if (error) {
+      errorToastDisplayed({ label: `Error retrieving accounts from device: ${error}` });
+    } else {
+      const hwAccounts = accounts.map((account, index) => ({
+        ...account,
+        name: this.getNameFromAccount(account.address),
+        shouldShow: !!account.balance || index === 0,
+      }));
+      this.setState({ hwAccounts });
+    }
   }
 
   onEditAccount(index) {

--- a/src/components/hwWalletLogin/selectAccount/selectAccount.js
+++ b/src/components/hwWalletLogin/selectAccount/selectAccount.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import { TertiaryButton } from '../../toolbox/buttons/button';
 import { displayAccounts } from '../../../utils/ledger';
+import { getAccountsFromDevice } from '../../../utils/hwManager';
 import { loginType } from '../../../constants/hwConstants';
-import routes from '../../../constants/routes';
 import AccountCard from './accountCard';
 import LoadingIcon from '../loadingIcon';
+import routes from '../../../constants/routes';
 import styles from './selectAccount.css';
 
 class SelectAccount extends React.Component {
@@ -19,7 +20,6 @@ class SelectAccount extends React.Component {
 
     this.onEditAccount = this.onEditAccount.bind(this);
     this.onChangeAccountTitle = this.onChangeAccountTitle.bind(this);
-    this.getAccountsFromDevice = this.getAccountsFromDevice.bind(this);
     this.onSaveNameAccounts = this.onSaveNameAccounts.bind(this);
     this.onAddNewAccount = this.onAddNewAccount.bind(this);
     this.onSelectAccount = this.onSelectAccount.bind(this);
@@ -56,24 +56,15 @@ class SelectAccount extends React.Component {
     const {
       device,
       liskAPIClient,
-      t,
     } = this.props;
-    let activeDevice = '';
-
-    setTimeout(async () => {
-      activeDevice = await displayAccounts({
-        liskAPIClient,
-        loginType: /trezor/ig.test(device.deviceModel) ? loginType.trezor : loginType.ledger,
-        hwAccounts: [],
-        t,
-        device,
-      });
-
-      const hwAccounts = activeDevice.hwAccounts.map(account =>
-        ({ ...account, name: this.getNameFromAccount(account.address) }));
-
-      this.setState({ activeDevice: { ...activeDevice }, hwAccounts });
-    }, 1000);
+    let hwAccounts = await getAccountsFromDevice({
+      device,
+      liskAPIClient,
+    });
+    hwAccounts = hwAccounts.map(account => ({
+      ...account, name: this.getNameFromAccount(account.address),
+    }));
+    this.setState({ hwAccounts });
   }
 
   onEditAccount(index) {

--- a/src/components/hwWalletLogin/selectAccount/selectAccount.test.js
+++ b/src/components/hwWalletLogin/selectAccount/selectAccount.test.js
@@ -16,35 +16,27 @@ describe('Select Account', () => {
       name: 'Unnamed account',
       address: '123456L',
       balance: 100,
-      isInitialized: true,
     },
     {
       name: 'Unnamed account',
       address: '098765L',
       balance: 50,
-      isInitialized: true,
     },
     {
       name: 'Unnamed account',
       address: '112233L',
       balance: 150,
-      isInitialized: true,
     },
-  ];
-
-  const newMockValue = [
-    ...mockValue,
     {
       name: 'Unnamed account',
       address: '555555L',
       balance: 0,
-      isInitialized: false,
     },
   ];
 
-  hwManager.getAccountsFromDevice.mockResolvedValue(mockValue);
-
   beforeEach(() => {
+    hwManager.getAccountsFromDevice.mockResolvedValue(mockValue);
+
     props = {
       devices: [
         { deviceId: 1, openApp: false, model: 'Ledger' },
@@ -88,9 +80,6 @@ describe('Select Account', () => {
   });
 
   it('Should render SelectAccount properly', async () => {
-    jest.advanceTimersByTime(2000);
-    const activeDevice = await hwManager.getAccountsFromDevice();
-    expect(activeDevice).toEqual(mockValue);
     expect(wrapper).toContainMatchingElement('.create-account');
     expect(wrapper).toContainMatchingElement('.hw-container');
     expect(wrapper).toContainMatchingElement('.go-back');
@@ -105,7 +94,6 @@ describe('Select Account', () => {
   });
 
   it('Should change name "label" of one account', async () => {
-    jest.advanceTimersByTime(2000);
     await hwManager.getAccountsFromDevice();
     wrapper.update();
     expect(wrapper.find('.hw-container')).toContainMatchingElement('.hw-account');
@@ -119,35 +107,25 @@ describe('Select Account', () => {
     expect(wrapper.find('.account-name').at(0).text()).toEqual('Lisk Account');
   });
 
-  it.skip('Should add another account to the list after do click on create account button', async () => {
-    jest.advanceTimersByTime(2000);
-    await hwManager.getAccountsFromDevice();
+  it('Should add another account to the list after do click on create account button', () => {
     wrapper.update();
     expect(wrapper).toContainMatchingElement('.create-account');
     expect(wrapper).toContainMatchingElements(3, '.hw-account');
-    hwManager.getAccountsFromDevice.mockResolvedValue(newMockValue);
     wrapper.find('.create-account').at(0).simulate('click');
-    await hwManager.getAccountsFromDevice();
     wrapper.update();
     expect(wrapper).toContainMatchingElements(4, '.hw-account');
   });
 
-  it.skip('Should NOT add another account to the list after do click on create account button', async () => {
-    jest.advanceTimersByTime(2000);
-    hwManager.getAccountsFromDevice.mockResolvedValue(newMockValue);
-    await hwManager.getAccountsFromDevice();
-    wrapper.update();
+  it('Should NOT add another account to the list after do click on create account button', () => {
     expect(wrapper).toContainMatchingElement('.create-account');
+    wrapper.find('.create-account').at(0).simulate('click');
     expect(wrapper).toContainMatchingElements(4, '.hw-account');
     wrapper.find('.create-account').at(0).simulate('click');
-    await hwManager.getAccountsFromDevice();
     wrapper.update();
     expect(props.errorToastDisplayed).toBeCalled();
   });
 
-  it('Should call login function after click on a select account button', async () => {
-    jest.advanceTimersByTime(2000);
-    await hwManager.getAccountsFromDevice();
+  it('Should call login function after click on a select account button', () => {
     wrapper.update();
     expect(wrapper.find('.hw-container')).toContainMatchingElement('.hw-account');
     wrapper.find('.select-account').at(0).simulate('click');

--- a/src/components/hwWalletLogin/selectAccount/selectAccount.test.js
+++ b/src/components/hwWalletLogin/selectAccount/selectAccount.test.js
@@ -1,67 +1,48 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import * as utils from '../../../utils/ledger';
 import SelectAccount from './selectAccount';
+import * as hwManager from '../../../utils/hwManager';
+import routes from '../../../constants/routes';
 
 jest.mock('../../../constants/routes.js');
-jest.mock('../../../utils/ledger.js');
+jest.mock('../../../utils/hwManager');
 
 describe('Select Account', () => {
   let wrapper;
   let props;
 
-  const mockValue = {
-    hwAccounts: [
-      {
-        name: 'Unnamed account',
-        address: '123456L',
-        balance: 100,
-        isInitialized: true,
-      },
-      {
-        name: 'Unnamed account',
-        address: '098765L',
-        balance: 50,
-        isInitialized: true,
-      },
-      {
-        name: 'Unnamed account',
-        address: '112233L',
-        balance: 150,
-        isInitialized: true,
-      },
-    ],
-  };
+  const mockValue = [
+    {
+      name: 'Unnamed account',
+      address: '123456L',
+      balance: 100,
+      isInitialized: true,
+    },
+    {
+      name: 'Unnamed account',
+      address: '098765L',
+      balance: 50,
+      isInitialized: true,
+    },
+    {
+      name: 'Unnamed account',
+      address: '112233L',
+      balance: 150,
+      isInitialized: true,
+    },
+  ];
 
-  const newMockValue = {
-    hwAccounts: [
-      {
-        name: 'Unnamed account',
-        address: '123456L',
-        balance: 100,
-        isInitialized: true,
-      },
-      {
-        name: 'Unnamed account',
-        address: '098765L',
-        balance: 50,
-        isInitialized: true,
-      },
-      {
-        name: 'Unnamed account',
-        address: '112233L',
-        balance: 150,
-        isInitialized: true,
-      },
-      {
-        name: 'Unnamed account',
-        address: '555555L',
-        balance: 0,
-        isInitialized: false,
-      },
-    ],
-  };
-  utils.displayAccounts.mockResolvedValue(mockValue);
+  const newMockValue = [
+    ...mockValue,
+    {
+      name: 'Unnamed account',
+      address: '555555L',
+      balance: 0,
+      isInitialized: false,
+    },
+  ];
+
+  hwManager.getAccountsFromDevice.mockResolvedValue(mockValue);
 
   beforeEach(() => {
     props = {
@@ -108,7 +89,7 @@ describe('Select Account', () => {
 
   it('Should render SelectAccount properly', async () => {
     jest.advanceTimersByTime(2000);
-    const activeDevice = await utils.displayAccounts();
+    const activeDevice = await hwManager.getAccountsFromDevice();
     expect(activeDevice).toEqual(mockValue);
     expect(wrapper).toContainMatchingElement('.create-account');
     expect(wrapper).toContainMatchingElement('.hw-container');
@@ -117,15 +98,15 @@ describe('Select Account', () => {
 
   it('Should call push function if do click in Go Back button', () => {
     wrapper = mount(<SelectAccount {...props} />);
-    expect(props.history.push).not.toBeCalled();
+    expect(props.history.push).not.toBeCalledWith(routes.splashscreen.path);
     wrapper.find('.go-back').at(0).simulate('click');
     wrapper.update();
-    expect(props.history.push).toBeCalled();
+    expect(props.history.push).toBeCalledWith(routes.splashscreen.path);
   });
 
   it('Should change name "label" of one account', async () => {
     jest.advanceTimersByTime(2000);
-    await utils.displayAccounts();
+    await hwManager.getAccountsFromDevice();
     wrapper.update();
     expect(wrapper.find('.hw-container')).toContainMatchingElement('.hw-account');
     wrapper.simulate('mouseover');
@@ -138,35 +119,35 @@ describe('Select Account', () => {
     expect(wrapper.find('.account-name').at(0).text()).toEqual('Lisk Account');
   });
 
-  it('Should add another account to the list after do click on create account button', async () => {
+  it.skip('Should add another account to the list after do click on create account button', async () => {
     jest.advanceTimersByTime(2000);
-    await utils.displayAccounts();
+    await hwManager.getAccountsFromDevice();
     wrapper.update();
     expect(wrapper).toContainMatchingElement('.create-account');
     expect(wrapper).toContainMatchingElements(3, '.hw-account');
-    utils.displayAccounts.mockResolvedValue(newMockValue);
+    hwManager.getAccountsFromDevice.mockResolvedValue(newMockValue);
     wrapper.find('.create-account').at(0).simulate('click');
-    await utils.displayAccounts();
+    await hwManager.getAccountsFromDevice();
     wrapper.update();
     expect(wrapper).toContainMatchingElements(4, '.hw-account');
   });
 
-  it('Should NOT add another account to the list after do click on create account button', async () => {
+  it.skip('Should NOT add another account to the list after do click on create account button', async () => {
     jest.advanceTimersByTime(2000);
-    utils.displayAccounts.mockResolvedValue(newMockValue);
-    await utils.displayAccounts();
+    hwManager.getAccountsFromDevice.mockResolvedValue(newMockValue);
+    await hwManager.getAccountsFromDevice();
     wrapper.update();
     expect(wrapper).toContainMatchingElement('.create-account');
     expect(wrapper).toContainMatchingElements(4, '.hw-account');
     wrapper.find('.create-account').at(0).simulate('click');
-    await utils.displayAccounts();
+    await hwManager.getAccountsFromDevice();
     wrapper.update();
     expect(props.errorToastDisplayed).toBeCalled();
   });
 
   it('Should call login function after click on a select account button', async () => {
     jest.advanceTimersByTime(2000);
-    await utils.displayAccounts();
+    await hwManager.getAccountsFromDevice();
     wrapper.update();
     expect(wrapper.find('.hw-container')).toContainMatchingElement('.hw-account');
     wrapper.find('.select-account').at(0).simulate('click');

--- a/src/components/hwWalletLogin/selectAccount/selectAccount.test.js
+++ b/src/components/hwWalletLogin/selectAccount/selectAccount.test.js
@@ -54,7 +54,7 @@ describe('Select Account', () => {
         name: 'Lisk',
         publicKey: '123bkgj45',
       },
-      network: 0,
+      network: {},
       settings: {
         hardwareAccounts: {
           'Ledger Nano S': [

--- a/src/utils/hwManager.js
+++ b/src/utils/hwManager.js
@@ -13,21 +13,14 @@ import {
  * getAccountsFromDevice - Function.
  * This function is used for retrieve the accounts from an hw device, using public keys.
  */
-// eslint-disable-next-line max-statements
-const getAccountsFromDevice = async ({ device: { deviceId }, liskAPIClient }) => {
+const getAccountsFromDevice = async ({ device: { deviceId }, networkConfig }) => {
   const accounts = [];
   let account = {};
   for (let index = 0; index === accounts.length; index++) {
-    try {
-      // eslint-disable-next-line no-await-in-loop
-      const publicKey = await getPublicKey({ index, deviceId });
-      // eslint-disable-next-line no-await-in-loop
-      account = await getAccount({ liskAPIClient, publicKey });
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error(error);
-      break;
-    }
+    // eslint-disable-next-line no-await-in-loop
+    const publicKey = await getPublicKey({ index, deviceId });
+    // eslint-disable-next-line no-await-in-loop
+    account = await getAccount({ networkConfig, publicKey });
     if (index === 0 || accounts[index - 1].balance) {
       accounts.push(account);
     }

--- a/src/utils/hwManager.js
+++ b/src/utils/hwManager.js
@@ -11,7 +11,7 @@ import {
 
 /**
  * getAccountsFromDevice - Function.
- * This function is used for retrieve the accounts from an hw device, using publick keys.
+ * This function is used for retrieve the accounts from an hw device, using public keys.
  */
 // eslint-disable-next-line max-statements
 const getAccountsFromDevice = async ({ device: { deviceId }, liskAPIClient }) => {
@@ -28,7 +28,7 @@ const getAccountsFromDevice = async ({ device: { deviceId }, liskAPIClient }) =>
       console.error(error);
       break;
     }
-    if (account.balance) {
+    if (index === 0 || accounts[index - 1].balance) {
       accounts.push(account);
     }
   }

--- a/src/utils/hwManager.js
+++ b/src/utils/hwManager.js
@@ -1,5 +1,6 @@
 // istanbul ignore file
 // TODO include unit test
+import { getAccount } from './api/lsk/account';
 import {
   getPublicKey,
   signTransaction,
@@ -12,10 +13,26 @@ import {
  * getAccountsFromDevice - Function.
  * This function is used for retrieve the accounts from an hw device, using publick keys.
  */
-const getAccountsFromDevice = async () => {
-  // TODO implement logic for this function
-  getPublicKey();
-  throw new Error('not umplemented');
+// eslint-disable-next-line max-statements
+const getAccountsFromDevice = async ({ device: { deviceId }, liskAPIClient }) => {
+  const accounts = [];
+  let account = {};
+  for (let index = 0; index === accounts.length; index++) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const publicKey = await getPublicKey({ index, deviceId });
+      // eslint-disable-next-line no-await-in-loop
+      account = await getAccount({ liskAPIClient, publicKey });
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error);
+      break;
+    }
+    if (account.balance) {
+      accounts.push(account);
+    }
+  }
+  return accounts;
 };
 
 /**

--- a/src/utils/hwManager.test.js
+++ b/src/utils/hwManager.test.js
@@ -1,0 +1,34 @@
+import { getAccountsFromDevice } from './hwManager';
+import * as accountApi from './api/lsk/account';
+import accounts from '../../test/constants/accounts';
+import * as communication from '../../libs/hwManager/communication';
+
+jest.mock('../../libs/hwManager/communication', () => ({
+  getPublicKey: jest.fn(),
+}));
+
+jest.mock('./api/lsk/account', () => ({
+  getAccount: jest.fn(),
+}));
+
+describe('hwManager util', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getAccountsFromDevice', () => {
+    it('should resolve all non-empty and one empty account', async () => {
+      communication.getPublicKey.mockResolvedValueOnce(accounts.genesis.publicKey);
+      communication.getPublicKey.mockResolvedValueOnce(accounts.empty_account.publicKey);
+      accountApi.getAccount.mockResolvedValueOnce(accounts.genesis);
+      accountApi.getAccount.mockResolvedValueOnce(accounts.empty_account);
+
+      const device = { deviceId: '1234125125' };
+      const networkConfig = { name: 'Testnet', networks: {} };
+
+      const accountsOnDevice = await getAccountsFromDevice({ device, networkConfig });
+
+      expect(accountsOnDevice).toEqual([accounts.genesis, accounts.empty_account]);
+    });
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#2444

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
- [x] :recycle: Update `SelectAccount` component to use `getAccountsFromDevice`
- [x] :recycle: Fix "Create an account" to work with `getAccountsFromDevice`
- [x] :bug: Don't leave hw loading page if no network so that loading accounts on `SelectAccount` won't get stuck on missing network when refreshing the hw login page.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Check everything still works when
- Try to login to a hardware wallet
- Try to create a new account on a hardware wallet

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
