### PR TITLE
Discreet mode is broken - closes #2550

### DIFF
--- a/src/components/screens/explorer/transactions/transactions.js
+++ b/src/components/screens/explorer/transactions/transactions.js
@@ -141,7 +141,7 @@ class Transactions extends React.Component {
                         <span className={styles.label}>
                           {t('Amount')}
                         </span>
-                        <DiscreetMode addresses={addresses} shouldEvaluate>
+                        <DiscreetMode addresses={addresses} shouldEvaluateForOtherAccounts>
                           <span className="tx-amount">
                             <LiskAmount val={transaction.amount} />
                             {' '}

--- a/src/components/screens/explorer/transactions/transactions.js
+++ b/src/components/screens/explorer/transactions/transactions.js
@@ -141,7 +141,7 @@ class Transactions extends React.Component {
                         <span className={styles.label}>
                           {t('Amount')}
                         </span>
-                        <DiscreetMode addresses={addresses}>
+                        <DiscreetMode addresses={addresses} shouldEvaluate>
                           <span className="tx-amount">
                             <LiskAmount val={transaction.amount} />
                             {' '}

--- a/src/components/screens/wallet/transactions/amount/TransactionAmount.js
+++ b/src/components/screens/wallet/transactions/amount/TransactionAmount.js
@@ -17,7 +17,7 @@ const TransactionAmount = ({
     <div className={`${styles.wrapper} transaction-amount`}>
       { transaction.type === transactionTypes.send
         ? (
-          <DiscreetMode>
+          <DiscreetMode shouldEvaluate>
             <span className={isRecieve && !isSentToSelf ? styles.recieve : ''}>
               {isRecieve ? '' : '- '}
               <LiskAmount val={transaction.amount} roundTo={roundTo} />

--- a/src/components/screens/wallet/transactions/amount/TransactionAmount.js
+++ b/src/components/screens/wallet/transactions/amount/TransactionAmount.js
@@ -17,7 +17,7 @@ const TransactionAmount = ({
     <div className={`${styles.wrapper} transaction-amount`}>
       { transaction.type === transactionTypes.send
         ? (
-          <DiscreetMode shouldEvaluate>
+          <DiscreetMode shouldEvaluateForOtherAccounts>
             <span className={isRecieve && !isSentToSelf ? styles.recieve : ''}>
               {isRecieve ? '' : '- '}
               <LiskAmount val={transaction.amount} roundTo={roundTo} />

--- a/src/components/screens/wallet/walletDetails.js
+++ b/src/components/screens/wallet/walletDetails.js
@@ -38,7 +38,7 @@ class WalletDetails extends React.Component {
           <Icon name="balance" />
           <div>
             <label>{t('Balance')}</label>
-            <DiscreetMode shouldEvaluate>
+            <DiscreetMode shouldEvaluateForOtherAccounts>
               <div className={styles.value}>
                 <LiskAmount val={balance} />
                 {' '}

--- a/src/components/screens/wallet/walletDetails.js
+++ b/src/components/screens/wallet/walletDetails.js
@@ -38,7 +38,7 @@ class WalletDetails extends React.Component {
           <Icon name="balance" />
           <div>
             <label>{t('Balance')}</label>
-            <DiscreetMode>
+            <DiscreetMode shouldEvaluate>
               <div className={styles.value}>
                 <LiskAmount val={balance} />
                 {' '}

--- a/src/components/shared/discreetMode/discreetMode.js
+++ b/src/components/shared/discreetMode/discreetMode.js
@@ -20,11 +20,11 @@ class DiscreetMode extends Component {
 
   shouldEnableDiscreetMode() {
     const {
-      addresses, location, isDiscreetMode, shouldEvaluate,
+      addresses, location, isDiscreetMode, shouldEvaluateForOtherAccounts,
     } = this.props;
     if (!isDiscreetMode) return false;
 
-    if (shouldEvaluate) {
+    if (shouldEvaluateForOtherAccounts) {
       if (addresses.length && location.pathname.includes(routes.transactions.path)) {
         return this.handleBlurOnTransactionDetailsPage();
       }
@@ -44,7 +44,7 @@ class DiscreetMode extends Component {
 
 DiscreetMode.defaultProps = {
   addresses: [],
-  shouldEvaluate: false,
+  shouldEvaluateForOtherAccounts: false,
 };
 
 DiscreetMode.propTypes = {
@@ -52,7 +52,7 @@ DiscreetMode.propTypes = {
   addresses: PropTypes.array,
   isDiscreetMode: PropTypes.bool.isRequired,
   location: PropTypes.object.isRequired,
-  shouldEvaluate: PropTypes.bool,
+  shouldEvaluateForOtherAccounts: PropTypes.bool,
 };
 
 

--- a/src/components/shared/discreetMode/discreetMode.js
+++ b/src/components/shared/discreetMode/discreetMode.js
@@ -19,13 +19,19 @@ class DiscreetMode extends Component {
   }
 
   shouldEnableDiscreetMode() {
-    const { addresses, location, isDiscreetMode } = this.props;
+    const {
+      addresses, location, isDiscreetMode, shouldEvaluate,
+    } = this.props;
     if (!isDiscreetMode) return false;
-    if (addresses.length && location.pathname.includes(routes.transactions.path)) {
-      return this.handleBlurOnTransactionDetailsPage();
-    }
-    if (location.pathname.includes(routes.accounts.path)) {
-      return this.handleBlurOnOtherWalletPage();
+
+    if (shouldEvaluate) {
+      if (addresses.length && location.pathname.includes(routes.transactions.path)) {
+        return this.handleBlurOnTransactionDetailsPage();
+      }
+
+      if (location.pathname.includes(routes.accounts.path)) {
+        return this.handleBlurOnOtherWalletPage();
+      }
     }
     return true;
   }
@@ -38,6 +44,7 @@ class DiscreetMode extends Component {
 
 DiscreetMode.defaultProps = {
   addresses: [],
+  shouldEvaluate: false,
 };
 
 DiscreetMode.propTypes = {
@@ -45,6 +52,7 @@ DiscreetMode.propTypes = {
   addresses: PropTypes.array,
   isDiscreetMode: PropTypes.bool.isRequired,
   location: PropTypes.object.isRequired,
+  shouldEvaluate: PropTypes.bool,
 };
 
 

--- a/src/components/shared/discreetMode/discreetMode.test.js
+++ b/src/components/shared/discreetMode/discreetMode.test.js
@@ -49,10 +49,25 @@ describe('DiscreetMode Component', () => {
       location: {
         pathname: '/explorer/accounts/34234234L',
       },
+      shouldEvaluate: true,
     };
     wrapper = setup(newProps);
     expect(wrapper).toContainMatchingElements(1, 'div');
     expect(wrapper.find('div')).not.toHaveClassName('discreetMode');
+  });
+
+  it('should render properly with DiscreetMode ON in Other  page with blur', () => {
+    const newProps = {
+      ...props,
+      location: {
+        pathname: '/explorer/transactions',
+      },
+      addresses: ['16313739661670634666L', '234324234L'],
+      shouldEvaluate: true,
+    };
+    wrapper = setup(newProps);
+    expect(wrapper).toContainMatchingElements(1, 'div');
+    expect(wrapper.find('div')).toHaveClassName('discreetMode');
   });
 
   it('should render properly with DiscreetMode OFF', () => {

--- a/src/components/shared/discreetMode/discreetMode.test.js
+++ b/src/components/shared/discreetMode/discreetMode.test.js
@@ -56,7 +56,7 @@ describe('DiscreetMode Component', () => {
     expect(wrapper.find('div')).not.toHaveClassName('discreetMode');
   });
 
-  it('should render properly with DiscreetMode ON in Other  page with blur', () => {
+  it('should render properly with DiscreetMode ON in Other page', () => {
     const newProps = {
       ...props,
       location: {

--- a/src/components/shared/discreetMode/discreetMode.test.js
+++ b/src/components/shared/discreetMode/discreetMode.test.js
@@ -49,7 +49,7 @@ describe('DiscreetMode Component', () => {
       location: {
         pathname: '/explorer/accounts/34234234L',
       },
-      shouldEvaluate: true,
+      shouldEvaluateForOtherAccounts: true,
     };
     wrapper = setup(newProps);
     expect(wrapper).toContainMatchingElements(1, 'div');
@@ -63,7 +63,7 @@ describe('DiscreetMode Component', () => {
         pathname: '/explorer/transactions',
       },
       addresses: ['16313739661670634666L', '234324234L'],
-      shouldEvaluate: true,
+      shouldEvaluateForOtherAccounts: true,
     };
     wrapper = setup(newProps);
     expect(wrapper).toContainMatchingElements(1, 'div');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #2550 

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
The DiscreetMode component check if the account that is in screen is the same as the logged user based on that execute the function to blur or not.
The fix consist is pass a prop to tell the component if need to evaluate the current address or not.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
1. Login into the app.
2. Go to wallet and select any account and see that the header amount is still blur.
3. Go to Delegates page.
4. Do click on any delegate account to view the details.
5. The header account mount should be blur

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
