### PR TITLE
Implement and use signSendTransaction and signVoteTransaction utils - closes #2445

### DIFF
--- a/libs/hwManager/communication.js
+++ b/libs/hwManager/communication.js
@@ -10,6 +10,7 @@ const IPC = window.ipc;
  * executeCommand - Function.
  * Use for send and request data to the HWManager.
  */
+<<<<<<< HEAD
 const executeCommand = (action, payload) => (
   new Promise((resolve, reject) => {
     // Listening for response
@@ -21,6 +22,17 @@ const executeCommand = (action, payload) => (
     IPC.send(`${action}.${REQUEST}`, payload);
   })
 );
+=======
+const executeCommand = (action, payload) => new Promise((resolve, reject) => {
+  // Listening for response
+  IPC.once(`${action}.result`, (event, response) => {
+    if (response.success) return resolve(response.data);
+    return reject(new Error(`${action} failed`));
+  });
+  // Requesting data
+  IPC.send(`${action}.request`, payload);
+});
+>>>>>>> :recycle: add hwMananger signSendTransaction
 
 /**
  * getPublicKey - Function.

--- a/libs/hwManager/communication.js
+++ b/libs/hwManager/communication.js
@@ -10,7 +10,6 @@ const IPC = window.ipc;
  * executeCommand - Function.
  * Use for send and request data to the HWManager.
  */
-<<<<<<< HEAD
 const executeCommand = (action, payload) => (
   new Promise((resolve, reject) => {
     // Listening for response
@@ -22,17 +21,6 @@ const executeCommand = (action, payload) => (
     IPC.send(`${action}.${REQUEST}`, payload);
   })
 );
-=======
-const executeCommand = (action, payload) => new Promise((resolve, reject) => {
-  // Listening for response
-  IPC.once(`${action}.result`, (event, response) => {
-    if (response.success) return resolve(response.data);
-    return reject(new Error(`${action} failed`));
-  });
-  // Requesting data
-  IPC.send(`${action}.request`, payload);
-});
->>>>>>> :recycle: add hwMananger signSendTransaction
 
 /**
  * getPublicKey - Function.

--- a/libs/hwManager/communication.js
+++ b/libs/hwManager/communication.js
@@ -47,7 +47,13 @@ const getPublicKey = async (data) => {
  * @param {object} data.tx -> Object with all transaction information
  */
 const signTransaction = async (data) => {
-  const response = await executeCommand(IPC_MESSAGES.SIGN_TRANSACTION, data);
+  const response = await executeCommand(
+    IPC_MESSAGES.HW_COMMAND,
+    {
+      action: IPC_MESSAGES.SIGN_TRANSACTION,
+      data,
+    },
+  );
   return response;
 };
 

--- a/src/actions/transactions.js
+++ b/src/actions/transactions.js
@@ -11,7 +11,8 @@ import { passphraseUsed } from './account';
 import { getTimeOffset } from '../utils/hacks';
 import { sendWithHW } from '../utils/api/hwWallet';
 import { loginType } from '../constants/hwConstants';
-import { transactions as transactionsAPI, hardwareWallet as hwAPI } from '../utils/api';
+import { transactions as transactionsAPI } from '../utils/api';
+import { signSendTransaction } from '../utils/hwManager';
 
 // ========================================= //
 //            ACTION CREATORS
@@ -257,7 +258,7 @@ export const transactionCreated = data => async (dispatch, getState) => {
       { ...data, timeOffset, network },
       createTransactionType.transaction,
     ))
-    : await to(hwAPI.create(account, data));
+    : await to(signSendTransaction(account, data));
 
   if (error) {
     return dispatch({

--- a/src/utils/hwManager.js
+++ b/src/utils/hwManager.js
@@ -1,5 +1,3 @@
-// istanbul ignore file
-// TODO include unit test
 import { castVotes, utils } from '@liskhq/lisk-transactions';
 import i18next from 'i18next';
 import { getAccount } from './api/lsk/account';
@@ -36,6 +34,7 @@ const getAccountsFromDevice = async ({ device: { deviceId }, networkConfig }) =>
  * signSendTransaction - Function.
  * This function is used for sign a send transaction.
  */
+// eslint-disable-next-line max-statements
 const signSendTransaction = async (account, data) => {
   const transactionObject = createSendTX(
     account.info.LSK.publicKey,
@@ -56,7 +55,7 @@ const signSendTransaction = async (account, data) => {
     const result = { ...signedTransaction, id: utils.getTransactionId(signedTransaction) };
     return result;
   } catch (error) {
-    return new Error(error);
+    throw new Error(error);
   }
 };
 
@@ -79,6 +78,7 @@ const signVoteTransaction = async (
         senderPublicKey: account.publicKey,
         recipientId: account.address,
       };
+
       // eslint-disable-next-line no-await-in-loop
       const signature = await signTransaction({
         deviceId: account.hwInfo.deviceId,
@@ -95,7 +95,7 @@ const signVoteTransaction = async (
 
     return signedTransactions;
   } catch (error) {
-    return new Error(i18next.t(
+    throw new Error(i18next.t(
       'The transaction has been canceled on your {{model}}',
       { model: account.hwInfo.deviceModel },
     ));

--- a/src/utils/hwManager.js
+++ b/src/utils/hwManager.js
@@ -1,6 +1,7 @@
 // istanbul ignore file
 // TODO include unit test
 import to from 'await-to-js';
+import i18next from 'i18next';
 import { getAccount } from './api/lsk/account';
 import {
   getPublicKey,
@@ -9,8 +10,8 @@ import {
   subscribeToDeviceDisonnceted,
   subscribeToDevicesList,
 } from '../../libs/hwManager/communication';
-import { calculateTxId, createSendTX } from './rawTransactionWrapper';
-import { calculateSecondPassphraseIndex } from '../constants/hwConstants';
+import { calculateTxId, createSendTX, createRawVoteTX } from './rawTransactionWrapper';
+import { splitVotesIntoRounds } from './voting';
 
 /**
  * getAccountsFromDevice - Function.
@@ -35,7 +36,7 @@ const getAccountsFromDevice = async ({ device: { deviceId }, networkConfig }) =>
  * signSendTransaction - Function.
  * This function is used for sign a send transaction.
  */
-const signSendTransaction = async (account, data, pin = null) => {
+const signSendTransaction = async (account, data) => {
   const transactionObject = createSendTX(
     account.info.LSK.publicKey,
     data.recipientId,
@@ -43,11 +44,12 @@ const signSendTransaction = async (account, data, pin = null) => {
     data.data,
   );
 
-  const index = (typeof pin === 'string' && pin !== '')
-    ? calculateSecondPassphraseIndex(account.hwInfo.derivationIndex, pin)
-    : account.hwInfo.derivationIndex;
+  const transaction = {
+    deviceId: account.hwInfo.deviceId,
+    index: account.hwInfo.derivationIndex,
+    tx: transactionObject,
+  };
 
-  const transaction = { deviceId: account.hwInfo.deviceId, index, tx: transactionObject };
   const [error, signature] = await to(signTransaction(transaction));
 
   if (error) throw new Error(error);
@@ -60,10 +62,43 @@ const signSendTransaction = async (account, data, pin = null) => {
  * signVoteTransaction - Function.
  * This function is used for sign a vote transaction.
  */
-const signVoteTransaction = () => {
-  // TODO implement logic for this function
-  signTransaction();
-  throw new Error('not umplemented');
+const signVoteTransaction = async (
+  account,
+  votedList,
+  unvotedList,
+) => {
+  const signedTransactions = [];
+  const votesChunks = splitVotesIntoRounds({ votes: [...votedList], unvotes: [...unvotedList] });
+
+  try {
+    for (let i = 0; i < votesChunks.length; i++) {
+      const transactionObject = createRawVoteTX(
+        account.publicKey,
+        account.address,
+        votesChunks[i].votes,
+        votesChunks[i].unvotes,
+      );
+
+      // eslint-disable-next-line no-await-in-loop
+      const signature = await signTransaction({
+        deviceId: account.hwInfo.deviceId,
+        index: account.hwInfo.derivationIndex,
+        tx: transactionObject,
+      });
+
+      signedTransactions.push({
+        ...transactionObject,
+        signature,
+        id: calculateTxId({ ...transactionObject, signature }),
+      });
+    }
+    return signedTransactions;
+  } catch (error) {
+    return new Error(i18next.t(
+      'The transaction has been canceled on your {{model}}',
+      { model: account.hwInfo.deviceModel },
+    ));
+  }
 };
 
 export {

--- a/src/utils/hwManager.js
+++ b/src/utils/hwManager.js
@@ -1,5 +1,6 @@
 // istanbul ignore file
 // TODO include unit test
+import to from 'await-to-js';
 import { getAccount } from './api/lsk/account';
 import {
   getPublicKey,
@@ -8,6 +9,8 @@ import {
   subscribeToDeviceDisonnceted,
   subscribeToDevicesList,
 } from '../../libs/hwManager/communication';
+import { calculateTxId, createSendTX } from './rawTransactionWrapper';
+import { calculateSecondPassphraseIndex } from '../constants/hwConstants';
 
 /**
  * getAccountsFromDevice - Function.
@@ -32,10 +35,25 @@ const getAccountsFromDevice = async ({ device: { deviceId }, networkConfig }) =>
  * signSendTransaction - Function.
  * This function is used for sign a send transaction.
  */
-const signSendTransaction = () => {
-  // TODO implement logic for this function
-  signTransaction();
-  throw new Error('not umplemented');
+const signSendTransaction = async (account, data, pin = null) => {
+  const transactionObject = createSendTX(
+    account.info.LSK.publicKey,
+    data.recipientId,
+    data.amount,
+    data.data,
+  );
+
+  const index = (typeof pin === 'string' && pin !== '')
+    ? calculateSecondPassphraseIndex(account.hwInfo.derivationIndex, pin)
+    : account.hwInfo.derivationIndex;
+
+  const transaction = { deviceId: account.hwInfo.deviceId, index, tx: transactionObject };
+  const [error, signature] = await to(signTransaction(transaction));
+
+  if (error) throw new Error(error);
+  const signedTransaction = { ...transactionObject, signature };
+  const result = { ...signedTransaction, id: calculateTxId(signedTransaction) };
+  return result;
 };
 
 /**

--- a/src/utils/hwManager.test.js
+++ b/src/utils/hwManager.test.js
@@ -1,10 +1,11 @@
-import { getAccountsFromDevice } from './hwManager';
+import { getAccountsFromDevice, signSendTransaction, signVoteTransaction } from './hwManager';
 import * as accountApi from './api/lsk/account';
 import accounts from '../../test/constants/accounts';
 import * as communication from '../../libs/hwManager/communication';
 
 jest.mock('../../libs/hwManager/communication', () => ({
   getPublicKey: jest.fn(),
+  signTransaction: jest.fn(),
 }));
 
 jest.mock('./api/lsk/account', () => ({
@@ -12,6 +13,10 @@ jest.mock('./api/lsk/account', () => ({
 }));
 
 describe('hwManager util', () => {
+  beforeEach(() => {
+    communication.signTransaction.mockResolvedValueOnce('abc123ABC789');
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -29,6 +34,70 @@ describe('hwManager util', () => {
       const accountsOnDevice = await getAccountsFromDevice({ device, networkConfig });
 
       expect(accountsOnDevice).toEqual([accounts.genesis, accounts.empty_account]);
+    });
+  });
+
+  describe('signSendTransaction', () => {
+    it('should return a transaction object with the proper signature', async () => {
+      const account = {
+        info: {
+          LSK: {
+            address: '7955155501030618852L',
+            publicKey: '9c854ea85fbcb32e2c5d2c7a820a354a6627213ebb74b42b1ee851d4e4fa035e',
+          },
+        },
+        hwInfo: {
+          deviceId: '060E803263E985C022CA2C9B',
+          derivationIndex: 0,
+        },
+      };
+
+      const data = {
+        amount: '100000000',
+        data: 'testing',
+        fee: '10000000',
+        passphrase: undefined,
+        recipientId: '7955155501030618852L',
+        secondPassphrase: null,
+        dynamicFeePerByte: 0,
+      };
+
+      const signedTransactions = await signSendTransaction(account, data);
+
+      expect(signedTransactions).toHaveProperty('id');
+      expect(signedTransactions).toHaveProperty('signature');
+      expect(signedTransactions).toHaveProperty('amount', '100000000');
+      expect(signedTransactions).toHaveProperty('asset', { data: 'testing' });
+      expect(signedTransactions).toHaveProperty('fee', '10000000');
+      expect(signedTransactions).toHaveProperty('recipientId', '7955155501030618852L');
+      expect(signedTransactions).toHaveProperty('senderPublicKey', '9c854ea85fbcb32e2c5d2c7a820a354a6627213ebb74b42b1ee851d4e4fa035e');
+    });
+  });
+
+  describe('signVoteTransaction', () => {
+    it('should return a transaction object with the proper signature', async () => {
+      const account = {
+        address: '7955155501030618852L',
+        publicKey: '9c854ea85fbcb32e2c5d2c7a820a354a6627213ebb74b42b1ee851d4e4fa035e',
+        hwInfo: {
+          deviceId: '060E803263E985C022CA2C9B',
+          derivationIndex: 0,
+        },
+      };
+
+      const votedList = ['3193057832bb1c9782a8e4a32e543b535ed9d750b1b10383f8b6f50853569609'];
+      const unvotedList = ['473c354cdf627b82e9113e02a337486dd3afc5615eb71ffd311c5a0beda37b8c'];
+
+      const signedTransactions = await signVoteTransaction(account, votedList, unvotedList);
+      signedTransactions.forEach((tx) => {
+        expect(tx).toHaveProperty('id');
+        expect(tx).toHaveProperty('signature');
+        expect(tx).toHaveProperty('amount', '0');
+        expect(tx).toHaveProperty('asset');
+        expect(tx).toHaveProperty('fee', '100000000');
+        expect(tx).toHaveProperty('recipientId', '7955155501030618852L');
+        expect(tx).toHaveProperty('senderPublicKey', '9c854ea85fbcb32e2c5d2c7a820a354a6627213ebb74b42b1ee851d4e4fa035e');
+      });
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #2445 

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
This PR includes the implementation of the hwManager sign transaction for send and vote.

- [x] Implementation of sendSignTransaction
- [x] Implementation of voteSignTransaction
- [x] remove unnecessary code

### How has this been tested?
<!--- Please describe how you tested your changes. -->
For test this, you have to manually run the following steps.

1. Run the application in electron.
2. Sign In with any hw device.
3. Go to send fill the form with the desire information and do click in the go to confirmation button.
4. Then you should watch in the hw device screen the information properly.
5. You can decline or accept the transaction in the hw device and see the correct result in the next page.

For voting you have to follow the same steps but off course in the delegate page and removing or adding new delegates after you do click in confirm button, you will see in the hw device screen the information based on what you select and after decline or accept the transaction you will see the corresponding result in the next page.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
