### PR TITLE
HW: Ledgers are not recognized - closes #2572

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bundlesize": "bundlesize",
     "analyze-bundles": "webpack  --config ./config/webpack.config.analyze",
     "start": "electron ./app/",
-    "dist": "build --ia32 --x64 --publish onTag",
+    "dist": "electron-builder --ia32 --x64 --publish onTag",
     "dist:win": "build --win --ia32 --x64 --publish onTag",
     "dist:mac": "build --mac",
     "dist:linux": "build --linux --x64 --publish onTag",
@@ -47,8 +47,8 @@
     "url": "https://github.com/LiskHQ/lisk-hub"
   },
   "dependencies": {
-    "@ledgerhq/hw-transport-node-hid": "4.68.2",
-    "@ledgerhq/hw-transport-u2f": "4.68.2",
+    "@ledgerhq/hw-transport-node-hid": "4.73.2",
+    "@ledgerhq/hw-transport-u2f": "4.73.2",
     "@liskhq/lisk-client": "2.0.0",
     "@liskhq/lisk-transactions": "2.0.0",
     "await-to-js": "2.1.1",
@@ -143,7 +143,7 @@
     "cypress-pipe": "1.3.3",
     "del-cli": "1.1.0",
     "electron": "4.2.4",
-    "electron-builder": "20.38.3",
+    "electron-builder": "21.2.0",
     "electron-devtools-installer": "2.2.4",
     "electron-ipc-mock": "0.0.3",
     "electron-json-storage": "4.1.5",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #2572 

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
So far the build looks is corrupted for MacOS but work fine in windows, the solution is update the ledger libraries and the electron builder package to latest version.

**Update ledger libraries to lates version:**

"@ledgerhq/hw-transport-node-hid": "4.73.2",
"@ledgerhq/hw-transport-u2f": "4.73.2",

**Update electron builder to latest version:**
"electron-builder": "21.2.0",


### How has this been tested?
<!--- Please describe how you tested your changes. -->

1. Run npm run pack.
2. Run the created image
3. Try to login with HW Ledger device


### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
