### PR TITLE
Implement sorting of active delegates in monitor - Closes #2562

### DIFF
--- a/src/components/screens/monitor/delegates/delegates.js
+++ b/src/components/screens/monitor/delegates/delegates.js
@@ -10,10 +10,13 @@ import Tooltip from '../../../toolbox/tooltip/tooltip';
 import routes from '../../../../constants/routes';
 
 const Delegates = ({
-  delegates, t, filters, applyFilters,
+  delegates, t, filters, applyFilters, changeSort, sort,
 }) => {
   const columns = [
-    { id: 'rank' },
+    {
+      id: 'rank',
+      isSortable: filters.tab === 'active',
+    },
     {
       id: 'username',
       header: ('Name'),
@@ -26,7 +29,10 @@ const Delegates = ({
       getValue: ({ address }) => <AccountVisualWithAddress {...{ address, size: 36 }} />,
       className: [grid['col-xs-5'], grid['col-md-6']].join(' '),
     },
-    { id: 'productivity' },
+    {
+      id: 'productivity',
+      isSortable: filters.tab === 'active',
+    },
     {
       id: 'approval',
       header: <React.Fragment>
@@ -66,7 +72,15 @@ const Delegates = ({
     <div>
       <MonitorHeader />
       <DelegatesTable {...{
-        columns, delegates, tabs, filters, applyFilters, canLoadMore, getRowLink,
+        columns,
+        delegates,
+        tabs,
+        filters,
+        applyFilters,
+        canLoadMore,
+        getRowLink,
+        onSortChange: changeSort,
+        sort,
       }}
       />
     </div>

--- a/src/components/screens/monitor/delegates/index.js
+++ b/src/components/screens/monitor/delegates/index.js
@@ -6,6 +6,7 @@ import Delegates from './delegates';
 import liskService from '../../../../utils/api/lsk/liskService';
 import withData from '../../../../utils/withData';
 import withFilters from '../../../../utils/withFilters';
+import withLocalSort from '../../../../utils/withLocalSort';
 
 const defaultUrlSearchParams = { tab: 'active' };
 const delegatesKey = 'delegates';
@@ -28,5 +29,6 @@ export default compose(
     },
   }),
   withFilters(delegatesKey, defaultUrlSearchParams),
+  withLocalSort(delegatesKey, 'rank:asc'),
   withTranslation(),
 )(Delegates);

--- a/src/components/toolbox/table/table.css
+++ b/src/components/toolbox/table/table.css
@@ -77,19 +77,29 @@
 }
 
 .sortAsc,
-.sortDesc {
+.sortDesc,
+.sortInactive {
   cursor: pointer;
 
+  &::before,
   &::after {
     display: inline-block;
     content: " ";
+    position: absolute;
+    right: -13px;
     width: 0;
     height: 0;
-    margin-left: 5px;
     border: 4px solid transparent;
-    border-top-color: var(--color-content-light);
     transition: all var(--animation-speed-fastest) linear;
     transform-origin: 5px 2px;
+  }
+}
+
+.sortAsc,
+.sortDesc {
+  &::after {
+    top: 7px;
+    border-top-color: var(--color-content-light);
   }
 }
 
@@ -102,30 +112,14 @@
 }
 
 .sortInactive {
-  cursor: pointer;
-
   &::after {
-    display: inline-block;
-    content: " ";
-    position: absolute;
-    top: 0;
-    right: -13px;
-    width: 0;
-    height: 0;
-    border: 4px solid transparent;
-    border-bottom-color: var(--color-ghost);
+    bottom: 0;
+    border-top-color: var(--color-ghost);
   }
 
   &::before {
-    display: inline-block;
-    content: " ";
-    position: absolute;
-    bottom: 0;
-    right: -13px;
-    width: 0;
-    height: 0;
-    border: 4px solid transparent;
-    border-top-color: var(--color-ghost);
+    top: 0;
+    border-bottom-color: var(--color-ghost);
   }
 }
 

--- a/src/utils/withLocalSort.js
+++ b/src/utils/withLocalSort.js
@@ -1,0 +1,45 @@
+import React from 'react';
+
+const withLocalSort = (dataKey, initialSort) => WrapperComponent => (
+  class WithSort extends React.Component {
+    constructor(props) {
+      super(props);
+      this.state = {
+        sort: initialSort,
+      };
+      this.actions = {
+        changeSort: this.changeSort.bind(this),
+      };
+    }
+
+    sort(data) {
+      const { sort } = this.state;
+      const [id, direction] = sort.split(':');
+      return data.sort((a, b) => ((a[id] > b[id]) ? 1 : -1) * (direction === 'asc' ? 1 : -1));
+    }
+
+    changeSort(id) {
+      const { sort } = this.state;
+      this.setState({
+        sort: `${id}:${sort.includes('asc') ? 'desc' : 'asc'}`,
+      });
+    }
+
+    render() {
+      return (
+        <WrapperComponent {...{
+          ...this.props,
+          [dataKey]: {
+            ...this.props[dataKey],
+            data: this.sort(this.props[dataKey].data),
+          },
+          ...this.state,
+          ...this.actions,
+        }}
+        />
+      );
+    }
+  }
+);
+
+export default withLocalSort;

--- a/src/utils/withLocalSort.test.js
+++ b/src/utils/withLocalSort.test.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import withLocalSort from './withLocalSort';
+
+describe('withLocalSort', () => {
+  const className = 'dummy';
+  const dataKey = 'dataKey';
+  const DummyComponent = props => (
+    <span className={className}>
+      <span className="sort" onClick={() => props.changeSort('id')} />
+      {props[dataKey].data.map(data => <span key={data.id}>{data.id}</span>)}
+    </span>
+  );
+  const initialSort = 'id:asc';
+  const props = {
+    [dataKey]: {
+      data: [{
+        id: 2,
+      }, {
+        id: 1,
+      }, {
+        id: 3,
+      }],
+    },
+  };
+  const setup = () => {
+    const DummyComponentHOC = withLocalSort(dataKey, initialSort)(DummyComponent);
+    const wrapper = mount(<DummyComponentHOC {...props} />);
+    return wrapper;
+  };
+
+  it('should render passed component', () => {
+    const wrapper = setup();
+    expect(wrapper).toContainMatchingElement(`.${className}`);
+  });
+
+  it('should change oder of passed data if props.onSortChange is called', () => {
+    const wrapper = setup();
+    expect(wrapper).toHaveText('123');
+    wrapper.find('.sort').simulate('click');
+    expect(wrapper).toHaveText('321');
+    wrapper.find('.sort').simulate('click');
+    expect(wrapper).toHaveText('123');
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
Closes #2562

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
- [x] Create `withLoacalSort` HOC
- [x] Use `withLoacalSort` HOC in delegates monitor

Note that this handles only Active delegates, because Standby delegates support is blocked by API support https://github.com/LiskHQ/lisk-service/issues/325 This was agreed on by @yasharAyari 

### How has this been tested?
<!--- Please describe how you tested your changes. -->
- Go to delegates monitor: https://ci.lisk.io/test/lisk-hub/PR-2573/#/monitor/delegates
- Try sorting the table

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
