### PR TITLE
Remove unused mount options from unit tests - Closes #2481

### DIFF
--- a/src/components/screens/bookmarks/bookmarkDropdown/bookmarkDropdown.test.js
+++ b/src/components/screens/bookmarks/bookmarkDropdown/bookmarkDropdown.test.js
@@ -1,18 +1,10 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { mount } from 'enzyme';
-import i18n from '../../../../i18n';
 import accounts from '../../../../../test/constants/accounts';
 import BookmarkDropdown from './bookmarkDropdown';
 
 describe('Bookmark Component', () => {
   let wrapper;
-  const options = {
-    context: { i18n },
-    childContextTypes: {
-      i18n: PropTypes.object.isRequired,
-    },
-  };
 
   const props = {
     address: accounts.genesis.address,
@@ -27,7 +19,7 @@ describe('Bookmark Component', () => {
   };
 
   beforeEach(() => {
-    wrapper = mount(<BookmarkDropdown {...props} />, options);
+    wrapper = mount(<BookmarkDropdown {...props} />);
   });
 
   describe('Should render in bookmark and bookmarking states', () => {
@@ -38,7 +30,7 @@ describe('Bookmark Component', () => {
         isBookmark: true,
         bookmarks: { LSK: [account], BTC: [] },
       };
-      wrapper = mount(<BookmarkDropdown {...bookmarkProps} />, options);
+      wrapper = mount(<BookmarkDropdown {...bookmarkProps} />);
       expect(wrapper.find('input[name="accountName"]')).toHaveValue(account.title);
       expect(wrapper.find('button').last()).toHaveText('Remove bookmark');
       wrapper.find('button').last().simulate('click');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
Closes #2481

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
- [ ] Removed the mount options from all tests that used it

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Check test files for use of mount options. I checked it with:
```
$ git grep -l "import PropTypes" | grep 'test.js'
```

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
